### PR TITLE
fix potassium scene issues from review feedback

### DIFF
--- a/src/runtime/PotassiumSlipScene.ts
+++ b/src/runtime/PotassiumSlipScene.ts
@@ -150,7 +150,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
 
       // Move player towards pointer with dead-zone to prevent jitter
       const pointer = this.input.activePointer;
-      if (pointer.isDown || pointer.active) {
+      if (pointer.isDown) {
         const dist = Phaser.Math.Distance.Between(this.player.x, this.player.y, pointer.x, pointer.y);
         if (dist < 8) {
           this.player.setVelocity(0, 0);
@@ -239,7 +239,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
       enemy = this.enemies.create(x, -50, 'enemy_bug');
       enemy.setVelocityY(Phaser.Math.Between(300, 500));
       // Erratic movement
-      this.time.addEvent({
+      const moveTimer = this.time.addEvent({
         delay: 500,
         callback: () => {
           if (enemy.active) {
@@ -248,6 +248,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
         },
         loop: true
       });
+      enemy.once(Phaser.GameObjects.Events.DESTROY, () => moveTimer.destroy());
     }
 
     enemy.body.setAllowGravity(false);
@@ -351,12 +352,12 @@ export class PotassiumSlipScene extends Phaser.Scene {
     this.isPaused = paused;
     if (paused) {
       this.physics.world.pause();
-      if (this.spawnTimer) this.spawnTimer.paused = true;
-      if (this.ripenessTimer) this.ripenessTimer.paused = true;
+      this.time.paused = true;
+      this.tweens.pauseAll();
     } else {
       this.physics.world.resume();
-      if (this.spawnTimer) this.spawnTimer.paused = false;
-      if (this.ripenessTimer) this.ripenessTimer.paused = false;
+      this.time.paused = false;
+      this.tweens.resumeAll();
     }
   }
 

--- a/src/runtime/textures/TextureGenerator.ts
+++ b/src/runtime/textures/TextureGenerator.ts
@@ -203,6 +203,8 @@ export class TextureGenerator {
   }
 
   static generatePotassiumAssets(scene: Phaser.Scene) {
+    if (scene.textures.exists('banana_peel_yellow')) return;
+
     const PEEL_SVG = (colorMain: string, colorLight: string) => `
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
   <path d="M 32 36 C 26 50, 22 62, 32 62 C 42 62, 38 50, 32 36 Z" fill="${colorMain}" stroke="#1a1a1a" stroke-width="3" stroke-linejoin="round"/>


### PR DESCRIPTION
## Summary
- fix bug enemy movement timer lifecycle by destroying per-enemy loop timers when enemies are destroyed
- align pointer movement with click-and-drag intent by requiring active pointer press
- pause and resume scene-level clock/tweens and prevent duplicate potassium texture loads

## Test plan
- [ ] Start Potassium Slip and verify peel moves only while pointer/touch is actively pressed
- [ ] Let bug enemies spawn repeatedly and verify no lingering timer behavior after enemies are destroyed
- [ ] Pause via React overlay and verify enemy movement/tweens/timers stop, then resume correctly
- [ ] Re-enter Potassium Slip multiple times and verify no duplicate texture warnings in console

Made with [Cursor](https://cursor.com)