### PR TITLE
Refine agent guidance docs

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,27 @@
+# Skill Invocation Playbook
+
+This file is for AI agents choosing repo-local skills; human project documentation lives in `README.md`, `AGENTS.md`, and `docs/`.
+
+This directory contains optional workflow skills for this repository. Project rules come first: read `AGENTS.md`, the scoped `.cursor/rules/`, and the relevant runtime docs before applying any generic workflow skill.
+
+## Core stack
+
+- `mattpocock-tdd/SKILL.md`
+- `mattpocock-improve-codebase-architecture/SKILL.md`
+
+## Manual opt-in
+
+- `top-down-node-architect/SKILL.md` — use only when the user explicitly asks for a top-down approach, wishful thinking, or stubs-first decomposition.
+
+## How to choose quickly
+
+- **Runtime, scene, input, or physics changes:** start from `AGENTS.md`, `.cursor/rules/20-game-runtime.mdc`, and `docs/ARCHITECTURE_RUNTIME.md`; pair with `mattpocock-tdd` when behavior is risky.
+- **Large refactor or architecture drift:** run `mattpocock-improve-codebase-architecture`.
+- **Top-down requests:** use `top-down-node-architect` only when the user explicitly asks for that workflow, then pair with `mattpocock-tdd` if implementation follows.
+
+## Usage cadence
+
+- The project architecture rules override any generic method advice from a skill.
+- Use `tdd` for most implementation changes that touch runtime, kernel, or bridge behavior.
+- Use architecture skill sparingly for larger changes, not every PR.
+- Keep YAGNI in force when a manual top-down workflow is requested; do not add abstraction layers just because the skill can name them.

--- a/.agents/skills/mattpocock-improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/.agents/skills/mattpocock-improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,44 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and whether they are domain, runtime, infrastructure, or UI concerns
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category, what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and this repo's existing architecture vocabulary in the brief so each sub-agent names things consistently.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/.agents/skills/mattpocock-improve-codebase-architecture/LANGUAGE.md
+++ b/.agents/skills/mattpocock-improve-codebase-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+*Avoid*: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+*Avoid*: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** *(from Michael Feathers)*
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+*Avoid*: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/.agents/skills/mattpocock-improve-codebase-architecture/SKILL.md
+++ b/.agents/skills/mattpocock-improve-codebase-architecture/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: improve-codebase-architecture
+description: Find deepening opportunities in this codebase. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make the repo more testable and AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is informed by the repository's existing architecture docs. In this project, use `AGENTS.md`, `.cursor/rules/`, `docs/ARCHITECTURE_RUNTIME.md`, `docs/ARCHITECTURE_CONSTITUTION.md`, and `docs/patterns/` as the source of language and constraints.
+
+## Process
+
+### 1. Explore
+
+Read existing documentation first:
+
+- `AGENTS.md`
+- `.cursor/rules/`
+- `docs/ARCHITECTURE_RUNTIME.md`
+- `docs/ARCHITECTURE_CONSTITUTION.md`
+- `docs/patterns/README.md`
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates
+
+Present a numbered list of deepening opportunities. For each candidate:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and also in how tests would improve
+
+**Use this repo's vocabulary and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** Talk about the bridge, kernel, SceneManager, context plugins, runtime modes, ECS systems, and React overlays using the names already present in `AGENTS.md` and `docs/`.
+
+**Document conflicts**: if a candidate contradicts existing project guidance, only surface it when the friction is real enough to warrant revisiting that guidance. Mark it clearly and explain why the trade-off may be worth reopening.
+
+Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen only when useful:
+
+- **Sharpening a fuzzy architectural term?** Prefer updating existing docs rather than creating a new documentation system.
+- **User rejects the candidate with a load-bearing reason?** Offer to record it in the most relevant existing architecture doc only if future agents are likely to repeat the same suggestion.
+- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).

