### PR TITLE
Guard runtime scene transitions against stale async loads

### DIFF
--- a/src/core/kernel/GameKernel.test.ts
+++ b/src/core/kernel/GameKernel.test.ts
@@ -9,7 +9,7 @@ import { PHASER_SCENE_KEYS } from '../../config/featureIds';
 
 interface FakeAdapter extends SceneRuntimeAdapter {
   registerScene: ReturnType<typeof vi.fn<(k: string, scene: unknown) => void>>;
-  startScene: ReturnType<typeof vi.fn<(k: string) => void>>;
+  startScene: ReturnType<typeof vi.fn<(k: string, data: Record<string, unknown>) => void>>;
   stopScene: ReturnType<typeof vi.fn<(k: string) => void>>;
   setPauseOnActiveScenes: ReturnType<typeof vi.fn<(paused: boolean) => void>>;
   getActiveScenes: () => string[];
@@ -41,6 +41,7 @@ describe('GameKernel', () => {
   let eventBus: KernelEventBus;
   let events: KernelEvent[];
   let adapter: FakeAdapter;
+  let sceneManager: SceneManager;
 
   afterEach(() => {
     kernel.stop();
@@ -54,7 +55,7 @@ describe('GameKernel', () => {
     eventBus.subscribe((e) => events.push(e));
 
     adapter = makeFakeAdapter();
-    const sceneManager = new SceneManager(adapter);
+    sceneManager = new SceneManager(adapter);
     sceneManager.registerContext({
       id: PHASER_SCENE_KEYS.main,
       sceneKey: PHASER_SCENE_KEYS.main,
@@ -123,6 +124,7 @@ describe('GameKernel', () => {
 
   it('enters a Phaser scene when a PHASER_SCENE mini-game becomes active', async () => {
     events.length = 0;
+    const enterSpy = vi.spyOn(sceneManager, 'enter');
 
     bridgeActions.requestInteraction('hobbies');
     await Promise.resolve();
@@ -132,6 +134,7 @@ describe('GameKernel', () => {
     expect((trans as Extract<KernelEvent, { type: 'SceneTransitionRequested' }>).targetContext).toBe(
       'hobbies'
     );
+    expect(enterSpy).toHaveBeenCalledWith('hobbies', { isCurrent: expect.any(Function) });
     expect(adapter.getActiveScenes()).toEqual(['hobbies']);
   });
 

--- a/src/core/kernel/GameKernel.ts
+++ b/src/core/kernel/GameKernel.ts
@@ -1,7 +1,7 @@
-import { PHASER_SCENE_KEYS } from '../../config/featureIds';
 import { modesEqual } from '../../runtime/gameState';
 import { bridgeStore, type BridgeState } from '../../shared/bridge/store';
 import { SceneManager } from './SceneManager';
+import { SceneTransitionCoordinator } from './SceneTransitionCoordinator';
 import { KernelEventBus } from './events';
 
 export class GameKernel {
@@ -9,11 +9,12 @@ export class GameKernel {
   private previousState?: BridgeState;
   private readonly sceneManager: SceneManager;
   private readonly eventBus: KernelEventBus;
-  private transitionVersion = 0;
+  private readonly transitionCoordinator: SceneTransitionCoordinator;
 
   constructor(sceneManager: SceneManager, eventBus: KernelEventBus = new KernelEventBus()) {
     this.sceneManager = sceneManager;
     this.eventBus = eventBus;
+    this.transitionCoordinator = new SceneTransitionCoordinator(sceneManager, eventBus);
   }
 
   start(): void {
@@ -25,6 +26,7 @@ export class GameKernel {
 
   stop(): void {
     this.unsubscribeStore?.();
+    this.transitionCoordinator.invalidate();
     this.sceneManager.dispose();
   }
 
@@ -48,24 +50,8 @@ export class GameKernel {
       return;
     }
 
-    this.transitionVersion += 1;
-    const transitionVersion = this.transitionVersion;
-    void this.syncSceneTransition(state, transitionVersion).catch(() => undefined);
+    this.transitionCoordinator.request(state.mode);
     this.previousState = state;
-  }
-
-  private async syncSceneTransition(state: BridgeState, transitionVersion: number): Promise<void> {
-    if (state.mode.kind === 'exploring') {
-      this.eventBus.emit({ type: 'SceneTransitionRequested', targetContext: null });
-      await this.sceneManager.exitTo(PHASER_SCENE_KEYS.main);
-      return;
-    }
-
-    if (state.mode.kind === 'phaserScene') {
-      this.eventBus.emit({ type: 'SceneTransitionRequested', targetContext: state.mode.miniGameId });
-      await this.sceneManager.enter(state.mode.miniGameId);
-      if (transitionVersion !== this.transitionVersion) return;
-    }
   }
 
   private emitStateEvents(state: BridgeState, modeChanged: boolean, pauseChanged: boolean): void {

--- a/src/core/kernel/SceneManager.test.ts
+++ b/src/core/kernel/SceneManager.test.ts
@@ -4,7 +4,7 @@ import type { ContextPluginDefinition } from './types';
 
 interface FakeAdapter extends SceneRuntimeAdapter {
   registerScene: ReturnType<typeof vi.fn<(sceneKey: string, scene: unknown) => void>>;
-  startScene: ReturnType<typeof vi.fn<(sceneKey: string) => void>>;
+  startScene: ReturnType<typeof vi.fn<(sceneKey: string, data: Record<string, unknown>) => void>>;
   stopScene: ReturnType<typeof vi.fn<(sceneKey: string) => void>>;
   captureResume: ReturnType<typeof vi.fn<(sceneKey: string) => { x: number; y: number } | null>>;
   activeScenes: () => string[];
@@ -131,5 +131,30 @@ describe('SceneManager', () => {
     expect(adapter.registerScene).toHaveBeenCalledWith('lazy-room', scene);
     expect(adapter.startScene).toHaveBeenCalledWith('lazy-room', { id: 'lazy-room' });
     expect(loadingEvents).toEqual(['lazy-room', null]);
+  });
+
+  it('registers a lazy context but skips start when the transition guard is stale', async () => {
+    const adapter = makeFakeAdapter(['main']);
+    const loadingEvents: Array<string | null> = [];
+    const manager = new SceneManager(adapter, {
+      onSceneLoadingChange: (contextId) => loadingEvents.push(contextId)
+    });
+    const scene = class LazyScene {};
+    let current = true;
+    manager.registerContext(context('main'));
+    manager.registerContext({
+      ...context('lazy-room'),
+      loadScene: async () => {
+        current = false;
+        return scene;
+      }
+    });
+
+    await manager.enter('lazy-room', { isCurrent: () => current });
+
+    expect(adapter.registerScene).toHaveBeenCalledWith('lazy-room', scene);
+    expect(adapter.startScene).not.toHaveBeenCalledWith('lazy-room', { id: 'lazy-room' });
+    expect(adapter.activeScenes()).toEqual(['main']);
+    expect(loadingEvents).toEqual(['lazy-room']);
   });
 });

--- a/src/core/kernel/SceneManager.test.ts
+++ b/src/core/kernel/SceneManager.test.ts
@@ -157,4 +157,33 @@ describe('SceneManager', () => {
     expect(adapter.activeScenes()).toEqual(['main']);
     expect(loadingEvents).toEqual(['lazy-room']);
   });
+
+  it('clears loading state on dispose even when a guarded load is in flight', async () => {
+    const adapter = makeFakeAdapter(['main']);
+    const loadingEvents: Array<string | null> = [];
+    const manager = new SceneManager(adapter, {
+      onSceneLoadingChange: (contextId) => loadingEvents.push(contextId)
+    });
+    let resolveScene!: (scene: unknown) => void;
+    const loadScene = new Promise<unknown>((resolve) => {
+      resolveScene = resolve;
+    });
+    let current = true;
+    manager.registerContext(context('main'));
+    manager.registerContext({
+      ...context('lazy-room'),
+      loadScene: () => loadScene
+    });
+
+    const enterPromise = manager.enter('lazy-room', { isCurrent: () => current });
+    await Promise.resolve();
+    current = false;
+    manager.dispose();
+    resolveScene(class LazyScene {});
+    await enterPromise;
+
+    expect(adapter.registerScene).toHaveBeenCalledWith('lazy-room', expect.any(Function));
+    expect(adapter.startScene).not.toHaveBeenCalledWith('lazy-room', { id: 'lazy-room' });
+    expect(loadingEvents).toEqual(['lazy-room', null]);
+  });
 });

--- a/src/core/kernel/SceneManager.ts
+++ b/src/core/kernel/SceneManager.ts
@@ -15,6 +15,10 @@ interface SceneManagerOptions {
   onSceneLoadingChange?: (contextId: ContextId | null) => void;
 }
 
+export interface SceneTransitionGuard {
+  isCurrent: () => boolean;
+}
+
 export class SceneManager {
   private readonly contexts = new Map<ContextId, ContextPluginDefinition>();
   private readonly adapter: SceneRuntimeAdapter;
@@ -30,24 +34,26 @@ export class SceneManager {
     def.onRegister?.();
   }
 
-  async enter(contextId: ContextId): Promise<void> {
+  async enter(contextId: ContextId, guard?: SceneTransitionGuard): Promise<void> {
     const target = this.contexts.get(contextId);
     if (!target) return;
 
     if (this.adapter.isSceneActive(target.sceneKey)) return;
 
-    await this.ensureSceneRegistered(target);
+    await this.ensureSceneRegistered(target, guard);
+    if (guard && !guard.isCurrent()) return;
     this.stopActiveContextsExcept(target.sceneKey);
 
     this.adapter.startScene(target.sceneKey, target.getStartData());
     target.onEnter?.();
   }
 
-  async exitTo(contextId: ContextId): Promise<void> {
+  async exitTo(contextId: ContextId, guard?: SceneTransitionGuard): Promise<void> {
     const target = this.contexts.get(contextId);
     if (!target) return;
 
-    await this.ensureSceneRegistered(target);
+    await this.ensureSceneRegistered(target, guard);
+    if (guard && !guard.isCurrent()) return;
     const allKeys = this.adapter.listKnownSceneKeys();
     for (const sceneKey of allKeys) {
       if (sceneKey === target.sceneKey) continue;
@@ -98,7 +104,10 @@ export class SceneManager {
     return this.adapter.captureResume(sceneKey);
   }
 
-  private async ensureSceneRegistered(context: ContextPluginDefinition): Promise<void> {
+  private async ensureSceneRegistered(
+    context: ContextPluginDefinition,
+    guard?: SceneTransitionGuard
+  ): Promise<void> {
     if (this.adapter.hasScene(context.sceneKey)) return;
     if (!context.loadScene) return;
 
@@ -107,7 +116,9 @@ export class SceneManager {
       const scene = await context.loadScene();
       this.adapter.registerScene(context.sceneKey, scene);
     } finally {
-      this.options.onSceneLoadingChange?.(null);
+      if (!guard || guard.isCurrent()) {
+        this.options.onSceneLoadingChange?.(null);
+      }
     }
   }
 

--- a/src/core/kernel/SceneManager.ts
+++ b/src/core/kernel/SceneManager.ts
@@ -36,12 +36,21 @@ export class SceneManager {
 
   async enter(contextId: ContextId, guard?: SceneTransitionGuard): Promise<void> {
     const target = this.contexts.get(contextId);
-    if (!target) return;
+    if (!target) {
+      this.clearLoadingIfCurrent(guard);
+      return;
+    }
 
-    if (this.adapter.isSceneActive(target.sceneKey)) return;
+    if (this.adapter.isSceneActive(target.sceneKey)) {
+      this.clearLoadingIfCurrent(guard);
+      return;
+    }
 
-    await this.ensureSceneRegistered(target, guard);
+    const loadedScene = await this.ensureSceneRegistered(target, guard);
     if (guard && !guard.isCurrent()) return;
+    if (!loadedScene) {
+      this.clearLoadingIfCurrent(guard);
+    }
     this.stopActiveContextsExcept(target.sceneKey);
 
     this.adapter.startScene(target.sceneKey, target.getStartData());
@@ -50,10 +59,16 @@ export class SceneManager {
 
   async exitTo(contextId: ContextId, guard?: SceneTransitionGuard): Promise<void> {
     const target = this.contexts.get(contextId);
-    if (!target) return;
+    if (!target) {
+      this.clearLoadingIfCurrent(guard);
+      return;
+    }
 
-    await this.ensureSceneRegistered(target, guard);
+    const loadedScene = await this.ensureSceneRegistered(target, guard);
     if (guard && !guard.isCurrent()) return;
+    if (!loadedScene) {
+      this.clearLoadingIfCurrent(guard);
+    }
     const allKeys = this.adapter.listKnownSceneKeys();
     for (const sceneKey of allKeys) {
       if (sceneKey === target.sceneKey) continue;
@@ -107,19 +122,23 @@ export class SceneManager {
   private async ensureSceneRegistered(
     context: ContextPluginDefinition,
     guard?: SceneTransitionGuard
-  ): Promise<void> {
-    if (this.adapter.hasScene(context.sceneKey)) return;
-    if (!context.loadScene) return;
+  ): Promise<boolean> {
+    if (this.adapter.hasScene(context.sceneKey)) return false;
+    if (!context.loadScene) return false;
 
     this.options.onSceneLoadingChange?.(context.id);
     try {
       const scene = await context.loadScene();
       this.adapter.registerScene(context.sceneKey, scene);
+      return true;
     } finally {
-      if (!guard || guard.isCurrent()) {
-        this.options.onSceneLoadingChange?.(null);
-      }
+      this.clearLoadingIfCurrent(guard);
     }
+  }
+
+  private clearLoadingIfCurrent(guard?: SceneTransitionGuard): void {
+    if (guard && !guard.isCurrent()) return;
+    this.options.onSceneLoadingChange?.(null);
   }
 
   private stopActiveContextsExcept(targetSceneKey: string): void {

--- a/src/core/kernel/SceneManager.ts
+++ b/src/core/kernel/SceneManager.ts
@@ -105,6 +105,7 @@ export class SceneManager {
   }
 
   dispose(): void {
+    this.options.onSceneLoadingChange?.(null);
     this.contexts.forEach((context) => context.onDispose?.());
   }
 

--- a/src/core/kernel/SceneTransitionCoordinator.test.ts
+++ b/src/core/kernel/SceneTransitionCoordinator.test.ts
@@ -95,7 +95,7 @@ describe('SceneTransitionCoordinator', () => {
     expect(adapter.registerScene).toHaveBeenCalledWith('hobbies', expect.any(Function));
     expect(adapter.startScene).not.toHaveBeenCalledWith('hobbies', { id: 'hobbies' });
     expect(adapter.activeScenes()).toEqual(['MainScene']);
-    expect(loadingEvents).toEqual(['hobbies']);
+    expect(loadingEvents).toEqual(['hobbies', null]);
     expect(events).toContainEqual({ type: 'SceneTransitionRequested', targetContext: null });
   });
 
@@ -130,6 +130,7 @@ describe('SceneTransitionCoordinator', () => {
   });
 
   it('clears loading and swallows failed current lazy loads', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const loadHobbies = deferred<unknown>();
     const adapter = makeFakeAdapter();
     const loadingEvents: Array<string | null> = [];
@@ -146,5 +147,7 @@ describe('SceneTransitionCoordinator', () => {
 
     expect(loadingEvents).toEqual(['hobbies', null]);
     expect(adapter.startScene).not.toHaveBeenCalledWith('hobbies', { id: 'hobbies' });
+    expect(warnSpy).toHaveBeenCalledWith('Scene transition failed', expect.any(Error));
+    warnSpy.mockRestore();
   });
 });

--- a/src/core/kernel/SceneTransitionCoordinator.test.ts
+++ b/src/core/kernel/SceneTransitionCoordinator.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MiniGameId } from '../../config/featureIds';
+import { EXPLORING_MODE, type RuntimeMode } from '../../runtime/gameState';
+import { SceneManager, type SceneRuntimeAdapter } from './SceneManager';
+import { SceneTransitionCoordinator } from './SceneTransitionCoordinator';
+import { KernelEventBus, type KernelEvent } from './events';
+import type { ContextPluginDefinition } from './types';
+
+interface FakeAdapter extends SceneRuntimeAdapter {
+  registerScene: ReturnType<typeof vi.fn<(sceneKey: string, scene: unknown) => void>>;
+  startScene: ReturnType<typeof vi.fn<(sceneKey: string, data: Record<string, unknown>) => void>>;
+  stopScene: ReturnType<typeof vi.fn<(sceneKey: string) => void>>;
+  activeScenes: () => string[];
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeFakeAdapter(initialScenes: readonly string[] = ['MainScene']): FakeAdapter {
+  const active = new Set(initialScenes);
+  const known = new Set(['MainScene']);
+  return {
+    hasScene: (sceneKey) => known.has(sceneKey),
+    registerScene: vi.fn((sceneKey: string) => {
+      known.add(sceneKey);
+    }),
+    isSceneActive: (sceneKey) => active.has(sceneKey),
+    startScene: vi.fn((sceneKey: string) => {
+      active.add(sceneKey);
+    }),
+    stopScene: vi.fn((sceneKey: string) => {
+      active.delete(sceneKey);
+    }),
+    listKnownSceneKeys: () => [...known],
+    setPauseOnActiveScenes: vi.fn(),
+    captureResume: vi.fn(() => null),
+    activeScenes: () => [...active]
+  };
+}
+
+function context(
+  id: string,
+  options: Partial<ContextPluginDefinition> = {}
+): ContextPluginDefinition {
+  return {
+    id,
+    sceneKey: id === 'main' ? 'MainScene' : id,
+    getStartData: () => ({ id }),
+    ...options
+  };
+}
+
+function mode(miniGameId: MiniGameId): RuntimeMode {
+  return { kind: 'phaserScene', miniGameId };
+}
+
+async function settleAsyncTransition(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('SceneTransitionCoordinator', () => {
+  it('registers but does not start a lazy scene after a newer exploring request', async () => {
+    const loadHobbies = deferred<unknown>();
+    const adapter = makeFakeAdapter();
+    const loadingEvents: Array<string | null> = [];
+    const sceneManager = new SceneManager(adapter, {
+      onSceneLoadingChange: (contextId) => loadingEvents.push(contextId)
+    });
+    const eventBus = new KernelEventBus();
+    const events: KernelEvent[] = [];
+    eventBus.subscribe((event) => events.push(event));
+    sceneManager.registerContext(context('MainScene'));
+    sceneManager.registerContext(context('hobbies', { loadScene: () => loadHobbies.promise }));
+
+    const coordinator = new SceneTransitionCoordinator(sceneManager, eventBus);
+    coordinator.request(mode('hobbies'));
+    coordinator.request(EXPLORING_MODE);
+    loadHobbies.resolve(class HobbiesScene {});
+    await settleAsyncTransition();
+
+    expect(adapter.registerScene).toHaveBeenCalledWith('hobbies', expect.any(Function));
+    expect(adapter.startScene).not.toHaveBeenCalledWith('hobbies', { id: 'hobbies' });
+    expect(adapter.activeScenes()).toEqual(['MainScene']);
+    expect(loadingEvents).toEqual(['hobbies']);
+    expect(events).toContainEqual({ type: 'SceneTransitionRequested', targetContext: null });
+  });
+
+  it('does not let stale lazy loads clear a newer loading state', async () => {
+    const loadHobbies = deferred<unknown>();
+    const loadBasement = deferred<unknown>();
+    const adapter = makeFakeAdapter();
+    const loadingEvents: Array<string | null> = [];
+    const sceneManager = new SceneManager(adapter, {
+      onSceneLoadingChange: (contextId) => loadingEvents.push(contextId)
+    });
+    const coordinator = new SceneTransitionCoordinator(sceneManager, new KernelEventBus());
+    sceneManager.registerContext(context('MainScene'));
+    sceneManager.registerContext(context('hobbies', { loadScene: () => loadHobbies.promise }));
+    sceneManager.registerContext(context('basement', { loadScene: () => loadBasement.promise }));
+
+    coordinator.request(mode('hobbies'));
+    coordinator.request(mode('basement'));
+    loadHobbies.resolve(class HobbiesScene {});
+    await settleAsyncTransition();
+
+    expect(adapter.registerScene).toHaveBeenCalledWith('hobbies', expect.any(Function));
+    expect(adapter.startScene).not.toHaveBeenCalledWith('hobbies', { id: 'hobbies' });
+    expect(loadingEvents).toEqual(['hobbies', 'basement']);
+
+    loadBasement.resolve(class BasementScene {});
+    await settleAsyncTransition();
+
+    expect(adapter.registerScene).toHaveBeenCalledWith('basement', expect.any(Function));
+    expect(adapter.startScene).toHaveBeenCalledWith('basement', { id: 'basement' });
+    expect(loadingEvents).toEqual(['hobbies', 'basement', null]);
+  });
+
+  it('clears loading and swallows failed current lazy loads', async () => {
+    const loadHobbies = deferred<unknown>();
+    const adapter = makeFakeAdapter();
+    const loadingEvents: Array<string | null> = [];
+    const sceneManager = new SceneManager(adapter, {
+      onSceneLoadingChange: (contextId) => loadingEvents.push(contextId)
+    });
+    const coordinator = new SceneTransitionCoordinator(sceneManager, new KernelEventBus());
+    sceneManager.registerContext(context('MainScene'));
+    sceneManager.registerContext(context('hobbies', { loadScene: () => loadHobbies.promise }));
+
+    coordinator.request(mode('hobbies'));
+    loadHobbies.reject(new Error('load failed'));
+    await settleAsyncTransition();
+
+    expect(loadingEvents).toEqual(['hobbies', null]);
+    expect(adapter.startScene).not.toHaveBeenCalledWith('hobbies', { id: 'hobbies' });
+  });
+});

--- a/src/core/kernel/SceneTransitionCoordinator.ts
+++ b/src/core/kernel/SceneTransitionCoordinator.ts
@@ -21,13 +21,13 @@ export class SceneTransitionCoordinator {
 
     if (mode.kind === 'exploring') {
       this.eventBus.emit({ type: 'SceneTransitionRequested', targetContext: null });
-      void this.sceneManager.exitTo(PHASER_SCENE_KEYS.main, guard).catch(() => undefined);
+      this.runTransition(this.sceneManager.exitTo(PHASER_SCENE_KEYS.main, guard));
       return;
     }
 
     if (mode.kind === 'phaserScene') {
       this.eventBus.emit({ type: 'SceneTransitionRequested', targetContext: mode.miniGameId });
-      void this.sceneManager.enter(mode.miniGameId, guard).catch(() => undefined);
+      this.runTransition(this.sceneManager.enter(mode.miniGameId, guard));
     }
   }
 
@@ -38,5 +38,11 @@ export class SceneTransitionCoordinator {
   private nextRequestId(): number {
     this.requestId += 1;
     return this.requestId;
+  }
+
+  private runTransition(transition: Promise<void>): void {
+    void transition.catch((error: unknown) => {
+      console.warn('Scene transition failed', error);
+    });
   }
 }

--- a/src/core/kernel/SceneTransitionCoordinator.ts
+++ b/src/core/kernel/SceneTransitionCoordinator.ts
@@ -1,0 +1,42 @@
+import { PHASER_SCENE_KEYS } from '../../config/featureIds';
+import type { RuntimeMode } from '../../runtime/gameState';
+import { SceneManager, type SceneTransitionGuard } from './SceneManager';
+import { KernelEventBus } from './events';
+
+export class SceneTransitionCoordinator {
+  private readonly sceneManager: SceneManager;
+  private readonly eventBus: KernelEventBus;
+  private requestId = 0;
+
+  constructor(sceneManager: SceneManager, eventBus: KernelEventBus) {
+    this.sceneManager = sceneManager;
+    this.eventBus = eventBus;
+  }
+
+  request(mode: RuntimeMode): void {
+    const requestId = this.nextRequestId();
+    const guard: SceneTransitionGuard = {
+      isCurrent: () => requestId === this.requestId
+    };
+
+    if (mode.kind === 'exploring') {
+      this.eventBus.emit({ type: 'SceneTransitionRequested', targetContext: null });
+      void this.sceneManager.exitTo(PHASER_SCENE_KEYS.main, guard).catch(() => undefined);
+      return;
+    }
+
+    if (mode.kind === 'phaserScene') {
+      this.eventBus.emit({ type: 'SceneTransitionRequested', targetContext: mode.miniGameId });
+      void this.sceneManager.enter(mode.miniGameId, guard).catch(() => undefined);
+    }
+  }
+
+  invalidate(): void {
+    this.nextRequestId();
+  }
+
+  private nextRequestId(): number {
+    this.requestId += 1;
+    return this.requestId;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a kernel-side `SceneTransitionCoordinator` to own runtime transition freshness and stale-request suppression.
- Update `GameKernel` to delegate Phaser scene transitions through the coordinator instead of tracking transition versioning inline.
- Extend `SceneManager` with an optional transition guard so lazy scene loads can register without starting or stopping obsolete scenes.
- Keep bridge state shape and failure behavior unchanged; loading still clears for the current request and errors remain swallowed.
- Add focused tests for rapid transition races, stale load suppression, and guarded scene manager behavior.

## Testing
- `npm test -- --run src/core/kernel`
- `npm test -- --run`
- `npm run build`
- `npm run lint`