### PR TITLE
feat: Polish static portfolio & mode picker; link employers in Experience

### DIFF
--- a/src/components/ContactOverlay.tsx
+++ b/src/components/ContactOverlay.tsx
@@ -1,25 +1,14 @@
 import React from 'react';
-import { Globe } from 'lucide-react';
 import { PORTFOLIO_DATA, type ContactIconId } from '../config/portfolio';
 import { TEXTS } from '../config/content';
 
-const CONTACT_ICON_SRC: Record<Exclude<ContactIconId, 'portfolio'>, string> = {
+const CONTACT_ICON_SRC: Record<ContactIconId, string> = {
   linkedin: '/icons/contact/linkedin.png',
   github: '/icons/contact/github.png',
   email: '/icons/contact/email.png',
 };
 
 function ContactLinkIcon({ icon }: { icon: ContactIconId }) {
-  if (icon === 'portfolio') {
-    return (
-      <Globe
-        className="h-6 w-6 shrink-0 text-[#1a1a1a] transition-colors group-hover:text-white"
-        strokeWidth={2}
-        aria-hidden
-      />
-    );
-  }
-
   return (
     <img
       src={CONTACT_ICON_SRC[icon]}
@@ -43,7 +32,7 @@ const ContactOverlay: React.FC = () => {
             href={item.link}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center p-4 bg-white border-2 border-[#1a1a1a] rounded-lg shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] transition-all group"
+            className="group flex cursor-pointer items-center p-4 bg-white border-2 border-[#1a1a1a] rounded-lg shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] transition-all"
           >
             <div className="w-10 h-10 shrink-0 bg-gray-100 rounded border border-[#1a1a1a] flex items-center justify-center mr-4 group-hover:bg-[#1a1a1a] transition-colors">
               <ContactLinkIcon icon={item.icon} />

--- a/src/components/ExperienceOverlay.tsx
+++ b/src/components/ExperienceOverlay.tsx
@@ -14,7 +14,21 @@ const ExperienceOverlay: React.FC = () => {
               <h3 className="text-xl font-bold">{exp.title}</h3>
               <span className="text-sm font-mono bg-gray-100 px-3 py-1 rounded-full">{exp.period}</span>
             </div>
-            <p className="text-lg font-semibold text-blue-800 mb-2">{exp.company}</p>
+            <p className="mb-2 text-lg font-semibold">
+              {exp.companyUrl ? (
+                <a
+                  href={exp.companyUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="cursor-pointer rounded-sm text-[#1a1a1a] underline decoration-dashed underline-offset-2 transition-opacity hover:opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1a1a1a]"
+                  aria-label={`${exp.company} (opens in new tab)`}
+                >
+                  {exp.company}
+                </a>
+              ) : (
+                <span className="text-[#1a1a1a]">{exp.company}</span>
+              )}
+            </p>
             <p className="text-base leading-relaxed text-gray-700">
               {exp.description}
             </p>

--- a/src/components/ExperienceOverlay.tsx
+++ b/src/components/ExperienceOverlay.tsx
@@ -9,7 +9,7 @@ const ExperienceOverlay: React.FC = () => {
     <div className="text-[#1a1a1a]">
       <div className="space-y-8">
         {experiences.map((exp, index) => (
-          <div key={index} className="bg-white p-6 rounded-lg border-4 border-[#1a1a1a] shadow-[8px_8px_0px_0px_rgba(26,26,26,1)] transition-transform hover:translate-x-1 hover:translate-y-1">
+          <div key={index} className="bg-white p-6 rounded-lg border-4 border-[#1a1a1a] shadow-[8px_8px_0px_0px_rgba(26,26,26,1)]">
             <div className="flex flex-col md:flex-row md:justify-between md:items-center mb-4 border-b-2 border-gray-100 pb-2">
               <h3 className="text-xl font-bold">{exp.title}</h3>
               <span className="text-sm font-mono bg-gray-100 px-3 py-1 rounded-full">{exp.period}</span>

--- a/src/components/ModePicker.tsx
+++ b/src/components/ModePicker.tsx
@@ -36,7 +36,7 @@ function ChoiceCard({ title, blurb, icon, recommended, cta, onClick }: ChoiceCar
     <button
       type="button"
       onClick={onClick}
-      className="group relative flex w-full max-w-sm flex-col items-center gap-4 rounded-lg border-4 border-[#1a1a1a] bg-[#fbfbf9] p-6 text-left shadow-[8px_8px_0px_0px_rgba(26,26,26,1)] transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[10px_10px_0px_0px_rgba(26,26,26,1)] focus:outline-none focus-visible:-translate-x-0.5 focus-visible:-translate-y-0.5 focus-visible:shadow-[10px_10px_0px_0px_rgba(26,26,26,1)] active:translate-x-[2px] active:translate-y-[2px] active:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] sm:p-8"
+      className="group relative flex w-full max-w-sm cursor-pointer flex-col items-center gap-4 rounded-lg border-4 border-[#1a1a1a] bg-[#fbfbf9] p-6 text-left shadow-[8px_8px_0px_0px_rgba(26,26,26,1)] transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[10px_10px_0px_0px_rgba(26,26,26,1)] focus:outline-none focus-visible:-translate-x-0.5 focus-visible:-translate-y-0.5 focus-visible:shadow-[10px_10px_0px_0px_rgba(26,26,26,1)] active:translate-x-[2px] active:translate-y-[2px] active:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] sm:p-8"
     >
       {recommended && (
         <span className="absolute -top-3 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border-2 border-[#1a1a1a] bg-yellow-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a] shadow-[3px_3px_0px_0px_rgba(26,26,26,1)]">
@@ -48,7 +48,7 @@ function ChoiceCard({ title, blurb, icon, recommended, cta, onClick }: ChoiceCar
       </div>
       <h2 className="text-center text-2xl font-bold text-[#1a1a1a] sm:text-3xl">{title}</h2>
       <p className="text-center text-sm leading-relaxed text-[#1a1a1a]/80 sm:text-base">{blurb}</p>
-      <span className="mt-2 inline-block border-2 border-[#1a1a1a] bg-[#1a1a1a] px-4 py-1.5 text-sm font-bold uppercase tracking-widest text-[#fbfbf9] transition-colors group-hover:bg-[#fbfbf9] group-hover:text-[#1a1a1a]">
+      <span className="mt-2 inline-block border-2 border-[#1a1a1a] bg-[#fbfbf9] px-4 py-1.5 text-sm font-bold uppercase tracking-widest text-[#1a1a1a] transition-colors group-hover:bg-[#1a1a1a] group-hover:text-[#fbfbf9] group-focus-visible:bg-[#1a1a1a] group-focus-visible:text-[#fbfbf9]">
         {cta}
       </span>
     </button>

--- a/src/components/StaticPortfolio.tsx
+++ b/src/components/StaticPortfolio.tsx
@@ -13,7 +13,7 @@ interface StaticPortfolioProps {
   onSwitchToInteractive: () => void;
 }
 
-const HERO_ICON_SRC: Record<Exclude<ContactIconId, 'portfolio'>, string> = {
+const HERO_ICON_SRC: Record<ContactIconId, string> = {
   linkedin: '/icons/contact/linkedin.png',
   github: '/icons/contact/github.png',
   email: '/icons/contact/email.png'
@@ -29,11 +29,9 @@ function HeroContactLinks() {
             href={item.link}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 rounded border-2 border-[#1a1a1a] bg-[#fbfbf9] px-2.5 py-1 text-xs font-bold uppercase tracking-widest text-[#1a1a1a] shadow-[3px_3px_0px_0px_rgba(26,26,26,1)] transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] active:translate-x-[1px] active:translate-y-[1px] active:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] sm:text-sm"
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded border-2 border-[#1a1a1a] bg-[#fbfbf9] px-2.5 py-1 text-xs font-bold uppercase tracking-widest text-[#1a1a1a] shadow-[3px_3px_0px_0px_rgba(26,26,26,1)] transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] active:translate-x-[1px] active:translate-y-[1px] active:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] sm:text-sm"
           >
-            {item.icon !== 'portfolio' && (
-              <img src={HERO_ICON_SRC[item.icon]} alt="" className="h-4 w-4 object-contain" width={16} height={16} />
-            )}
+            <img src={HERO_ICON_SRC[item.icon]} alt="" className="h-5 w-5 object-contain" width={20} height={20} />
             {item.name}
           </a>
         </li>
@@ -114,10 +112,10 @@ export default function StaticPortfolio({ onSwitchToInteractive }: StaticPortfol
       <button
         type="button"
         onClick={onSwitchToInteractive}
-        className="fixed right-2 top-[max(0.5rem,env(safe-area-inset-top,0px))] z-40 inline-flex items-center gap-1.5 rounded border-2 border-[#1a1a1a] bg-[#fbfbf9]/90 px-2.5 py-1 text-[11px] font-bold uppercase tracking-widest text-[#1a1a1a] shadow-[3px_3px_0px_0px_rgba(26,26,26,1)] backdrop-blur-sm transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] active:translate-x-[1px] active:translate-y-[1px] active:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] sm:right-4 sm:top-4 sm:px-3 sm:py-1.5 sm:text-xs"
+        className="fixed right-2 top-[max(0.5rem,env(safe-area-inset-top,0px))] z-40 inline-flex cursor-pointer items-center gap-1.5 rounded border-2 border-[#1a1a1a] bg-[#fbfbf9]/90 px-2.5 py-1 text-[11px] font-bold uppercase tracking-widest text-[#1a1a1a] shadow-[3px_3px_0px_0px_rgba(26,26,26,1)] backdrop-blur-sm transition-all hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[4px_4px_0px_0px_rgba(26,26,26,1)] active:translate-x-[1px] active:translate-y-[1px] active:shadow-[2px_2px_0px_0px_rgba(26,26,26,1)] sm:right-4 sm:top-4 sm:px-3 sm:py-1.5 sm:text-xs"
         aria-label="Switch to interactive portfolio"
       >
-        <Gamepad2 className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
+        <Gamepad2 className="h-4 w-4" strokeWidth={2} aria-hidden />
         <span className="hidden sm:inline">Try interactive</span>
         <span className="sm:hidden">Interactive</span>
       </button>
@@ -172,7 +170,7 @@ export default function StaticPortfolio({ onSwitchToInteractive }: StaticPortfol
             <button
               type="button"
               onClick={onSwitchToInteractive}
-              className="underline decoration-dashed underline-offset-2 hover:text-[#1a1a1a]"
+              className="cursor-pointer underline decoration-dashed underline-offset-2 hover:text-[#1a1a1a]"
             >
               Try interactive mode →
             </button>

--- a/src/config/portfolio.ts
+++ b/src/config/portfolio.ts
@@ -3,6 +3,8 @@ import { TEXTS } from './content';
 export interface Experience {
   title: string;
   company: string;
+  /** Employer site; when set, the company name is shown as an external link in overlays. */
+  companyUrl?: string;
   period: string;
   description: string;
 }
@@ -33,24 +35,28 @@ export const PORTFOLIO_DATA = {
     {
       title: "Software Engineer",
       company: "Hummingbird",
+      companyUrl: "https://hummingbird.rs/",
       period: "April 2024 - Present",
       description: "Built web applications in the financial sector for US clients. Led the implementation of a shared UI design system (Storybook, Theme Provider, Figma tokens). Developed core UI components and ensured WCAG-compliant accessibility. Contributed to innovative features like a finance AI chatbot and real-time collaboration using Liveblocks."
     },
     {
       title: "Software Engineer",
       company: "Vega IT",
+      companyUrl: "https://www.vegaitglobal.com/",
       period: "October 2019 - April 2024",
       description: "Played a pivotal role in feature development for a social network app (Timeline, Chat, Teams). Collaborated on an apartment reservation app. Developed a custom UI library and enhanced code quality with custom eslint plugins and advanced TypeScript rules. Mentored in React to foster team growth."
     },
     {
       title: "Software Engineer Intern",
       company: "Vega IT",
+      companyUrl: "https://www.vegaitglobal.com/",
       period: "September 2019 - October 2019",
       description: "Worked on a Recreational Basketball League app. Optimized import algorithm for large data sets (92% faster) and improved team name correction using Levenshtein distance algorithm."
     },
     {
       title: "Student Assistant",
       company: "Faculty of Technical Sciences",
+      companyUrl: "https://ftn.uns.ac.rs/engfaculty-of-technical-sciences-eng/",
       period: "February 2018 - June 2018",
       description: "Demonstrator in Object-Oriented-Programming course. Provided assistance to students under the guidance of academic staff."
     }

--- a/src/config/portfolio.ts
+++ b/src/config/portfolio.ts
@@ -15,7 +15,7 @@ export interface Project {
   image?: string;
 }
 
-export type ContactIconId = 'linkedin' | 'portfolio' | 'github' | 'email';
+export type ContactIconId = 'linkedin' | 'github' | 'email';
 
 export interface ContactLink {
   name: string;
@@ -82,7 +82,6 @@ export const PORTFOLIO_DATA = {
   },
   contact: [
     { name: "LinkedIn", link: "https://www.linkedin.com/in/danilo-novakovic", icon: "linkedin" },
-    { name: "Portfolio", link: "https://danilonovakovic.github.io/", icon: "portfolio" },
     { name: "GitHub", link: "https://github.com/DaniloNovakovic", icon: "github" },
     { name: "Email", link: "mailto:dakenzi97@gmail.com", icon: "email" }
   ] satisfies ContactLink[],


### PR DESCRIPTION
Summary
This branch tightens affordances and styling on the initial mode picker and static portfolio, removes a redundant self-link, and turns employer names in the Experience section into real external links so they match how they already read visually.

Changes
Mode picker

Use a pointer cursor on choice cards so both paths read clearly as clickable.
CTA pills (“Start walking” / “Read the page”) default to light paper styling and darken on hover and keyboard focus for clearer interaction feedback.
Static portfolio

Add cursor-pointer on interactive controls: fixed “Try interactive”, hero contact pills, footer switch, and contact rows in the lazy-loaded overlay.
Remove hover translation from non-interactive experience cards so only real controls feel “alive.”
Drop the Portfolio contact entry that pointed at this site; narrow contact icon typing and simplify hero/contact rendering.
Slightly enlarge hero contact PNGs and the sticky mode-switch icon for better balance with the labels.
Experience

Extend portfolio Experience with optional companyUrl and set URLs for Hummingbird, Vega IT (both roles), and Faculty of Technical Sciences.
Render the company line as an external link when companyUrl is present, with sketch-consistent ink styling, dashed underline, focus ring, and an accessible label for new-tab behavior. Entries without a URL stay plain text (no link styling).
How to test
Open the app without ?mode= — confirm mode cards and CTAs behave as above (cursor, hover, keyboard focus on CTA).
Open static mode — confirm hero links, sticky switch, footer link, and Contact section links show a pointer; experience cards do not slide on hover; hero icons look slightly larger.
In Experience, confirm each employer name opens the expected site in a new tab and that both Vega rows use the corporate URL.
Notes
Interactive mode reuses ExperienceOverlay, so employer links appear there as well with the same data.