--- a/.agents/skills/mattpocock-tdd/SKILL.md
+++ b/.agents/skills/mattpocock-tdd/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: tdd
+description: Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions "red-green-refactor", wants integration tests, or asks for test-first development.
+---
+
+# Test-Driven Development
+
+## Philosophy
+
+**Core principle**: Tests should verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't.
+
+**Good tests** are integration-style: they exercise real code paths through public APIs. They describe *what* the system does, not *how* it does it. A good test reads like a specification - "user can checkout with valid cart" tells you exactly what capability exists. These tests survive refactors because they don't care about internal structure.
+
+**Bad tests** are coupled to implementation. They mock internal collaborators, test private methods, or verify through external means (like querying a database directly instead of using the interface). The warning sign: your test breaks when you refactor, but behavior hasn't changed. If you rename an internal function and tests fail, those tests were testing implementation, not behavior.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
+
+## Anti-Pattern: Horizontal Slices
+
+**DO NOT write all tests first, then all implementation.** This is "horizontal slicing" - treating RED as "write all tests" and GREEN as "write all code."
+
+This produces **crap tests**:
+
+- Tests written in bulk test *imagined* behavior, not *actual* behavior
+- You end up testing the *shape* of things (data structures, function signatures) rather than user-facing behavior
+- Tests become insensitive to real changes - they pass when behavior breaks, fail when behavior is fine
+- You outrun your headlights, committing to test structure before understanding the implementation
+
+**Correct approach**: Vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behavior matters and how to verify it.
+
+```
+WRONG (horizontal):
+  RED:   test1, test2, test3, test4, test5
+  GREEN: impl1, impl2, impl3, impl4, impl5
+
+RIGHT (vertical):
+  RED→GREEN: test1→impl1
+  RED→GREEN: test2→impl2
+  RED→GREEN: test3→impl3
+  ...
+```
+
+## Workflow
+
+### 1. Planning
+
+Before writing any code:
+
+- Confirm with user what interface changes are needed
+- Confirm with user which behaviors to test (prioritize)
+- Identify opportunities for [deep modules](deep-modules.md) (small interface, deep implementation)
+- Design interfaces for [testability](interface-design.md)
+- List the behaviors to test (not implementation steps)
+- Get user approval on the plan
+
+Ask: "What should the public interface look like? Which behaviors are most important to test?"
+
+**You can't test everything.** Confirm with the user exactly which behaviors matter most. Focus testing effort on critical paths and complex logic, not every possible edge case.
+
+### 2. Tracer Bullet
+
+Write ONE test that confirms ONE thing about the system:
+
+```
+RED:   Write test for first behavior → test fails
+GREEN: Write minimal code to pass → test passes
+```
+
+This is your tracer bullet - proves the path works end-to-end.
+
+### 3. Incremental Loop
+
+For each remaining behavior:
+
+```
+RED:   Write next test → fails
+GREEN: Minimal code to pass → passes
+```
+
+Rules:
+
+- One test at a time
+- Only enough code to pass current test
+- Don't anticipate future tests
+- Keep tests focused on observable behavior
+
+### 4. Refactor
+
+After all tests pass, look for [refactor candidates](refactoring.md):
+
+- Extract duplication
+- Deepen modules (move complexity behind simple interfaces)
+- Apply SOLID principles where natural
+- Consider what new code reveals about existing code
+- Run tests after each refactor step
+
+**Never refactor while RED.** Get to GREEN first.
+
+## Checklist Per Cycle
+
+```
+[ ] Test describes behavior, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive internal refactor
+[ ] Code is minimal for this test
+[ ] No speculative features added
+```
+

--- a/.agents/skills/mattpocock-tdd/deep-modules.md
+++ b/.agents/skills/mattpocock-tdd/deep-modules.md
@@ -1,0 +1,33 @@
+# Deep Modules
+
+From "A Philosophy of Software Design":
+
+**Deep module** = small interface + lots of implementation
+
+```
+┌─────────────────────┐
+│   Small Interface   │  ← Few methods, simple params
+├─────────────────────┤
+│                     │
+│                     │
+│  Deep Implementation│  ← Complex logic hidden
+│                     │
+│                     │
+└─────────────────────┘
+```
+
+**Shallow module** = large interface + little implementation (avoid)
+
+```
+┌─────────────────────────────────┐
+│       Large Interface           │  ← Many methods, complex params
+├─────────────────────────────────┤
+│  Thin Implementation            │  ← Just passes through
+└─────────────────────────────────┘
+```
+
+When designing interfaces, ask:
+
+- Can I reduce the number of methods?
+- Can I simplify the parameters?
+- Can I hide more complexity inside?

--- a/.agents/skills/mattpocock-tdd/interface-design.md
+++ b/.agents/skills/mattpocock-tdd/interface-design.md
@@ -1,0 +1,31 @@
+# Interface Design for Testability
+
+Good interfaces make testing natural:
+
+1. **Accept dependencies, don't create them**
+
+   ```typescript
+   // Testable
+   function processOrder(order, paymentGateway) {}
+
+   // Hard to test
+   function processOrder(order) {
+     const gateway = new StripeGateway();
+   }
+   ```
+
+2. **Return results, don't produce side effects**
+
+   ```typescript
+   // Testable
+   function calculateDiscount(cart): Discount {}
+
+   // Hard to test
+   function applyDiscount(cart): void {
+     cart.total -= discount;
+   }
+   ```
+
+3. **Small surface area**
+   - Fewer methods = fewer tests needed
+   - Fewer params = simpler test setup

--- a/.agents/skills/mattpocock-tdd/mocking.md
+++ b/.agents/skills/mattpocock-tdd/mocking.md
@@ -1,0 +1,61 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+  return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+  const client = new StripeClient(process.env.STRIPE_KEY);
+  return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint
+

--- a/.agents/skills/mattpocock-tdd/refactoring.md
+++ b/.agents/skills/mattpocock-tdd/refactoring.md
@@ -1,0 +1,10 @@
+# Refactor Candidates
+
+After TDD cycle, look for:
+
+- **Duplication** → Extract function/class
+- **Long methods** → Break into private helpers (keep tests on public interface)
+- **Shallow modules** → Combine or deepen
+- **Feature envy** → Move logic to where data lives
+- **Primitive obsession** → Introduce value objects
+- **Existing code** the new code reveals as problematic

--- a/.agents/skills/mattpocock-tdd/tests.md
+++ b/.agents/skills/mattpocock-tdd/tests.md
@@ -1,0 +1,62 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test("user can checkout with valid cart", async () => {
+  const cart = createCart();
+  cart.add(product);
+  const result = await checkout(cart, paymentMethod);
+  expect(result.status).toBe("confirmed");
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test("checkout calls paymentService.process", async () => {
+  const mockPayment = jest.mock(paymentService);
+  await checkout(cart, payment);
+  expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test("createUser makes user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  const retrieved = await getUser(user.id);
+  expect(retrieved.name).toBe("Alice");
+});
+```
+

--- a/.agents/skills/top-down-node-architect/SKILL.md
+++ b/.agents/skills/top-down-node-architect/SKILL.md
@@ -14,17 +14,6 @@ Never mix orchestration (the "what") with implementation (the "how") in the same
 - **Orchestration Nodes**: high-level functions that call other functions and express domain intent.
 - **Leaf Nodes**: low-level functions that do concrete work (API calls, math, framework/library specifics, transformations).
 
-## Invocation Triggers
-
-Use this skill only when the user explicitly:
-
-- asks for top-down decomposition
-- requests "wishful thinking" or "stubs first"
-- wants abstraction-first TypeScript design
-- wants approval before low-level implementation
-
-Do not infer this skill from ordinary complex work. The repository's normal default remains direct, YAGNI-first implementation through the existing architecture.
-
 ## Workflow
 
 Copy this checklist and keep it updated in-progress:

--- a/.agents/skills/top-down-node-architect/SKILL.md
+++ b/.agents/skills/top-down-node-architect/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: top-down-node-architect
+description: Manual opt-in skill for top-down decomposition. Use only when the user explicitly asks for a top-down approach, wishful thinking, stubs-first TypeScript flow, abstraction trees, or stepwise approval before leaf implementation.
+---
+
+# Top-Down Node Architect
+
+Philosophy: Programming by wishful thinking and microscopic incrementalism.
+
+## Prime Directive
+
+Never mix orchestration (the "what") with implementation (the "how") in the same function.
+
+- **Orchestration Nodes**: high-level functions that call other functions and express domain intent.
+- **Leaf Nodes**: low-level functions that do concrete work (API calls, math, framework/library specifics, transformations).
+
+## Invocation Triggers
+
+Use this skill only when the user explicitly:
+
+- asks for top-down decomposition
+- requests "wishful thinking" or "stubs first"
+- wants abstraction-first TypeScript design
+- wants approval before low-level implementation
+
+Do not infer this skill from ordinary complex work. The repository's normal default remains direct, YAGNI-first implementation through the existing architecture.
+
+## Workflow
+
+Copy this checklist and keep it updated in-progress:
+
+```md
+Top-Down Progress
+- [ ] Step 1: Define wishful root
+- [ ] Step 2: Declare stubs + types
+- [ ] Step 3: Recursively decompose
+- [ ] Step 4: Present abstraction tree
+- [ ] Step 5: Wait for approval
+- [ ] Step 6: Implement leaf nodes only
+- [ ] Step 7: Validate abstraction purity
+```
+
+### Step 1: Wishful Root
+
+Write the entry point as orchestration-only code using invented domain-first function names.
+
+- Use intent names: `validateTransaction`, `buildSceneTransitionPlan`
+- Avoid technical names: `checkIfInputIsNumber`, `loopItemsAndFilter`
+
+### Step 2: Node Declaration (Stubbing)
+
+For every invented function, immediately create a TypeScript stub.
+
+- Define input/output types first.
+- Keep body empty, `throw new Error("TODO")`, or minimal mock return.
+- Do not implement real logic yet.
+
+### Step 3: Recursive Decomposition
+
+Treat each stub as a new root and repeat Steps 1 and 2 until each unresolved node is a true leaf.
+
+Stop decomposition when the task is a direct primitive/standard-library/library call.
+
+### Step 4: Abstraction Tree Review Gate
+
+Before implementing any leaf logic, present:
+
+1. Root function
+2. Tree of nodes (orchestration vs leaf classification)
+3. Type contracts at each edge
+4. Open decisions/assumptions
+
+Then explicitly wait for approval.
+
+### Step 5: Leaf Implementation
+
+After approval, implement leaf nodes one by one.
+
+- Keep orchestration nodes orchestration-only.
+- If low-level logic appears in an orchestration node, extract a new leaf.
+- After each leaf, run tests/lints relevant to changed behavior.
+
+## Implementation Rules
+
+- **Single level of abstraction**: avoid mixing flow-level orchestration with low-level details.
+- **Types first**: define interfaces/types before logic.
+- **No early implementation**: no heavy async/effects/data transforms in orchestration nodes.
+- **Table of contents rule**: top-level flow should be readable without opening leaves.
+
+## Output Contract
+
+When using this skill, structure responses in this order:
+
+1. **Abstraction Tree** (root + child nodes)
+2. **Type Contracts** (input/output for each node)
+3. **Approval Request**
+4. **Leaf Implementation Plan** (only after approval)
+
+## Guardrails
+
+- Prefer direct solutions over speculative architecture if the task is simple.
+- Do not create extra indirection unless it improves clarity of orchestration vs implementation.
+- Follow existing project architecture boundaries (store/kernel/scene/plugin/context patterns, etc.) rather than introducing parallel systems.
+

--- a/docs/ARCHITECTURE_CONSTITUTION.md
+++ b/docs/ARCHITECTURE_CONSTITUTION.md
@@ -1,6 +1,6 @@
 # Project Constitution: Scalable Browser Game Architecture
 
-This document describes the architectural direction for the project. For what exists in code today, treat [`docs/ARCHITECTURE_RUNTIME.md`](ARCHITECTURE_RUNTIME.md), `AGENTS.md`, and the scoped `.cursor/rules/` files as the current operational guidance.
+This document describes the architectural direction for the project. For what exists in code today, treat [`ARCHITECTURE_RUNTIME.md`](ARCHITECTURE_RUNTIME.md), `AGENTS.md`, and the scoped `.cursor/rules/` files as the current operational guidance.
 
 ## 1. Architectural Philosophy
 

--- a/docs/ARCHITECTURE_CONSTITUTION.md
+++ b/docs/ARCHITECTURE_CONSTITUTION.md
@@ -1,30 +1,32 @@
 # Project Constitution: Scalable Browser Game Architecture
 
+This document describes the architectural direction for the project. For what exists in code today, treat [`docs/ARCHITECTURE_RUNTIME.md`](ARCHITECTURE_RUNTIME.md), `AGENTS.md`, and the scoped `.cursor/rules/` files as the current operational guidance.
+
 ## 1. Architectural Philosophy
 
-This project is built on three core pillars to ensure that adding complex minigames (Guitar Hero, Terminal, Fighting) does not create technical debt or "God Objects."
+This project is built on three core pillars to ensure that adding future complex minigames does not create technical debt or "God Objects."
 
 ### A. Entity Component System (ECS)
 
 - **Entities:** Numeric IDs representing game objects (e.g., The Player, an NPC, a Note).
 - **Components:** Pure Data objects (no methods). Examples: `Transform`, `Velocity`, `Appearance`, `Health`.
 - **Systems:** Logic loops that process entities with specific component sets. 
-- **Goal:** Logic is decoupled from data. If the player is in the 'Street,' they have a `PhysicsSystem`. if they are in the 'Barber Shop,' they only have a `UIAppearanceSystem`.
+- **Goal:** Logic is decoupled from data. If the player is in the street, scene runtime applies physics-backed systems; if a mini-game is a React overlay, it should stay in the UI layer and avoid Phaser coupling.
 
 ### B. Hexagonal (Clean) Architecture
 
 - **Domain (Core):** Pure TypeScript logic. No `window`, `document`, or engine-specific (`PIXI`, `Phaser`) references.
-- **Infrastructure (Adapters):** The "Body." This is where PixiJS/Phaser, Web Audio API, and DOM Event Listeners live.
+- **Infrastructure (Adapters):** The "Body." This is where Phaser, Web Audio API, and DOM event listeners live.
 - **The Bridge (Hybrid UI):** Use the custom bridge store in `src/shared/bridge/store.ts` as the source of truth between the Game Engine and HTML Modals.
 
 ### C. Micro-Kernel (Plugin) Architecture
 
-- **Kernel:** Handles the global lifecycle, asset management, and the central Event Bus.
-- **Plugins (Contexts):** Every building or minigame is an isolated module. 
+- **Kernel:** Handles global lifecycle, scene/context orchestration, and typed kernel events. Asset loading remains owned by the Phaser runtime and scene/plugin code unless a dedicated asset pipeline is introduced.
+- **Plugins (Contexts):** Each Phaser context is isolated behind a plugin definition. React-overlay buildings remain registry-driven overlays rather than kernel plugins unless they need Phaser scene lifecycle.
   - *Street:* Side-scrolling world logic.
-  - *Guitar Game:* Rhythm/Time-based logic using Web Audio.
-  - *Coding Terminal:* HTML/DOM-driven text parser.
-- **Scene Manager:** Responsible for mounting/unmounting specific ECS Systems when transitioning between contexts.
+  - *Hobbies:* Interior Phaser scene logic.
+  - *Future rhythm or terminal games:* Add only when their runtime needs justify a new context.
+- **Scene Manager:** Responsible for entering/exiting Phaser contexts, resume capture, and pause propagation through the Phaser adapter. ECS systems are currently called from scene runtime code as part of the incremental migration.
 
 ---
 
@@ -59,4 +61,4 @@ When proposing future refactors, prefer extending these modules instead of re-in
 
 ## 4. Pattern Reference
 
-Architectural decisions in this project are anchored to Robert Nystrom's *[Game Programming Patterns](https://gameprogrammingpatterns.com/)*. Per-pattern notes, adoption status, and JS/TS + Phaser caveats live in `[docs/patterns/](./patterns/README.md)`. Scoped AI rules that mirror those patterns live under `[.cursor/rules/](../.cursor/rules/)`.
+Architectural decisions in this project are anchored to Robert Nystrom's *[Game Programming Patterns](https://gameprogrammingpatterns.com/)*. Per-pattern notes, adoption status, and JS/TS + Phaser caveats live in [docs/patterns/](./patterns/README.md). Scoped AI rules that mirror those patterns live under [.cursor/rules/](../.cursor/rules/).

--- a/docs/ARCHITECTURE_RUNTIME.md
+++ b/docs/ARCHITECTURE_RUNTIME.md
@@ -16,7 +16,7 @@ This document describes the current runtime architecture in `src/` after the mic
   - Single source of truth for:
     - app state (`status`, `activeMiniGameId`, `isPaused`)
     - touch flags (`left`, `right`, `jumpQueued`, `interactTap`)
-  - Exposes `bridgeActions` and `useBridgeSelector`.
+  - Exposes `bridgeActions` and `useBridgeState`.
 - `src/core/kernel/GameKernel.ts`
   - Reacts to bridge state changes.
   - Emits lifecycle events (`SceneTransitionRequested`, `OverlayOpened`, `OverlayClosed`, `PauseChanged`).

--- a/docs/patterns/README.md
+++ b/docs/patterns/README.md
@@ -65,7 +65,7 @@ A quick scan of which patterns are live, planned, or intentionally parked for th
 
 - **Command** — `in use` (small). `src/core/input/commands.ts` models scene input as intent frames before player movement consumes it.
 - **Flyweight** — `not yet read`. Possible fit for tilemaps / repeated sprites later.
-- **Observer** — `in use`. `[src/shared/bridge/store.ts](../../src/shared/bridge/store.ts)` subscriptions + `useBridgeSelector`.
+- **Observer** — `in use`. [`src/shared/bridge/store.ts`](../../src/shared/bridge/store.ts) subscriptions + `useBridgeState`.
 - **Prototype** — `not yet read`.
 - **Singleton** — `skip-for-now`. Nystrom warns against it; the bridge store covers the legitimate use case as a scoped service locator.
 - **State** — `in use` (small). `src/runtime/gameState.ts` models runtime modes as a discriminated union used by the bridge and kernel.
@@ -75,11 +75,11 @@ A quick scan of which patterns are live, planned, or intentionally parked for th
 - **Bytecode** — `skip-for-now`. Overkill for a portfolio; revisit only if a mini-game needs user-authored scripts.
 - **Subclass Sandbox** — `deferred`. Possible fit if we expose a mini-game authoring surface later.
 - **Type Object** — `in use` (small). Feature, building, and room interactable kinds are data-driven config variants.
-- **Component** — `in use` (partial). `[src/core/ecs](../../src/core/ecs)`; player and interaction-system migration is in progress.
-- **Event Queue** — `in use` (scaffolded). `KernelEventQueue` exists beside the synchronous kernel bus for future time-decoupled side effects.
+- **Component** — `in use` (partial). [`src/core/ecs`](../../src/core/ecs); player and interaction-system migration is in progress.
+- **Event Queue** — `in use` (scaffolded, narrow). `KernelEventQueue` exists beside the synchronous kernel bus for future time-decoupled side effects; same-frame observers remain the default.
 - **Service Locator** — `in use` (scoped). The bridge store *is* the locator; do not introduce new globals.
 - **Data Locality** — `skip-for-now`. V8 hides memory layout; actionable subset is "no per-frame allocations, typed arrays for hot numeric loops."
-- **Dirty Flag** — `planned`. Good fit for React↔Phaser sync and for composited dynamic textures.
+- **Dirty Flag** — `in use` at the bridge/kernel boundary; `planned` for composited dynamic textures.
 - **Object Pool** — `deferred`. Only worth it for particles/bullets after a measured GC problem. Phaser `Group` is already pool-shaped (`createMultiple` / `getFirstDead`).
 - **Spatial Partition** — `skip-for-now`. Arcade Physics already does broadphase; entity counts are tiny.
 
@@ -93,4 +93,4 @@ The AI should not introduce these unprompted in this repo at its current scale. 
 - **Bytecode** — no current user-authored scripting surface.
 - **Singleton (as a convenience global)** — banned. Pass dependencies in, or go through the bridge store / kernel.
 
-See also: `[AGENTS.md](../../AGENTS.md)`, `[docs/ARCHITECTURE_CONSTITUTION.md](../ARCHITECTURE_CONSTITUTION.md)`, `[docs/ARCHITECTURE_RUNTIME.md](../ARCHITECTURE_RUNTIME.md)`.
+See also: [AGENTS.md](../../AGENTS.md), [docs/ARCHITECTURE_CONSTITUTION.md](../ARCHITECTURE_CONSTITUTION.md), [docs/ARCHITECTURE_RUNTIME.md](../ARCHITECTURE_RUNTIME.md).


### PR DESCRIPTION
## Summary
- Add a repo-local AI skill playbook with TDD and architecture-review skills, while making top-down decomposition an explicit opt-in workflow.
- Align architecture docs with the current bridge/kernel/runtime model by fixing stale API names and clarifying constitution-vs-runtime guidance.
- Tighten the pattern adoption map around Event Queue, Dirty Flag, and Markdown links so future agents get clearer constraints.

## Test plan
- Verified all remaining `SKILL.md` files use valid skill front matter.
- Searched for stale references including removed Phaser skills, `useBridgeSelector`, `CONTEXT.md`, ADR scaffolding, and deleted helper docs.
- Confirmed the working tree was clean before opening the PR.


Made with [Cursor](https://cursor.com)