### PR TITLE
Refactor Potassium Slip into combat, session, boss, and renderer runtimes

### DIFF
--- a/src/runtime/PotassiumSlipScene.ts
+++ b/src/runtime/PotassiumSlipScene.ts
@@ -60,6 +60,7 @@ import {
   getPotassiumSessionSkillRank,
   markPotassiumRowSpawned,
   resolvePotassiumDraftChoice,
+  resolvePotassiumDevSkipWave,
   resolvePotassiumEnemyEscaped,
   resolvePotassiumEnemyKilled,
   resolvePotassiumTerminalAction,
@@ -124,8 +125,9 @@ const SIDE_BOUNCE_MARGIN = 32;
 const BANANA_RICOCHET_MIN_SPEED = 360;
 const BANANA_RICOCHET_BOOST = 1.08;
 const CLONE_RICOCHET_MAX_SPEED = 660;
-const NON_BOSS_ENEMY_SPEED = 64;
+const NON_BOSS_ENEMY_SPEED = 54;
 const ROW_SPAWN_DELAY_MS = 900;
+const MID_GAME_ROW_SPAWN_DELAY_MS = 1050;
 const TRAIL_DROP_INTERVAL_MS = 180;
 const FIRE_TRAIL_LIFETIME_MS = 1500;
 const GHOST_BEAM_LIFETIME_MS = 190;
@@ -154,14 +156,6 @@ const ENEMY_CONFIGS: Record<EnemyKind, EnemyConfig> = {
     texture: 'potassium_enemy_scope',
     scale: 0.95
   },
-  meeting: {
-    label: 'Meeting Brick',
-    hp: 6,
-    score: 3,
-    speed: 38,
-    texture: 'potassium_enemy_meeting',
-    scale: 1
-  },
   deadline: {
     label: 'Deadline Drone',
     hp: 3,
@@ -171,7 +165,7 @@ const ENEMY_CONFIGS: Record<EnemyKind, EnemyConfig> = {
     scale: 0.9
   },
   wall: {
-    label: 'Filing Wall',
+    label: 'Wooden Wall',
     hp: 14,
     score: 4,
     speed: 30,
@@ -179,7 +173,7 @@ const ENEMY_CONFIGS: Record<EnemyKind, EnemyConfig> = {
     scale: 0.78
   },
   hardWall: {
-    label: 'Hard Filing Wall',
+    label: 'Unbreakable Wall',
     hp: 999,
     score: 0,
     speed: 30,
@@ -231,6 +225,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   private fireCells = new Set<string>();
   private activeBoss?: EnemySprite;
   private bossState?: PotassiumBossState;
+  private rowSpawnTimers: Phaser.Time.TimerEvent[] = [];
   private combatIdCounter: number = 0;
 
   private onClose?: () => void;
@@ -410,6 +405,12 @@ export class PotassiumSlipScene extends Phaser.Scene {
       }
     });
 
+    if (import.meta.env.DEV) {
+      this.input.keyboard?.on('keydown-N', () => {
+        this.skipCurrentWaveForDev();
+      });
+    }
+
     this.input.keyboard?.on('keydown-ESC', () => {
       this.onClose?.();
     });
@@ -424,6 +425,19 @@ export class PotassiumSlipScene extends Phaser.Scene {
 
   private startEndlessMode(): void {
     this.applySessionResult(startPotassiumEndless(this.session));
+  }
+
+  private skipCurrentWaveForDev(): void {
+    if (this.session.gameState !== 'PLAYING') return;
+    const result = resolvePotassiumDevSkipWave(this.session);
+    if (result.commands.length === 0) return;
+    this.cancelControl();
+    this.clearScheduledWaveRows();
+    this.enemies.clear(true, true);
+    this.bossBlockers.clear(true, true);
+    this.activeBoss = undefined;
+    this.bossState = undefined;
+    this.applySessionResult(result);
   }
 
   private applySessionResult(result: { state: PotassiumSessionState; commands: readonly PotassiumSessionCommand[] }): void {
@@ -448,8 +462,13 @@ export class PotassiumSlipScene extends Phaser.Scene {
       } else if (command.type === 'spawnBoss') {
         this.time.delayedCall(350, () => this.spawnEnemy('boss', 0));
       } else if (command.type === 'scheduleWaveRows') {
+        this.clearScheduledWaveRows();
         command.rows.forEach((row, rowIndex) => {
-          this.time.delayedCall(rowIndex * ROW_SPAWN_DELAY_MS, () => this.spawnEnemyRow(row, rowIndex));
+          const timer = this.time.delayedCall(rowIndex * this.getRowSpawnDelayMs(), () => {
+            this.rowSpawnTimers = this.rowSpawnTimers.filter((entry) => entry !== timer);
+            this.spawnEnemyRow(row, rowIndex);
+          });
+          this.rowSpawnTimers.push(timer);
         });
       } else if (command.type === 'scheduleUpgradeChoices') {
         this.time.delayedCall(UPGRADE_CHOICE_DELAY_MS, () => {
@@ -493,6 +512,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private resetBoardObjects(): void {
+    this.clearScheduledWaveRows();
     this.destroyProjectileVisuals(this.banana);
     this.destroyAllCloneVisuals();
     this.enemies?.clear(true, true);
@@ -521,6 +541,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
 
   private clearBoardForOutcome(): void {
     this.setBananaRecallVisual(false);
+    this.clearScheduledWaveRows();
     this.destroyAllCloneVisuals();
     this.enemies.clear(true, true);
     this.clones.clear(true, true);
@@ -746,7 +767,19 @@ export class PotassiumSlipScene extends Phaser.Scene {
 
   private spawnWave(waveNumber: number): void {
     this.cancelControl();
+    this.clearScheduledWaveRows();
     this.applySessionResult(spawnPotassiumWave(this.session, waveNumber));
+  }
+
+  private clearScheduledWaveRows(): void {
+    this.rowSpawnTimers.forEach((timer) => timer.remove(false));
+    this.rowSpawnTimers = [];
+  }
+
+  private getRowSpawnDelayMs(): number {
+    return this.session.wave >= 5 && this.session.wave <= 6
+      ? MID_GAME_ROW_SPAWN_DELAY_MS
+      : ROW_SPAWN_DELAY_MS;
   }
 
   private spawnEnemyRow(row: readonly WaveCell[], rowIndex: number = 0): void {
@@ -831,7 +864,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
     if (kind === 'scope') {
       enemy.setAngularVelocity(Phaser.Math.Between(-70, 70));
     }
-    if (kind === 'meeting' || kind === 'wall' || kind === 'hardWall') {
+    if (kind === 'wall' || kind === 'hardWall') {
       enemy.setImmovable(true);
     }
     this.fitEnemyBodyToOneCell(enemy, kind);
@@ -1062,6 +1095,8 @@ export class PotassiumSlipScene extends Phaser.Scene {
     this.spreadPoisonOnDeath(enemy);
     this.spawnSplitterChildren(enemy);
     enemy.setData('dying', true);
+    const damageCueTween = enemy.getData('damageCueTween') as Phaser.Tweens.Tween | undefined;
+    damageCueTween?.stop();
     enemy.body.enable = false;
     const killResult = resolvePotassiumEnemyKilled(this.session, config.score, kind);
     if (kind !== 'boss') {

--- a/src/runtime/PotassiumSlipScene.ts
+++ b/src/runtime/PotassiumSlipScene.ts
@@ -1092,8 +1092,6 @@ export class PotassiumSlipScene extends Phaser.Scene {
   private killEnemy(enemy: EnemySprite): void {
     const kind = enemy.getData('kind') as EnemyKind;
     const config = ENEMY_CONFIGS[kind];
-    this.spreadPoisonOnDeath(enemy);
-    this.spawnSplitterChildren(enemy);
     enemy.setData('dying', true);
     const damageCueTween = enemy.getData('damageCueTween') as Phaser.Tweens.Tween | undefined;
     damageCueTween?.stop();
@@ -1117,13 +1115,6 @@ export class PotassiumSlipScene extends Phaser.Scene {
         }
       }
     });
-  }
-
-  private spreadPoisonOnDeath(enemy: EnemySprite): void {
-    const poisonExpiresAt = enemy.getData('poisonExpiresAt') as number | undefined;
-    if (this.getSkillRank('poison') < 2 || poisonExpiresAt === undefined || poisonExpiresAt <= this.time.now) return;
-    const effectMultiplier = (enemy.getData('poisonMultiplier') as number | undefined) ?? 1;
-    this.spreadPoisonFrom(enemy.x, enemy.y, effectMultiplier, enemy);
   }
 
   private spawnSplitterChildren(enemy: EnemySprite): void {

--- a/src/runtime/PotassiumSlipScene.ts
+++ b/src/runtime/PotassiumSlipScene.ts
@@ -530,9 +530,9 @@ export class PotassiumSlipScene extends Phaser.Scene {
     this.banana.setVelocity(0, 0);
   }
 
-  private beginAiming(pointer: Phaser.Input.Pointer): void {
+  private beginAiming(pointer: Phaser.Input.Pointer, pointerId: number = pointer.id): void {
     this.controlState = 'aiming';
-    this.aimPointerId = pointer.id;
+    this.aimPointerId = pointerId;
     this.setBananaRecallVisual(false);
     this.banana.setPosition(LAUNCH_PAD.x, LAUNCH_PAD.y);
     this.banana.setVelocity(0, 0);
@@ -591,7 +591,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
         this.banana.setVelocity(0, 0);
       }
       if (this.isBananaInLaunchZone(34)) {
-        this.beginAiming(this.input.activePointer);
+        this.beginAiming(this.input.activePointer, this.aimPointerId ?? this.input.activePointer.id);
       }
       return;
     }

--- a/src/runtime/PotassiumSlipScene.ts
+++ b/src/runtime/PotassiumSlipScene.ts
@@ -6,25 +6,14 @@ import {
 import { bridgeActions } from '../shared/bridge/store';
 import { TextureGenerator } from './textures/TextureGenerator';
 import {
-  applyPotassiumDraftOption,
-  applyPotassiumGenericDraftOption,
-  getPotassiumDraftChoices,
   getPotassiumExplosionRadius,
   getPotassiumFireCellKey,
-  getPotassiumGenericUpgradeRank,
   getPotassiumShieldSide,
-  getPotassiumSkillRank,
-  getPotassiumWave,
   getPotassiumSplitterSpawnColumns,
   getScaledPotassiumEnemyHp,
-  isPotassiumBossWave,
   POTASSIUM_COLUMN_COUNT,
-  type PotassiumDraftOption as DraftOption,
-  type PotassiumGenericDraftOption as GenericDraftOption,
-  type PotassiumGenericUpgradeKind as GenericUpgradeKind,
-  type PotassiumGenericUpgradeRanks as GenericRanks,
   type PotassiumShieldSide as ShieldSide,
-  type PotassiumSkillRanks as SkillRanks,
+  type PotassiumGenericUpgradeKind as GenericUpgradeKind,
   type PotassiumSkillRank as SkillRank,
   type PotassiumWaveCell as WaveCell,
   type PotassiumEnemyKind as EnemyKind,
@@ -49,15 +38,30 @@ import {
 import {
   getPotassiumLeaderboardTop,
   savePotassiumRunRecord,
-  type PotassiumRunMode as RunMode,
-  type PotassiumRunOutcome as RunOutcome
+  type PotassiumRunOutcome
 } from './potassiumSlipLeaderboard';
 import {
-  PotassiumSlipRenderer,
-  type PotassiumUpgradeChoiceView
+  PotassiumSlipRenderer
 } from './potassiumSlipRenderer';
+import {
+  createPotassiumSession,
+  getPotassiumSessionGenericRank,
+  getPotassiumSessionHud,
+  getPotassiumSessionSkillRank,
+  markPotassiumRowSpawned,
+  resolvePotassiumDraftChoice,
+  resolvePotassiumEnemyEscaped,
+  resolvePotassiumEnemyKilled,
+  resolvePotassiumTerminalAction,
+  resolvePotassiumWaveClear,
+  showPotassiumDraftChoices,
+  spawnPotassiumWave,
+  startPotassiumCampaign,
+  startPotassiumEndless,
+  type PotassiumSessionCommand,
+  type PotassiumSessionState
+} from './potassiumSlipSession';
 
-type GameState = 'START' | 'PLAYING' | 'UPGRADE' | 'WON' | 'GAME_OVER';
 type ControlState = 'idle' | 'aiming' | 'recalling';
 type EnemySprite = Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
 type ProjectileSprite = Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
@@ -72,12 +76,6 @@ interface EnemyConfig {
   indestructible?: boolean;
   splitsOnDeath?: boolean;
   shielded?: boolean;
-}
-
-interface UpgradeConfig {
-  label: string;
-  color: string;
-  description: string;
 }
 
 const ARENA = {
@@ -103,7 +101,6 @@ const LAUNCH_PAD = {
   radius: 44
 } as const;
 
-const LIVES_INITIAL = 5;
 const MAIN_BANANA_MAX_SPEED = 760;
 const LAUNCH_POWER = 6.2;
 const LAUNCH_MAX_DRAG = 130;
@@ -136,39 +133,6 @@ const BOSS_STONE_INTERVAL_MS = 4300;
 const BOSS_SUMMON_INTERVAL_MS = 3600;
 const BOSS_ORBIT_RADIUS = 78;
 const BOSS_ORBIT_SPEED = 0.0017;
-
-const GENERIC_UPGRADE_CONFIGS: Record<GenericUpgradeKind, UpgradeConfig> = {
-  damage: {
-    label: 'Damage +',
-    color: '#1a1a1a',
-    description: '+12% banana and beam damage.'
-  },
-  poison: {
-    label: 'Poison +',
-    color: '#65a30d',
-    description: '+10% poison tick strength.'
-  },
-  explosion: {
-    label: 'Explosion +',
-    color: '#ef4444',
-    description: '+6% blast radius.'
-  },
-  cloneTime: {
-    label: 'Clone Time +',
-    color: '#facc15',
-    description: '+300ms clone lifetime.'
-  },
-  bananaSpeed: {
-    label: 'Banana Speed +',
-    color: '#38bdf8',
-    description: '+5% launch speed.'
-  },
-  bonusLife: {
-    label: 'Bonus Life',
-    color: '#a855f7',
-    description: '+1 life right now.'
-  }
-};
 
 const ENEMY_CONFIGS: Record<EnemyKind, EnemyConfig> = {
   intern: {
@@ -248,81 +212,6 @@ const ENEMY_CONFIGS: Record<EnemyKind, EnemyConfig> = {
   }
 };
 
-const UPGRADE_CONFIGS: Record<UpgradeKind, UpgradeConfig> = {
-  fire: {
-    label: 'Fire Trail',
-    color: '#f97316',
-    description: 'Moving bananas leave hot nonsense.'
-  },
-  poison: {
-    label: 'Poison Damage',
-    color: '#65a30d',
-    description: 'Hits tick for 1 dmg every 500ms.'
-  },
-  explosion: {
-    label: 'Explosion Damage',
-    color: '#ef4444',
-    description: 'Every hit pops nearby paperwork.'
-  },
-  duplicate: {
-    label: 'Duplicate',
-    color: '#facc15',
-    description: 'Main hits spawn two tiny bananas.'
-  },
-  ghostHorizontal: {
-    label: 'Horizontal Ghost',
-    color: '#38bdf8',
-    description: 'Hits sweep a blue row beam.'
-  },
-  ghostVertical: {
-    label: 'Vertical Ghost',
-    color: '#60a5fa',
-    description: 'Hits sweep a blue column beam.'
-  }
-};
-
-function isGenericDraftOption(option: DraftOption): option is GenericDraftOption {
-  return option.type === 'generic';
-}
-
-function getDraftOptionDescription(option: DraftOption): string {
-  if (isGenericDraftOption(option)) return GENERIC_UPGRADE_CONFIGS[option.kind].description;
-  if (option.kind === 'fire') {
-    return option.action === 'unlock'
-      ? 'Moving bananas leave fire.'
-      : 'Hits drop extra fire patches.';
-  }
-  if (option.kind === 'poison') {
-    return option.action === 'unlock'
-      ? 'Hits poison enemies over time.'
-      : 'Poisoned enemies spread on death.';
-  }
-  if (option.kind === 'explosion') {
-    return option.action === 'unlock'
-      ? 'Hits explode with falloff damage.'
-      : 'Bigger blasts apply statuses.';
-  }
-  if (option.kind === 'duplicate') {
-    return option.action === 'unlock'
-      ? 'Main hits spawn 2 small bananas.'
-      : 'Clones apply half-strength procs and spawn +1.';
-  }
-  if (option.kind === 'ghostHorizontal') {
-    return option.action === 'unlock'
-      ? 'Hits fire a blue row beam.'
-      : 'Row beams apply statuses.';
-  }
-  return option.action === 'unlock'
-    ? 'Hits fire a blue column beam.'
-    : 'Column beams apply statuses.';
-}
-
-function getDraftOptionTitle(option: DraftOption): string {
-  if (isGenericDraftOption(option)) return GENERIC_UPGRADE_CONFIGS[option.kind].label;
-  const label = UPGRADE_CONFIGS[option.kind].label;
-  return option.action === 'upgrade' ? `${label} +` : label;
-}
-
 export class PotassiumSlipScene extends Phaser.Scene {
   private banana!: ProjectileSprite;
   private enemies!: Phaser.Physics.Arcade.Group;
@@ -333,18 +222,9 @@ export class PotassiumSlipScene extends Phaser.Scene {
   private tetherLine!: Phaser.GameObjects.Graphics;
   private potassiumRenderer!: PotassiumSlipRenderer;
 
-  private gameState: GameState = 'START';
+  private session: PotassiumSessionState = createPotassiumSession();
   private controlState: ControlState = 'idle';
-  private score: number = 0;
-  private lives: number = LIVES_INITIAL;
-  private wave: number = 1;
-  private waveAdvancing: boolean = false;
-  private pendingRows: number = 0;
   private aimPointerId: number | null = null;
-  private skillRanks: SkillRanks = {};
-  private genericRanks: GenericRanks = {};
-  private runMode: RunMode = 'campaign';
-  private runRecordCompletedAt?: string;
   private fireCells = new Set<string>();
   private activeBoss?: EnemySprite;
   private combatIdCounter: number = 0;
@@ -394,7 +274,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   update(time: number, delta: number): void {
     if (this.isPaused) return;
 
-    if (this.gameState !== 'PLAYING') {
+    if (this.session.gameState !== 'PLAYING') {
       this.banana.setVelocity(0, 0);
       return;
     }
@@ -413,18 +293,9 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private resetRunState(): void {
-    this.gameState = 'START';
+    this.session = createPotassiumSession();
     this.controlState = 'idle';
-    this.score = 0;
-    this.lives = LIVES_INITIAL;
-    this.wave = 1;
-    this.waveAdvancing = false;
-    this.pendingRows = 0;
     this.aimPointerId = null;
-    this.skillRanks = {};
-    this.genericRanks = {};
-    this.runMode = 'campaign';
-    this.runRecordCompletedAt = undefined;
     this.combatIdCounter = 0;
     this.fireCells.clear();
   }
@@ -486,19 +357,19 @@ export class PotassiumSlipScene extends Phaser.Scene {
 
   private registerInput(): void {
     this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
-      if (this.gameState === 'UPGRADE') {
+      if (this.session.gameState === 'UPGRADE') {
         this.handleUpgradeChoicePointer(pointer);
         return;
       }
-      if (this.gameState === 'START') {
+      if (this.session.gameState === 'START') {
         this.startGame();
         return;
       }
-      if (this.gameState === 'WON' || this.gameState === 'GAME_OVER') {
+      if (this.session.gameState === 'WON' || this.session.gameState === 'GAME_OVER') {
         this.handleTerminalPointer(pointer);
         return;
       }
-      if (this.gameState !== 'PLAYING') return;
+      if (this.session.gameState !== 'PLAYING') return;
       if (this.isBananaInLaunchZone()) {
         this.beginAiming(pointer);
       } else {
@@ -517,19 +388,19 @@ export class PotassiumSlipScene extends Phaser.Scene {
     });
 
     this.input.keyboard?.on('keydown-E', () => {
-      if (this.gameState === 'WON' || this.gameState === 'GAME_OVER') {
+      if (this.session.gameState === 'WON' || this.session.gameState === 'GAME_OVER') {
         this.onClose?.();
       }
     });
 
     this.input.keyboard?.on('keydown-R', () => {
-      if (this.gameState === 'WON' || this.gameState === 'GAME_OVER') {
+      if (this.session.gameState === 'WON' || this.session.gameState === 'GAME_OVER') {
         this.startGame();
       }
     });
 
     this.input.keyboard?.on('keydown-SPACE', () => {
-      if (this.gameState === 'WON') {
+      if (this.session.gameState === 'WON') {
         this.startEndlessMode();
       }
     });
@@ -540,28 +411,80 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private startGame(): void {
-    this.resetRunState();
-    this.gameState = 'PLAYING';
-    this.potassiumRenderer.hideMainOverlay();
-    this.clearTerminalOverlay();
-    this.resetBoardObjects();
-    bridgeActions.setSceneHintText('Drag toward a target • Hold to recall');
-    this.spawnWave(1);
-    this.updateHud();
+    this.controlState = 'idle';
+    this.aimPointerId = null;
+    this.combatIdCounter = 0;
+    this.applySessionResult(startPotassiumCampaign(this.session));
   }
 
   private startEndlessMode(): void {
-    if (this.gameState !== 'WON') return;
-    this.runMode = 'endless';
-    this.gameState = 'PLAYING';
-    this.waveAdvancing = false;
-    this.pendingRows = 0;
-    this.potassiumRenderer.hideMainOverlay();
-    this.clearTerminalOverlay();
-    this.resetBoardObjects();
-    bridgeActions.setSceneHintText('Endless audit • The nonsense keeps filing');
-    this.spawnWave(12);
-    this.updateHud();
+    this.applySessionResult(startPotassiumEndless(this.session));
+  }
+
+  private applySessionResult(result: { state: PotassiumSessionState; commands: readonly PotassiumSessionCommand[] }): void {
+    this.session = result.state;
+    this.applySessionCommands(result.commands);
+  }
+
+  private applySessionCommands(commands: readonly PotassiumSessionCommand[]): void {
+    commands.forEach((command) => {
+      if (command.type === 'resetBoard') {
+        this.resetBoardObjects();
+      } else if (command.type === 'hideMainOverlay') {
+        this.potassiumRenderer.hideMainOverlay();
+      } else if (command.type === 'clearTerminal') {
+        this.clearTerminalOverlay();
+      } else if (command.type === 'clearUpgradeChoices') {
+        this.clearUpgradeChoiceOverlay();
+      } else if (command.type === 'setHint') {
+        bridgeActions.setSceneHintText(command.text);
+      } else if (command.type === 'spawnWave') {
+        this.spawnWave(command.wave);
+      } else if (command.type === 'spawnBoss') {
+        this.time.delayedCall(350, () => this.spawnEnemy('boss', 0));
+      } else if (command.type === 'scheduleWaveRows') {
+        command.rows.forEach((row, rowIndex) => {
+          this.time.delayedCall(rowIndex * ROW_SPAWN_DELAY_MS, () => this.spawnEnemyRow(row, rowIndex));
+        });
+      } else if (command.type === 'scheduleUpgradeChoices') {
+        this.time.delayedCall(UPGRADE_CHOICE_DELAY_MS, () => {
+          if (this.session.gameState === 'PLAYING') {
+            this.showUpgradeChoices();
+          }
+        });
+      } else if (command.type === 'showUpgradeChoices') {
+        this.potassiumRenderer.showUpgradeChoices([...command.choices]);
+      } else if (command.type === 'advanceWaveAfterDelay') {
+        this.time.delayedCall(WAVE_ADVANCE_DELAY_MS, () => {
+          if (this.session.gameState === 'PLAYING') {
+            this.spawnWave(command.wave);
+          }
+        });
+      } else if (command.type === 'refreshProjectileVisuals') {
+        this.refreshAllProjectileVisuals();
+      } else if (command.type === 'updateHud') {
+        this.potassiumRenderer.updateHud(command.hud);
+      } else if (command.type === 'collectCircuit') {
+        bridgeActions.collectItem('circuit');
+      } else if (command.type === 'saveRunRecord') {
+        savePotassiumRunRecord(command.record);
+      } else if (command.type === 'showOutcome') {
+        this.potassiumRenderer.showOutcomeOverlay({
+          title: command.title,
+          score: command.score,
+          titleFontSize: command.titleFontSize
+        });
+      } else if (command.type === 'showTerminal') {
+        this.createTerminalOverlay(command.outcome);
+      } else if (command.type === 'closeScene') {
+        this.onClose?.();
+      } else if (command.type === 'stopBanana') {
+        this.banana.setVelocity(0, 0);
+        this.banana.setAngularVelocity(0);
+      } else if (command.type === 'clearBoardForOutcome') {
+        this.clearBoardForOutcome();
+      }
+    });
   }
 
   private resetBoardObjects(): void {
@@ -588,6 +511,16 @@ export class PotassiumSlipScene extends Phaser.Scene {
     this.tetherLine?.clear();
     this.clearUpgradeChoiceOverlay();
     this.clearTerminalOverlay();
+  }
+
+  private clearBoardForOutcome(): void {
+    this.setBananaRecallVisual(false);
+    this.destroyAllCloneVisuals();
+    this.enemies.clear(true, true);
+    this.clones.clear(true, true);
+    this.trailZones.clear(true, true);
+    this.bossBlockers.clear(true, true);
+    this.banana.setVelocity(0, 0);
   }
 
   private beginAiming(pointer: Phaser.Input.Pointer): void {
@@ -749,11 +682,11 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private getSkillRank(upgrade: UpgradeKind): SkillRank {
-    return getPotassiumSkillRank(this.skillRanks, upgrade);
+    return getPotassiumSessionSkillRank(this.session, upgrade);
   }
 
   private getGenericRank(upgrade: GenericUpgradeKind): number {
-    return getPotassiumGenericUpgradeRank(this.genericRanks, upgrade);
+    return getPotassiumSessionGenericRank(this.session, upgrade);
   }
 
   private getExplosionRadiusMultiplier(): number {
@@ -773,7 +706,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private refreshBananaUpgradeVisuals(projectile: ProjectileSprite, options: { isClone?: boolean } = {}): void {
-    this.potassiumRenderer.refreshProjectileVisuals(projectile, this.skillRanks, {
+    this.potassiumRenderer.refreshProjectileVisuals(projectile, this.session.skillRanks, {
       isClone: options.isClone,
       isMain: projectile === this.banana,
       isRecall: projectile === this.banana && ((projectile.getData('recallVisual') as boolean | undefined) ?? false)
@@ -805,27 +738,13 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private spawnWave(waveNumber: number): void {
-    this.wave = waveNumber;
-    this.waveAdvancing = false;
     this.cancelControl();
-
-    const wave = getPotassiumWave(waveNumber);
-    if (isPotassiumBossWave(waveNumber)) {
-      this.time.delayedCall(350, () => this.spawnEnemy('boss', 0));
-      bridgeActions.setSceneHintText('Boss wave • Stop the audit before it lands');
-      return;
-    }
-
-    this.pendingRows = wave.rows.length;
-    wave.rows.forEach((row, rowIndex) => {
-      this.time.delayedCall(rowIndex * ROW_SPAWN_DELAY_MS, () => this.spawnEnemyRow(row, rowIndex));
-    });
-    bridgeActions.setSceneHintText(`${wave.title}: ${this.getWaveHint(waveNumber)}`);
+    this.applySessionResult(spawnPotassiumWave(this.session, waveNumber));
   }
 
   private spawnEnemyRow(row: readonly WaveCell[], rowIndex: number = 0): void {
-    if (this.gameState !== 'PLAYING') return;
-    this.pendingRows = Math.max(0, this.pendingRows - 1);
+    if (this.session.gameState !== 'PLAYING') return;
+    this.applySessionResult(markPotassiumRowSpawned(this.session));
     row.forEach((kind, columnIndex) => {
       if (kind === null) return;
       this.spawnEnemy(kind, columnIndex, rowIndex);
@@ -833,12 +752,12 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private spawnEnemy(kind: EnemyKind, columnIndex: number = 0, rowIndex: number = 0, yOverride?: number): EnemySprite | undefined {
-    if (this.gameState !== 'PLAYING') return;
+    if (this.session.gameState !== 'PLAYING') return;
     const config = ENEMY_CONFIGS[kind];
     const x = this.getEnemySpawnX(kind, columnIndex);
     const y = yOverride ?? (kind === 'boss' ? SAFE.top + 60 : SAFE.top + 12);
     const enemy = this.enemies.create(x, y, config.texture) as EnemySprite;
-    this.configureEnemy(enemy, kind, this.wave, columnIndex, rowIndex);
+    this.configureEnemy(enemy, kind, this.session.wave, columnIndex, rowIndex);
 
     if (kind === 'boss') {
       this.activeBoss = enemy;
@@ -928,7 +847,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private hitEnemy(enemy: EnemySprite, projectile: ProjectileSprite, hitKey: string): void {
-    if (this.gameState !== 'PLAYING' || !enemy.active) return;
+    if (this.session.gameState !== 'PLAYING' || !enemy.active) return;
     const cooldownKey = `hitUntil:${hitKey}`;
     const hitUntil = enemy.getData(cooldownKey) as number | undefined;
     if (hitUntil !== undefined && hitUntil > this.time.now) return;
@@ -938,8 +857,8 @@ export class PotassiumSlipScene extends Phaser.Scene {
       now: this.time.now,
       enemy: this.getEnemyCombatFacts(enemy),
       projectile: this.getProjectileCombatFacts(projectile),
-      skillRanks: this.skillRanks,
-      genericRanks: this.genericRanks
+      skillRanks: this.session.skillRanks,
+      genericRanks: this.session.genericRanks
     }), this.createCombatContext([enemy], [projectile]));
   }
 
@@ -1090,8 +1009,8 @@ export class PotassiumSlipScene extends Phaser.Scene {
       enemy: this.getEnemyCombatFacts(enemy),
       amount,
       source,
-      skillRanks: this.skillRanks,
-      genericRanks: this.genericRanks
+      skillRanks: this.session.skillRanks,
+      genericRanks: this.session.genericRanks
     }), this.createCombatContext());
   }
 
@@ -1138,7 +1057,10 @@ export class PotassiumSlipScene extends Phaser.Scene {
     this.spawnSplitterChildren(enemy);
     enemy.setData('dying', true);
     enemy.body.enable = false;
-    this.score += config.score;
+    const killResult = resolvePotassiumEnemyKilled(this.session, config.score, kind);
+    if (kind !== 'boss') {
+      this.applySessionResult(killResult);
+    }
 
     this.tweens.add({
       targets: enemy,
@@ -1150,7 +1072,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
       onComplete: () => {
         enemy.destroy();
         if (kind === 'boss') {
-          this.winGame();
+          this.applySessionResult(killResult);
         }
       }
     });
@@ -1328,8 +1250,8 @@ export class PotassiumSlipScene extends Phaser.Scene {
         enemy: this.getEnemyCombatFacts(enemy),
         distance: Phaser.Math.Distance.Between(x, y, enemy.x, enemy.y)
       })),
-      skillRanks: this.skillRanks,
-      genericRanks: this.genericRanks
+      skillRanks: this.session.skillRanks,
+      genericRanks: this.session.genericRanks
     }), this.createCombatContext(enemies));
     this.cameras.main.shake(130, 0.006);
   }
@@ -1350,8 +1272,8 @@ export class PotassiumSlipScene extends Phaser.Scene {
           ? Math.abs(enemy.y - y) <= 28
           : Math.abs(enemy.x - x) <= 28
       })),
-      skillRanks: this.skillRanks,
-      genericRanks: this.genericRanks
+      skillRanks: this.session.skillRanks,
+      genericRanks: this.session.genericRanks
     }), this.createCombatContext(enemies));
   }
 
@@ -1573,96 +1495,40 @@ export class PotassiumSlipScene extends Phaser.Scene {
 
   private handleBossEscape(enemy: EnemySprite): void {
     enemy.destroy();
-    this.lives = 0;
     this.cameras.main.shake(320, 0.014);
-    this.gameOver();
+    this.applySessionResult(resolvePotassiumEnemyEscaped(this.session, 'boss'));
   }
 
   private handleEnemyEscape(enemy: EnemySprite): void {
+    const kind = enemy.getData('kind') as EnemyKind;
     enemy.destroy();
-    this.lives -= 1;
     this.cameras.main.shake(180, 0.008);
-    if (this.lives <= 0) {
-      this.gameOver();
-    }
+    this.applySessionResult(resolvePotassiumEnemyEscaped(this.session, kind));
   }
 
   private checkWaveClear(): void {
-    if (this.waveAdvancing || this.gameState !== 'PLAYING' || isPotassiumBossWave(this.wave)) return;
-    if (this.pendingRows > 0) return;
     const hasLivingEnemies = this.enemies.getChildren().some((gameObject) => {
       const enemy = gameObject as EnemySprite;
       return enemy.active && !enemy.getData('dying');
     });
-    if (hasLivingEnemies) return;
-    this.waveAdvancing = true;
-    bridgeActions.setSceneHintText('Wave clear • Choose fresh banana nonsense');
-    this.time.delayedCall(UPGRADE_CHOICE_DELAY_MS, () => {
-      if (this.gameState === 'PLAYING') {
-        this.showUpgradeChoices();
-      }
-    });
+    this.applySessionResult(resolvePotassiumWaveClear({
+      state: this.session,
+      hasLivingEnemies
+    }));
   }
 
   private showUpgradeChoices(): void {
-    const choices = getPotassiumDraftChoices(this.skillRanks, this.genericRanks, this.wave);
-    if (choices.length === 0) {
-      this.advanceToNextWave();
-      return;
-    }
-
-    this.gameState = 'UPGRADE';
-    this.banana.setVelocity(0, 0);
-    this.banana.setAngularVelocity(0);
-    this.clearUpgradeChoiceOverlay();
-    this.potassiumRenderer.showUpgradeChoices(choices.map<PotassiumUpgradeChoiceView>((option) => {
-      const config = isGenericDraftOption(option) ? GENERIC_UPGRADE_CONFIGS[option.kind] : UPGRADE_CONFIGS[option.kind];
-      return {
-        option,
-        title: getDraftOptionTitle(option),
-        description: getDraftOptionDescription(option),
-        color: config.color,
-      };
-    }));
+    this.applySessionResult(showPotassiumDraftChoices(this.session));
   }
 
   private handleUpgradeChoicePointer(pointer: Phaser.Input.Pointer): void {
     const choice = this.potassiumRenderer.getUpgradeChoiceAt(pointer.x, pointer.y);
     if (!choice) return;
-    this.applyDraftChoice(choice);
-    this.clearUpgradeChoiceOverlay();
-    this.advanceToNextWave();
-  }
-
-  private applyDraftChoice(option: DraftOption): void {
-    if (isGenericDraftOption(option)) {
-      this.genericRanks = applyPotassiumGenericDraftOption(this.genericRanks, option);
-      if (option.kind === 'bonusLife') {
-        this.lives += 1;
-      }
-      bridgeActions.setSceneHintText(`${GENERIC_UPGRADE_CONFIGS[option.kind].label} stacked • Endless paperwork trembles`);
-      this.updateHud();
-      return;
-    }
-
-    this.skillRanks = applyPotassiumDraftOption(this.skillRanks, option);
-    const actionLabel = option.action === 'unlock' ? 'unlocked' : 'upgraded';
-    bridgeActions.setSceneHintText(`${UPGRADE_CONFIGS[option.kind].label} ${actionLabel} • It stacks forever`);
-    this.refreshAllProjectileVisuals();
-    this.updateHud();
+    this.applySessionResult(resolvePotassiumDraftChoice(this.session, choice));
   }
 
   private clearUpgradeChoiceOverlay(): void {
     this.potassiumRenderer.clearUpgradeChoices();
-  }
-
-  private advanceToNextWave(): void {
-    this.gameState = 'PLAYING';
-    this.time.delayedCall(WAVE_ADVANCE_DELAY_MS, () => {
-      if (this.gameState === 'PLAYING') {
-        this.spawnWave(this.wave + 1);
-      }
-    });
   }
 
   private updateEnemyVisuals(): void {
@@ -1672,82 +1538,10 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private updateHud(): void {
-    const wave = getPotassiumWave(this.wave);
-    this.potassiumRenderer.updateHud({
-      waveLabel: `W${this.wave} ${wave.title}`,
-      score: this.score,
-      lives: this.lives
-    });
+    this.potassiumRenderer.updateHud(getPotassiumSessionHud(this.session));
   }
 
-  private getWaveHint(wave: number): string {
-    if (wave > 11) return 'endless paperwork escalation';
-    if (wave === 1) return 'launch and bounce';
-    if (wave === 2) return 'multi-hit blobs';
-    if (wave === 3) return 'walls block angles';
-    if (wave === 4) return 'walls block angles';
-    if (wave === 5) return 'splitter memos make smaller problems';
-    if (wave === 6) return 'stack your choices';
-    if (wave === 7) return 'shield plates reject bad angles';
-    if (wave >= 8 && wave <= 10) return 'hard walls ignore banana law';
-    return 'boss time';
-  }
-
-  private winGame(): void {
-    this.gameState = 'WON';
-    this.banana.setVelocity(0, 0);
-    this.setBananaRecallVisual(false);
-    this.destroyAllCloneVisuals();
-    this.enemies.clear(true, true);
-    this.clones.clear(true, true);
-    this.trailZones.clear(true, true);
-    this.bossBlockers.clear(true, true);
-    this.clearUpgradeChoiceOverlay();
-    if (this.runMode === 'campaign') {
-      bridgeActions.collectItem('circuit');
-    }
-    this.saveRunRecord('won');
-    bridgeActions.setSceneHintText(null);
-    this.potassiumRenderer.showOutcomeOverlay({
-      title: 'CIRCUIT ACQUIRED',
-      score: this.score,
-      titleFontSize: 26
-    });
-    this.createTerminalOverlay('won');
-  }
-
-  private gameOver(): void {
-    this.gameState = 'GAME_OVER';
-    this.setBananaRecallVisual(false);
-    this.destroyAllCloneVisuals();
-    this.enemies.clear(true, true);
-    this.clones.clear(true, true);
-    this.trailZones.clear(true, true);
-    this.bossBlockers.clear(true, true);
-    this.banana.setVelocity(0, 0);
-    this.clearUpgradeChoiceOverlay();
-    this.saveRunRecord('game_over');
-    bridgeActions.setSceneHintText(null);
-    this.potassiumRenderer.showOutcomeOverlay({
-      title: 'BANANA BANKRUPTCY',
-      score: this.score,
-      titleFontSize: 24
-    });
-    this.createTerminalOverlay('game_over');
-  }
-
-  private saveRunRecord(outcome: RunOutcome): void {
-    this.runRecordCompletedAt ??= new Date().toISOString();
-    savePotassiumRunRecord({
-      score: this.score,
-      wave: this.wave,
-      mode: this.runMode,
-      outcome,
-      completedAt: this.runRecordCompletedAt
-    });
-  }
-
-  private createTerminalOverlay(outcome: RunOutcome): void {
+  private createTerminalOverlay(outcome: PotassiumRunOutcome): void {
     this.potassiumRenderer.showTerminal(outcome, this.getRecordsOverlayText());
   }
 
@@ -1765,13 +1559,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   private handleTerminalPointer(pointer: Phaser.Input.Pointer): void {
     const action = this.potassiumRenderer.getTerminalActionAt(pointer.x, pointer.y);
     if (!action) return;
-    if (action === 'return') {
-      this.onClose?.();
-    } else if (action === 'retry') {
-      this.startGame();
-    } else {
-      this.startEndlessMode();
-    }
+    this.applySessionResult(resolvePotassiumTerminalAction(this.session, action));
   }
 
   private clearTerminalOverlay(): void {

--- a/src/runtime/PotassiumSlipScene.ts
+++ b/src/runtime/PotassiumSlipScene.ts
@@ -10,18 +10,14 @@ import {
   applyPotassiumDraftOption,
   applyPotassiumGenericDraftOption,
   getPotassiumDraftChoices,
-  getPotassiumDuplicateCloneCount,
-  getPotassiumEnemyHealthState,
+  getPotassiumExplosionRadius,
   getPotassiumFireCellKey,
-  getPotassiumExplosionDamage,
   getPotassiumGenericUpgradeRank,
-  getPotassiumScaledExplosionRadius,
   getPotassiumShieldSide,
   getPotassiumSkillRank,
   getPotassiumWave,
   getPotassiumSplitterSpawnColumns,
   getScaledPotassiumEnemyHp,
-  isPotassiumShieldedHit,
   isPotassiumBossWave,
   POTASSIUM_COLUMN_COUNT,
   type PotassiumDraftOption as DraftOption,
@@ -36,6 +32,22 @@ import {
   type PotassiumEnemyKind as EnemyKind,
   type PotassiumUpgradeKind as UpgradeKind
 } from './potassiumSlipWaves';
+import {
+  POTASSIUM_GHOST_STATUS_FIELD_LIFETIME_MS,
+  POTASSIUM_POISON_DURATION_MS,
+  POTASSIUM_POISON_TICK_INTERVAL_MS,
+  resolvePotassiumDamage,
+  resolvePotassiumExplosion,
+  resolvePotassiumGhostBeam,
+  resolvePotassiumPoisonTick,
+  resolvePotassiumProjectileHit,
+  type PotassiumCombatCommand,
+  type PotassiumDamageSource,
+  type PotassiumEnemyCombatFacts,
+  type PotassiumGhostBeamDirection,
+  type PotassiumApplyPoisonCommand,
+  type PotassiumProjectileCombatFacts
+} from './potassiumSlipCombat';
 import {
   getPotassiumLeaderboardTop,
   savePotassiumRunRecord,
@@ -117,7 +129,6 @@ const RECALL_SPEED = 720;
 const RECALL_MODE: 'direct' | 'elastic' = 'direct';
 const RECALL_ELASTIC_PULL = 980;
 const RECALL_ELASTIC_MAX_SPEED = 780;
-const RECALL_DAMAGE = 0.65;
 const WAVE_ADVANCE_DELAY_MS = 900;
 const SIDE_BOUNCE_MARGIN = 32;
 const BANANA_RICOCHET_MIN_SPEED = 360;
@@ -127,18 +138,11 @@ const NON_BOSS_ENEMY_SPEED = 64;
 const ROW_SPAWN_DELAY_MS = 900;
 const TRAIL_DROP_INTERVAL_MS = 180;
 const FIRE_TRAIL_LIFETIME_MS = 1500;
-const FIRE_TICK_COOLDOWN_MS = 420;
-const POISON_TICK_INTERVAL_MS = 500;
-const POISON_DURATION_MS = 2500;
-const DUPLICATE_CLONE_LIFETIME_MS = 3000;
 const GHOST_BEAM_LIFETIME_MS = 190;
-const GHOST_STATUS_FIELD_LIFETIME_MS = 680;
 const UPGRADE_CHOICE_DELAY_MS = 450;
 const POISON_TINT = 0x65a30d;
 const CLONE_EFFECT_MULTIPLIER = 0.5;
-const FIRE_HIT_PATCH_LIFETIME_MS = 900;
 const POISON_DEATH_SPREAD_RADIUS = 76;
-const POISON_UPGRADED_DAMAGE_MULTIPLIER = 1.25;
 const CELL_FIRE_ROW_HEIGHT = 48;
 const BOSS_PATROL_SPEED = 54;
 const BOSS_PHASE_1_DRIFT = 4;
@@ -365,6 +369,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   private terminalButtons: TerminalButton[] = [];
   private recordsText?: Phaser.GameObjects.Text;
   private activeBoss?: EnemySprite;
+  private combatIdCounter: number = 0;
 
   private hudText!: Phaser.GameObjects.Text;
   private scoreText!: Phaser.GameObjects.Text;
@@ -443,6 +448,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
     this.genericRanks = {};
     this.runMode = 'campaign';
     this.runRecordCompletedAt = undefined;
+    this.combatIdCounter = 0;
     this.fireCells.clear();
   }
 
@@ -850,20 +856,8 @@ export class PotassiumSlipScene extends Phaser.Scene {
     return getPotassiumGenericUpgradeRank(this.genericRanks, upgrade);
   }
 
-  private getDamageMultiplier(): number {
-    return 1 + this.getGenericRank('damage') * 0.12;
-  }
-
-  private getPoisonGenericMultiplier(): number {
-    return 1 + this.getGenericRank('poison') * 0.1;
-  }
-
   private getExplosionRadiusMultiplier(): number {
     return 1 + this.getGenericRank('explosion') * 0.06;
-  }
-
-  private getCloneLifetimeMs(): number {
-    return DUPLICATE_CLONE_LIFETIME_MS + this.getGenericRank('cloneTime') * 300;
   }
 
   private getProjectileEffectMultiplier(projectile: ProjectileSprite): number {
@@ -1150,78 +1144,116 @@ export class PotassiumSlipScene extends Phaser.Scene {
     if (hitUntil !== undefined && hitUntil > this.time.now) return;
     enemy.setData(cooldownKey, this.time.now + HIT_COOLDOWN_MS);
 
-    const isMainRecall = projectile === this.banana && this.controlState === 'recalling';
-    const effectMultiplier = this.getProjectileEffectMultiplier(projectile);
-    if (this.isBossStoneProtected(enemy) || this.isShieldProtectedHit(enemy, projectile)) {
-      this.showDamageRing(enemy, 'ghost');
-      if (isMainRecall) {
-        projectile.setVelocity(projectile.body.velocity.x * 1.01, projectile.body.velocity.y * 1.01);
-      } else {
-        this.ricochetProjectileFromEnemy(projectile, enemy);
+    this.applyCombatCommands(resolvePotassiumProjectileHit({
+      now: this.time.now,
+      enemy: this.getEnemyCombatFacts(enemy),
+      projectile: this.getProjectileCombatFacts(projectile),
+      skillRanks: this.skillRanks,
+      genericRanks: this.genericRanks
+    }), this.createCombatContext([enemy], [projectile]));
+  }
+
+  private getEnemyCombatFacts(enemy: EnemySprite): PotassiumEnemyCombatFacts {
+    return {
+      id: this.getCombatId(enemy, 'enemy'),
+      kind: enemy.getData('kind') as EnemyKind,
+      active: enemy.active,
+      dying: Boolean(enemy.getData('dying')),
+      hp: (enemy.getData('hp') as number | undefined) ?? 0,
+      maxHp: (enemy.getData('maxHp') as number | undefined) ?? 0,
+      x: enemy.x,
+      y: enemy.y,
+      indestructible: Boolean(enemy.getData('indestructible')),
+      splitsOnDeath: Boolean(enemy.getData('splitsOnDeath')),
+      poisonExpiresAt: enemy.getData('poisonExpiresAt') as number | undefined,
+      poisonMultiplier: enemy.getData('poisonMultiplier') as number | undefined,
+      poisonNextTickAt: enemy.getData('poisonNextTickAt') as number | undefined,
+      fireTickUntil: enemy.getData('fireTickUntil') as number | undefined,
+      shieldSide: enemy.getData('shieldSide') as ShieldSide | undefined,
+      stoneUntil: enemy.getData('stoneUntil') as number | undefined
+    };
+  }
+
+  private getProjectileCombatFacts(projectile: ProjectileSprite): PotassiumProjectileCombatFacts {
+    return {
+      id: this.getCombatId(projectile, projectile === this.banana ? 'main' : 'projectile'),
+      isMain: projectile === this.banana,
+      isRecall: projectile === this.banana && this.controlState === 'recalling',
+      x: projectile.x,
+      y: projectile.y,
+      effectMultiplier: this.getProjectileEffectMultiplier(projectile),
+      canApplyHitProcs: this.canProjectileApplyHitProcs(projectile),
+      canDuplicate: Boolean(projectile.getData('canDuplicate')),
+      explosionRadiusMultiplier: this.getProjectileExplosionRadiusMultiplier(projectile)
+    };
+  }
+
+  private getCombatId(object: Phaser.GameObjects.GameObject, prefix: string): string {
+    const existingId = object.getData('combatId') as string | undefined;
+    if (existingId) return existingId;
+    const id = `${prefix}-${this.combatIdCounter}`;
+    this.combatIdCounter += 1;
+    object.setData('combatId', id);
+    return id;
+  }
+
+  private createCombatContext(
+    enemies: EnemySprite[] = this.enemies.getChildren() as EnemySprite[],
+    projectiles: ProjectileSprite[] = [this.banana, ...(this.clones.getChildren() as ProjectileSprite[])]
+  ): {
+    enemies: Map<string, EnemySprite>;
+    projectiles: Map<string, ProjectileSprite>;
+  } {
+    return {
+      enemies: new Map(enemies.map((enemy) => [this.getCombatId(enemy, 'enemy'), enemy])),
+      projectiles: new Map(projectiles.map((projectile) => [this.getCombatId(projectile, projectile === this.banana ? 'main' : 'projectile'), projectile]))
+    };
+  }
+
+  private applyCombatCommands(
+    commands: readonly PotassiumCombatCommand[],
+    context = this.createCombatContext()
+  ): void {
+    commands.forEach((command) => {
+      const enemy = 'enemyId' in command ? context.enemies.get(command.enemyId) : undefined;
+      const projectile = 'projectileId' in command ? context.projectiles.get(command.projectileId) : undefined;
+      if (command.type === 'damageEnemy') {
+        if (enemy) this.damageEnemy(enemy, command.amount, command.source);
+      } else if (command.type === 'setEnemyHp') {
+        enemy?.setData('hp', command.hp);
+        enemy?.setData('damageState', command.damageState);
+      } else if (command.type === 'setFireTickUntil') {
+        enemy?.setData('fireTickUntil', command.fireTickUntil);
+      } else if (command.type === 'setPoisonNextTickAt') {
+        enemy?.setData('poisonNextTickAt', command.poisonNextTickAt);
+      } else if (command.type === 'showDamageCue') {
+        if (enemy) this.showDamageCue(enemy, command.source);
+      } else if (command.type === 'ricochetProjectile') {
+        if (projectile && enemy) this.ricochetProjectileFromEnemy(projectile, enemy);
+      } else if (command.type === 'boostRecallVelocity') {
+        projectile?.setVelocity(projectile.body.velocity.x * 1.01, projectile.body.velocity.y * 1.01);
+      } else if (command.type === 'applyPoison') {
+        if (enemy) this.applyPoisonCommand(enemy, command);
+      } else if (command.type === 'clearPoison') {
+        if (enemy) this.clearPoison(enemy);
+      } else if (command.type === 'spawnFirePatch') {
+        this.spawnFirePatch(command.x, command.y, command.effectMultiplier, command.lifetimeMs, command.scale);
+      } else if (command.type === 'explodeAt') {
+        this.explodeAt(command.x, command.y, command.effectMultiplier, command.radiusMultiplier);
+      } else if (command.type === 'spawnBananaClones') {
+        this.spawnBananaClones(command.count, command.lifetimeMs);
+      } else if (command.type === 'spawnGhostBeam') {
+        this.spawnGhostBeam(command.x, command.y, command.direction, command.effectMultiplier);
+      } else if (command.type === 'spawnGhostStatusField') {
+        this.spawnGhostStatusField(command.x, command.y, command.direction, command.effectMultiplier);
+      } else if (command.type === 'spreadPoisonFrom') {
+        this.spreadPoisonFrom(command.x, command.y, command.effectMultiplier, context.enemies.get(command.sourceEnemyId));
+      } else if (command.type === 'spawnSplitterChildren') {
+        if (enemy) this.spawnSplitterChildren(enemy);
+      } else if (command.type === 'killEnemy') {
+        if (enemy) this.killEnemy(enemy);
       }
-      return;
-    }
-    this.damageEnemy(enemy, (isMainRecall ? RECALL_DAMAGE : 1) * effectMultiplier * this.getDamageMultiplier(), 'banana');
-    if (isMainRecall) {
-      projectile.setVelocity(projectile.body.velocity.x * 1.01, projectile.body.velocity.y * 1.01);
-    } else {
-      this.ricochetProjectileFromEnemy(projectile, enemy);
-    }
-
-    this.applyUnlockedHitEffects(projectile, enemy, isMainRecall, effectMultiplier);
-  }
-
-  private isBossStoneProtected(enemy: EnemySprite): boolean {
-    if ((enemy.getData('kind') as EnemyKind) !== 'boss') return false;
-    const stoneUntil = enemy.getData('stoneUntil') as number | undefined;
-    return stoneUntil !== undefined && stoneUntil > this.time.now;
-  }
-
-  private isShieldProtectedHit(enemy: EnemySprite, projectile: ProjectileSprite): boolean {
-    const shieldSide = enemy.getData('shieldSide') as ShieldSide | undefined;
-    if (!shieldSide) return false;
-    return isPotassiumShieldedHit(shieldSide, projectile.x - enemy.x, projectile.y - enemy.y);
-  }
-
-  private applyUnlockedHitEffects(
-    projectile: ProjectileSprite,
-    enemy: EnemySprite,
-    isMainRecall: boolean,
-    effectMultiplier: number
-  ): void {
-    const canApplyHitProcs = this.canProjectileApplyHitProcs(projectile);
-    if (canApplyHitProcs) {
-      this.applyStatusEffects(enemy, effectMultiplier, false);
-    }
-
-    if (canApplyHitProcs && this.getSkillRank('fire') >= 2) {
-      this.spawnFirePatch(enemy.x, enemy.y, effectMultiplier, FIRE_HIT_PATCH_LIFETIME_MS, projectile === this.banana ? 0.7 : 0.5);
-    }
-    if (canApplyHitProcs && !isMainRecall && this.getSkillRank('explosion') > 0) {
-      this.explodeAt(enemy.x, enemy.y, effectMultiplier, this.getProjectileExplosionRadiusMultiplier(projectile));
-    }
-    if (!isMainRecall && projectile.getData('canDuplicate') && this.getSkillRank('duplicate') > 0) {
-      this.spawnBananaClones(getPotassiumDuplicateCloneCount(this.getSkillRank('duplicate')), this.getCloneLifetimeMs());
-    }
-    if (!isMainRecall && this.getSkillRank('ghostHorizontal') > 0) {
-      this.spawnGhostBeam(enemy.x, enemy.y, 'horizontal', effectMultiplier);
-    }
-    if (!isMainRecall && this.getSkillRank('ghostVertical') > 0) {
-      this.spawnGhostBeam(enemy.x, enemy.y, 'vertical', effectMultiplier);
-    }
-  }
-
-  private applyStatusEffects(
-    enemy: EnemySprite,
-    effectMultiplier: number,
-    allowExplosionStatus: boolean
-  ): void {
-    if (this.getSkillRank('poison') > 0) {
-      this.applyPoison(enemy, effectMultiplier);
-    }
-    if (allowExplosionStatus && this.getSkillRank('fire') > 0) {
-      this.spawnFirePatch(enemy.x, enemy.y, effectMultiplier, FIRE_HIT_PATCH_LIFETIME_MS, 0.58);
-    }
+    });
   }
 
   private ricochetProjectileFromEnemy(projectile: ProjectileSprite, enemy: EnemySprite): void {
@@ -1262,47 +1294,24 @@ export class PotassiumSlipScene extends Phaser.Scene {
     projectile.setAngularVelocity(Phaser.Math.Clamp(ricochet.x * 1.4, -720, 720));
   }
 
-  private damageEnemy(enemy: EnemySprite, amount: number, source: 'banana' | 'fire' | 'poison' | 'explosion' | 'ghost'): void {
-    if (!enemy.active || enemy.getData('dying')) return;
-    if (source === 'fire') {
-      const fireUntil = enemy.getData('fireTickUntil') as number | undefined;
-      if (fireUntil !== undefined && fireUntil > this.time.now) return;
-      enemy.setData('fireTickUntil', this.time.now + FIRE_TICK_COOLDOWN_MS);
-    }
-    if (enemy.getData('indestructible')) {
-      this.showDamageCue(enemy, source);
-      return;
-    }
-
-    const hp = Math.max(0, (enemy.getData('hp') as number) - amount);
-    enemy.setData('hp', hp);
-    this.updateEnemyDamageState(enemy);
-    this.showDamageCue(enemy, source);
-    if (hp <= 0) {
-      this.killEnemy(enemy);
-    }
+  private damageEnemy(enemy: EnemySprite, amount: number, source: PotassiumDamageSource): void {
+    this.applyCombatCommands(resolvePotassiumDamage({
+      now: this.time.now,
+      enemy: this.getEnemyCombatFacts(enemy),
+      amount,
+      source,
+      skillRanks: this.skillRanks,
+      genericRanks: this.genericRanks
+    }), this.createCombatContext());
   }
 
-  private updateEnemyDamageState(enemy: EnemySprite): void {
-    const state = getPotassiumEnemyHealthState(
-      enemy.getData('hp') as number,
-      enemy.getData('maxHp') as number
-    );
-    enemy.setData('damageState', state);
-  }
-
-  private applyPoison(enemy: EnemySprite, effectMultiplier: number = 1, applyRankBonus = true): void {
-    const poisonMultiplier = applyRankBonus && this.getSkillRank('poison') >= 2
-      ? effectMultiplier * POISON_UPGRADED_DAMAGE_MULTIPLIER * this.getPoisonGenericMultiplier()
-      : effectMultiplier;
-    const currentExpiresAt = (enemy.getData('poisonExpiresAt') as number | undefined) ?? 0;
-    enemy.setData('poisonExpiresAt', Math.max(currentExpiresAt, this.time.now + POISON_DURATION_MS * poisonMultiplier));
+  private applyPoisonCommand(enemy: EnemySprite, command: PotassiumApplyPoisonCommand): void {
+    enemy.setData('poisonExpiresAt', command.expiresAt);
     enemy.setData('poisoned', true);
-    enemy.setData('poisonMultiplier', Math.max((enemy.getData('poisonMultiplier') as number | undefined) ?? 0, poisonMultiplier));
+    enemy.setData('poisonMultiplier', command.poisonMultiplier);
     enemy.setTint(POISON_TINT);
-    const nextTickAt = enemy.getData('poisonNextTickAt') as number | undefined;
-    if (nextTickAt === undefined || nextTickAt < this.time.now) {
-      enemy.setData('poisonNextTickAt', this.time.now + POISON_TICK_INTERVAL_MS);
+    if (command.nextTickAt !== undefined) {
+      enemy.setData('poisonNextTickAt', command.nextTickAt);
     }
   }
 
@@ -1311,7 +1320,19 @@ export class PotassiumSlipScene extends Phaser.Scene {
       const enemy = gameObject as EnemySprite;
       if (enemy === sourceEnemy || !enemy.active || enemy.getData('dying')) return;
       if (Phaser.Math.Distance.Between(x, y, enemy.x, enemy.y) <= POISON_DEATH_SPREAD_RADIUS) {
-        this.applyPoison(enemy, effectMultiplier, false);
+        this.applyPoisonCommand(enemy, {
+          type: 'applyPoison',
+          enemyId: this.getCombatId(enemy, 'enemy'),
+          effectMultiplier,
+          poisonMultiplier: Math.max((enemy.getData('poisonMultiplier') as number | undefined) ?? 0, effectMultiplier),
+          expiresAt: Math.max(
+            (enemy.getData('poisonExpiresAt') as number | undefined) ?? 0,
+            this.time.now + POTASSIUM_POISON_DURATION_MS * effectMultiplier
+          ),
+          nextTickAt: ((enemy.getData('poisonNextTickAt') as number | undefined) ?? 0) < this.time.now
+            ? this.time.now + POTASSIUM_POISON_TICK_INTERVAL_MS
+            : undefined
+        });
       }
     });
   }
@@ -1501,16 +1522,11 @@ export class PotassiumSlipScene extends Phaser.Scene {
     if (this.getSkillRank('poison') <= 0) return;
     this.enemies.getChildren().forEach((gameObject) => {
       const enemy = gameObject as EnemySprite;
-      const expiresAt = enemy.getData('poisonExpiresAt') as number | undefined;
-      if (!enemy.active || expiresAt === undefined) return;
-      if (expiresAt <= time) {
-        this.clearPoison(enemy);
-        return;
-      }
-      const nextTickAt = (enemy.getData('poisonNextTickAt') as number | undefined) ?? time;
-      if (nextTickAt > time) return;
-      enemy.setData('poisonNextTickAt', time + POISON_TICK_INTERVAL_MS);
-      this.damageEnemy(enemy, (enemy.getData('poisonMultiplier') as number | undefined) ?? 1, 'poison');
+      this.applyCombatCommands(resolvePotassiumPoisonTick({
+        now: time,
+        enemy: this.getEnemyCombatFacts(enemy),
+        poisonUnlocked: this.getSkillRank('poison') > 0
+      }), this.createCombatContext([enemy]));
     });
   }
 
@@ -1529,7 +1545,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
 
   private explodeAt(x: number, y: number, effectMultiplier: number, radiusMultiplier: number): void {
     const rank = this.getSkillRank('explosion');
-    const radius = getPotassiumScaledExplosionRadius(rank, radiusMultiplier * this.getExplosionRadiusMultiplier());
+    const radius = getPotassiumExplosionRadius(rank) * radiusMultiplier * this.getExplosionRadiusMultiplier();
     const blast = this.add.circle(x, y, 18, 0xf97316, 0.22)
       .setStrokeStyle(5, 0x1a1a1a, 1)
       .setDepth(940);
@@ -1540,23 +1556,25 @@ export class PotassiumSlipScene extends Phaser.Scene {
       duration: 240,
       onComplete: () => blast.destroy()
     });
-    this.enemies.getChildren().forEach((gameObject) => {
-      const enemy = gameObject as EnemySprite;
-      const distance = Phaser.Math.Distance.Between(x, y, enemy.x, enemy.y);
-      const damage = getPotassiumExplosionDamage(distance, radius, effectMultiplier * this.getDamageMultiplier());
-      if (damage > 0) {
-        this.damageEnemy(enemy, damage, 'explosion');
-        if (rank >= 2) {
-          this.applyStatusEffects(enemy, effectMultiplier, true);
-        }
-      }
-    });
+    const enemies = this.enemies.getChildren() as EnemySprite[];
+    this.applyCombatCommands(resolvePotassiumExplosion({
+      now: this.time.now,
+      x,
+      y,
+      effectMultiplier,
+      radiusMultiplier,
+      hits: enemies.map((enemy) => ({
+        enemy: this.getEnemyCombatFacts(enemy),
+        distance: Phaser.Math.Distance.Between(x, y, enemy.x, enemy.y)
+      })),
+      skillRanks: this.skillRanks,
+      genericRanks: this.genericRanks
+    }), this.createCombatContext(enemies));
     this.cameras.main.shake(130, 0.006);
   }
 
   private spawnGhostBeam(x: number, y: number, direction: 'horizontal' | 'vertical', effectMultiplier: number): void {
     const isHorizontal = direction === 'horizontal';
-    const rank = this.getSkillRank(isHorizontal ? 'ghostHorizontal' : 'ghostVertical');
     const width = isHorizontal ? ARENA.width - 42 : 24;
     const height = isHorizontal ? 24 : ARENA.height - 128;
     const beam = this.add.rectangle(
@@ -1567,21 +1585,22 @@ export class PotassiumSlipScene extends Phaser.Scene {
       0x38bdf8,
       0.24
     ).setStrokeStyle(4, 0x1a1a1a, 0.82).setDepth(935);
-    this.enemies.getChildren().forEach((gameObject) => {
-      const enemy = gameObject as EnemySprite;
-      const inBeam = isHorizontal
-        ? Math.abs(enemy.y - y) <= 28
-        : Math.abs(enemy.x - x) <= 28;
-      if (inBeam) {
-        this.damageEnemy(enemy, 1 * effectMultiplier * this.getDamageMultiplier(), 'ghost');
-        if (rank >= 2) {
-          this.applyStatusEffects(enemy, effectMultiplier, false);
-        }
-      }
-    });
-    if (rank >= 2) {
-      this.spawnGhostStatusField(x, y, direction, effectMultiplier, width, height);
-    }
+    const enemies = this.enemies.getChildren() as EnemySprite[];
+    this.applyCombatCommands(resolvePotassiumGhostBeam({
+      now: this.time.now,
+      x,
+      y,
+      direction,
+      effectMultiplier,
+      hits: enemies.map((enemy) => ({
+        enemy: this.getEnemyCombatFacts(enemy),
+        inBeam: isHorizontal
+          ? Math.abs(enemy.y - y) <= 28
+          : Math.abs(enemy.x - x) <= 28
+      })),
+      skillRanks: this.skillRanks,
+      genericRanks: this.genericRanks
+    }), this.createCombatContext(enemies));
     this.tweens.add({
       targets: beam,
       alpha: 0,
@@ -1593,19 +1612,19 @@ export class PotassiumSlipScene extends Phaser.Scene {
   private spawnGhostStatusField(
     x: number,
     y: number,
-    direction: 'horizontal' | 'vertical',
-    effectMultiplier: number,
-    width: number,
-    height: number
+    direction: PotassiumGhostBeamDirection,
+    effectMultiplier: number
   ): void {
+    const isHorizontal = direction === 'horizontal';
+    const width = isHorizontal ? ARENA.width - 42 : 24;
+    const height = isHorizontal ? 24 : ARENA.height - 128;
     if (this.getSkillRank('fire') > 0) {
-      const isHorizontal = direction === 'horizontal';
       const patchCount = isHorizontal ? 5 : 7;
       for (let index = 0; index < patchCount; index += 1) {
         const t = patchCount <= 1 ? 0.5 : index / (patchCount - 1);
         const patchX = isHorizontal ? Phaser.Math.Linear(ARENA.left + 46, ARENA.right - 46, t) : x;
         const patchY = isHorizontal ? y : Phaser.Math.Linear(ARENA.top + 112, ARENA.bottom - 92, t);
-        this.spawnFirePatch(patchX, patchY, effectMultiplier, GHOST_STATUS_FIELD_LIFETIME_MS, 0.46);
+        this.spawnFirePatch(patchX, patchY, effectMultiplier, POTASSIUM_GHOST_STATUS_FIELD_LIFETIME_MS, 0.46);
       }
     }
     if (this.getSkillRank('poison') > 0) {
@@ -1620,7 +1639,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
       this.tweens.add({
         targets: field,
         alpha: 0,
-        duration: GHOST_STATUS_FIELD_LIFETIME_MS,
+        duration: POTASSIUM_GHOST_STATUS_FIELD_LIFETIME_MS,
         onComplete: () => field.destroy()
       });
     }

--- a/src/runtime/PotassiumSlipScene.ts
+++ b/src/runtime/PotassiumSlipScene.ts
@@ -44,6 +44,16 @@ import {
   PotassiumSlipRenderer
 } from './potassiumSlipRenderer';
 import {
+  createPotassiumBossState,
+  POTASSIUM_BOSS_PHASE_1_DRIFT,
+  POTASSIUM_BOSS_PATROL_SPEED,
+  resolvePotassiumBossFrame,
+  type PotassiumBossCommand,
+  type PotassiumBossFacts,
+  type PotassiumBossState,
+  type PotassiumBossSummonFacts
+} from './potassiumSlipBoss';
+import {
   createPotassiumSession,
   getPotassiumSessionGenericRank,
   getPotassiumSessionHud,
@@ -124,13 +134,6 @@ const POISON_TINT = 0x65a30d;
 const CLONE_EFFECT_MULTIPLIER = 0.5;
 const POISON_DEATH_SPREAD_RADIUS = 76;
 const CELL_FIRE_ROW_HEIGHT = 48;
-const BOSS_PATROL_SPEED = 54;
-const BOSS_PHASE_1_DRIFT = 4;
-const BOSS_PHASE_2_DRIFT = 6;
-const BOSS_PHASE_3_DRIFT = 3;
-const BOSS_STONE_DURATION_MS = 1350;
-const BOSS_STONE_INTERVAL_MS = 4300;
-const BOSS_SUMMON_INTERVAL_MS = 3600;
 const BOSS_ORBIT_RADIUS = 78;
 const BOSS_ORBIT_SPEED = 0.0017;
 
@@ -227,6 +230,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   private aimPointerId: number | null = null;
   private fireCells = new Set<string>();
   private activeBoss?: EnemySprite;
+  private bossState?: PotassiumBossState;
   private combatIdCounter: number = 0;
 
   private onClose?: () => void;
@@ -297,6 +301,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
     this.controlState = 'idle';
     this.aimPointerId = null;
     this.combatIdCounter = 0;
+    this.bossState = undefined;
     this.fireCells.clear();
   }
 
@@ -495,6 +500,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
     this.trailZones?.clear(true, true);
     this.bossBlockers?.clear(true, true);
     this.activeBoss = undefined;
+    this.bossState = undefined;
     this.fireCells.clear();
     this.banana.setPosition(LAUNCH_PAD.x, LAUNCH_PAD.y);
     this.banana.setVelocity(0, 0);
@@ -520,6 +526,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
     this.clones.clear(true, true);
     this.trailZones.clear(true, true);
     this.bossBlockers.clear(true, true);
+    this.bossState = undefined;
     this.banana.setVelocity(0, 0);
   }
 
@@ -761,13 +768,15 @@ export class PotassiumSlipScene extends Phaser.Scene {
 
     if (kind === 'boss') {
       this.activeBoss = enemy;
+      this.bossState = createPotassiumBossState(this.time.now);
       enemy.once(Phaser.GameObjects.Events.DESTROY, () => {
         if (this.activeBoss === enemy) {
           this.activeBoss = undefined;
+          this.bossState = undefined;
         }
       });
       enemy.setPosition(LAUNCH_PAD.x, SAFE.top + 132);
-      enemy.setVelocity(BOSS_PATROL_SPEED, BOSS_PHASE_1_DRIFT);
+      enemy.setVelocity(POTASSIUM_BOSS_PATROL_SPEED, POTASSIUM_BOSS_PHASE_1_DRIFT);
       enemy.setBounce(1, 1);
       this.cameras.main.shake(250, 0.008);
     } else {
@@ -817,9 +826,6 @@ export class PotassiumSlipScene extends Phaser.Scene {
     });
     if (kind === 'boss') {
       enemy.setData('bossPhase', 1);
-      enemy.setData('nextStoneAt', this.time.now + BOSS_STONE_INTERVAL_MS);
-      enemy.setData('nextSummonAt', this.time.now + BOSS_SUMMON_INTERVAL_MS);
-      enemy.setData('orbitStarted', false);
     }
 
     if (kind === 'scope') {
@@ -1306,59 +1312,66 @@ export class PotassiumSlipScene extends Phaser.Scene {
 
   private updateBossFight(time: number): void {
     const boss = this.activeBoss;
-    if (!boss || boss.getData('dying')) {
-      this.bossBlockers.getChildren().forEach((gameObject) => gameObject.destroy());
-      return;
-    }
-
-    const phase = this.getBossPhase(boss);
-    const previousPhase = (boss.getData('bossPhase') as number | undefined) ?? 1;
-    if (phase !== previousPhase) {
-      boss.setData('bossPhase', phase);
-      this.cameras.main.shake(220, 0.007);
-      bridgeActions.setSceneHintText(phase === 2
-        ? 'Boss phase 2 • Orbiting walls hate angles'
-        : 'Boss phase 3 • Stone audits summon witnesses');
-    }
-
-    this.updateBossPatrol(boss, phase);
-    if (phase >= 2 && !boss.getData('orbitStarted')) {
-      this.spawnBossOrbitBlockers(boss);
-      boss.setData('orbitStarted', true);
-    }
-    if (phase >= 2) {
-      this.updateBossOrbitBlockers(boss, time);
-    }
-    if (phase >= 3) {
-      this.updateBossStoneAndSummons(boss, time);
-    } else {
-      this.setBossStoneVisual(boss, false);
-    }
+    const result = resolvePotassiumBossFrame({
+      now: time,
+      state: this.bossState,
+      boss: boss ? this.getBossFacts(boss) : undefined,
+      patrolBounds: {
+        left: SAFE.left + 42,
+        right: SAFE.right - 42
+      },
+      summonLayout: {
+        arenaLeft: ARENA.left,
+        arenaWidth: ARENA.width,
+        safeTop: SAFE.top,
+        safeBottom: SAFE.bottom
+      }
+    });
+    this.bossState = result.state;
+    this.applyBossCommands(result.commands, boss);
   }
 
-  private getBossPhase(boss: EnemySprite): number {
-    const hp = boss.getData('hp') as number;
-    const maxHp = boss.getData('maxHp') as number;
-    const ratio = maxHp > 0 ? hp / maxHp : 1;
-    if (ratio <= 0.3) return 3;
-    if (ratio <= 0.6) return 2;
-    return 1;
+  private getBossFacts(boss: EnemySprite): PotassiumBossFacts {
+    return {
+      active: boss.active,
+      dying: Boolean(boss.getData('dying')),
+      hp: (boss.getData('hp') as number | undefined) ?? 0,
+      maxHp: (boss.getData('maxHp') as number | undefined) ?? 0,
+      x: boss.x,
+      y: boss.y,
+      velocityX: boss.body.velocity.x
+    };
   }
 
-  private updateBossPatrol(boss: EnemySprite, phase: number): void {
-    const left = SAFE.left + 42;
-    const right = SAFE.right - 42;
-    if (boss.x <= left) {
-      boss.setX(left);
-      boss.setVelocityX(BOSS_PATROL_SPEED);
-    } else if (boss.x >= right) {
-      boss.setX(right);
-      boss.setVelocityX(-BOSS_PATROL_SPEED);
-    } else if (Math.abs(boss.body.velocity.x) < 10) {
-      boss.setVelocityX(BOSS_PATROL_SPEED);
-    }
-    const drift = phase === 1 ? BOSS_PHASE_1_DRIFT : phase === 2 ? BOSS_PHASE_2_DRIFT : BOSS_PHASE_3_DRIFT;
-    boss.setVelocityY(drift);
+  private applyBossCommands(commands: readonly PotassiumBossCommand[], boss?: EnemySprite): void {
+    commands.forEach((command) => {
+      if (command.type === 'setBossPhase') {
+        boss?.setData('bossPhase', command.phase);
+      } else if (command.type === 'setBossVelocity') {
+        if (!boss) return;
+        if (command.x !== undefined) boss.setX(command.x);
+        if (command.velocityX !== undefined) boss.setVelocityX(command.velocityX);
+        boss.setVelocityY(command.velocityY);
+      } else if (command.type === 'setBossHint') {
+        bridgeActions.setSceneHintText(command.text);
+      } else if (command.type === 'shakeCamera') {
+        this.cameras.main.shake(command.durationMs, command.intensity);
+      } else if (command.type === 'spawnOrbitBlockers') {
+        if (boss) this.spawnBossOrbitBlockers(boss);
+      } else if (command.type === 'updateOrbitBlockers') {
+        if (boss) this.updateBossOrbitBlockers(boss, command.now);
+      } else if (command.type === 'startStone') {
+        boss?.setData('stoneUntil', command.stoneUntil);
+      } else if (command.type === 'endStone') {
+        boss?.setData('stoneUntil', undefined);
+      } else if (command.type === 'setStoneVisual') {
+        if (boss) this.setBossStoneVisual(boss, command.active);
+      } else if (command.type === 'spawnSummons') {
+        this.spawnBossSummons(command.summons);
+      } else if (command.type === 'clearOrbitBlockers') {
+        this.bossBlockers.getChildren().forEach((gameObject) => gameObject.destroy());
+      }
+    });
   }
 
   private spawnBossOrbitBlockers(boss: EnemySprite): void {
@@ -1388,26 +1401,6 @@ export class PotassiumSlipScene extends Phaser.Scene {
     });
   }
 
-  private updateBossStoneAndSummons(boss: EnemySprite, time: number): void {
-    const stoneUntil = boss.getData('stoneUntil') as number | undefined;
-    if (stoneUntil !== undefined && stoneUntil > time) {
-      this.setBossStoneVisual(boss, true);
-    } else {
-      this.setBossStoneVisual(boss, false);
-      const nextStoneAt = (boss.getData('nextStoneAt') as number | undefined) ?? 0;
-      if (time >= nextStoneAt) {
-        boss.setData('stoneUntil', time + BOSS_STONE_DURATION_MS);
-        boss.setData('nextStoneAt', time + BOSS_STONE_INTERVAL_MS);
-      }
-    }
-
-    const nextSummonAt = (boss.getData('nextSummonAt') as number | undefined) ?? 0;
-    if (time >= nextSummonAt) {
-      this.spawnBossSummons(boss);
-      boss.setData('nextSummonAt', time + BOSS_SUMMON_INTERVAL_MS);
-    }
-  }
-
   private setBossStoneVisual(boss: EnemySprite, active: boolean): void {
     if (active) {
       boss.setTint(0x78716c);
@@ -1423,18 +1416,10 @@ export class PotassiumSlipScene extends Phaser.Scene {
     }
   }
 
-  private spawnBossSummons(boss: EnemySprite): void {
-    const centerColumn = Phaser.Math.Clamp(
-      Math.round(((boss.x - ARENA.left) / ARENA.width) * POTASSIUM_COLUMN_COUNT - 0.5),
-      0,
-      POTASSIUM_COLUMN_COUNT - 1
-    );
-    const columns = getPotassiumSplitterSpawnColumns(centerColumn);
-    const y = Phaser.Math.Clamp(boss.y + 76, SAFE.top + 24, SAFE.bottom - 120);
-    columns.forEach((column, index) => {
-      const kind: EnemyKind = index % 2 === 0 ? 'scope' : 'deadline';
-      const enemy = this.spawnEnemy(kind, column, 0, y);
-      enemy?.setVelocity(0, NON_BOSS_ENEMY_SPEED + 10);
+  private spawnBossSummons(summons: readonly PotassiumBossSummonFacts[]): void {
+    summons.forEach((summon) => {
+      const enemy = this.spawnEnemy(summon.kind, summon.column, 0, summon.y);
+      enemy?.setVelocity(0, summon.velocityY);
     });
   }
 

--- a/src/runtime/PotassiumSlipScene.ts
+++ b/src/runtime/PotassiumSlipScene.ts
@@ -3,7 +3,6 @@ import {
   GAME_DESIGN_HEIGHT,
   GAME_DESIGN_WIDTH
 } from './config';
-import { createUiText, snapUiTextCoordinate } from './text/createUiText';
 import { bridgeActions } from '../shared/bridge/store';
 import { TextureGenerator } from './textures/TextureGenerator';
 import {
@@ -21,7 +20,6 @@ import {
   isPotassiumBossWave,
   POTASSIUM_COLUMN_COUNT,
   type PotassiumDraftOption as DraftOption,
-  type PotassiumEnemyHealthState as EnemyHealthState,
   type PotassiumGenericDraftOption as GenericDraftOption,
   type PotassiumGenericUpgradeKind as GenericUpgradeKind,
   type PotassiumGenericUpgradeRanks as GenericRanks,
@@ -54,10 +52,13 @@ import {
   type PotassiumRunMode as RunMode,
   type PotassiumRunOutcome as RunOutcome
 } from './potassiumSlipLeaderboard';
+import {
+  PotassiumSlipRenderer,
+  type PotassiumUpgradeChoiceView
+} from './potassiumSlipRenderer';
 
 type GameState = 'START' | 'PLAYING' | 'UPGRADE' | 'WON' | 'GAME_OVER';
 type ControlState = 'idle' | 'aiming' | 'recalling';
-type TerminalAction = 'retry' | 'return' | 'endless';
 type EnemySprite = Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
 type ProjectileSprite = Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
 
@@ -77,24 +78,6 @@ interface UpgradeConfig {
   label: string;
   color: string;
   description: string;
-}
-
-interface UpgradeChoiceButton {
-  option: DraftOption;
-  panel: Phaser.GameObjects.Rectangle;
-  label: Phaser.GameObjects.Text;
-  description: Phaser.GameObjects.Text;
-}
-
-interface TerminalButton {
-  action: TerminalAction;
-  panel: Phaser.GameObjects.Rectangle;
-  label: Phaser.GameObjects.Text;
-}
-
-interface BananaVisuals {
-  behind: Phaser.GameObjects.Graphics;
-  front: Phaser.GameObjects.Graphics;
 }
 
 const ARENA = {
@@ -346,9 +329,9 @@ export class PotassiumSlipScene extends Phaser.Scene {
   private clones!: Phaser.Physics.Arcade.Group;
   private trailZones!: Phaser.Physics.Arcade.Group;
   private bossBlockers!: Phaser.Physics.Arcade.Group;
-  private fieldInk!: Phaser.GameObjects.Graphics;
   private aimLine!: Phaser.GameObjects.Graphics;
   private tetherLine!: Phaser.GameObjects.Graphics;
+  private potassiumRenderer!: PotassiumSlipRenderer;
 
   private gameState: GameState = 'START';
   private controlState: ControlState = 'idle';
@@ -363,19 +346,8 @@ export class PotassiumSlipScene extends Phaser.Scene {
   private runMode: RunMode = 'campaign';
   private runRecordCompletedAt?: string;
   private fireCells = new Set<string>();
-  private upgradeChoiceButtons: UpgradeChoiceButton[] = [];
-  private upgradeChoiceBackdrop?: Phaser.GameObjects.Rectangle;
-  private upgradeChoiceTitle?: Phaser.GameObjects.Text;
-  private terminalButtons: TerminalButton[] = [];
-  private recordsText?: Phaser.GameObjects.Text;
   private activeBoss?: EnemySprite;
   private combatIdCounter: number = 0;
-
-  private hudText!: Phaser.GameObjects.Text;
-  private scoreText!: Phaser.GameObjects.Text;
-  private livesText!: Phaser.GameObjects.Text;
-  private overlayText!: Phaser.GameObjects.Text;
-  private subOverlayText!: Phaser.GameObjects.Text;
 
   private onClose?: () => void;
   private isPaused: boolean = false;
@@ -395,6 +367,11 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   create(): void {
+    this.potassiumRenderer = new PotassiumSlipRenderer(this, {
+      arena: ARENA,
+      safe: SAFE,
+      launchPad: LAUNCH_PAD
+    });
     this.createPotassiumTextures();
     this.physics.world.setBounds(ARENA.left, ARENA.top, ARENA.width, ARENA.height);
     this.physics.world.gravity.set(0, 0);
@@ -453,53 +430,11 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private createPotassiumTextures(): void {
-    if (!this.textures.exists('potassium_enemy_intern')) this.createInternTexture();
-    if (!this.textures.exists('potassium_enemy_scope')) this.createScopeTexture();
-    if (!this.textures.exists('potassium_enemy_meeting')) this.createMeetingTexture();
-    if (!this.textures.exists('potassium_enemy_deadline')) this.createDeadlineTexture();
-    if (!this.textures.exists('potassium_enemy_wall')) this.createWallTexture();
-    if (!this.textures.exists('potassium_enemy_hard_wall')) this.createHardWallTexture();
-    if (!this.textures.exists('potassium_enemy_splitter')) this.createSplitterTexture();
-    if (!this.textures.exists('potassium_enemy_shield')) this.createShieldTexture();
-    if (!this.textures.exists('potassium_damage_cracked') || !this.textures.exists('potassium_damage_critical')) {
-      if (this.textures.exists('potassium_damage_cracked')) this.textures.remove('potassium_damage_cracked');
-      if (this.textures.exists('potassium_damage_critical')) this.textures.remove('potassium_damage_critical');
-      this.createDamageOverlayTextures();
-    }
-    if (!this.textures.exists('potassium_wall_damage_cracked') || !this.textures.exists('potassium_wall_damage_critical')) {
-      if (this.textures.exists('potassium_wall_damage_cracked')) this.textures.remove('potassium_wall_damage_cracked');
-      if (this.textures.exists('potassium_wall_damage_critical')) this.textures.remove('potassium_wall_damage_critical');
-      this.createWallDamageOverlayTextures();
-    }
-    if (!this.textures.exists('potassium_enemy_boss')) this.createBossTexture();
-    if (!this.textures.exists('potassium_fire')) this.createFireTexture();
+    this.potassiumRenderer.ensureTextures();
   }
 
   private drawField(): void {
-    this.fieldInk = this.add.graphics().setDepth(1);
-    this.fieldInk.fillStyle(0xfbfbf9, 1);
-    this.fieldInk.fillRect(ARENA.left, ARENA.top, ARENA.width, ARENA.height);
-    this.fieldInk.lineStyle(2, 0x1a1a1a, 0.2);
-    for (let y = 72; y < ARENA.bottom - 70; y += 48) {
-      this.fieldInk.beginPath();
-      this.fieldInk.moveTo(ARENA.left + 14, y);
-      this.fieldInk.lineTo(ARENA.right - 14, y + Phaser.Math.Between(-2, 2));
-      this.fieldInk.strokePath();
-    }
-
-    this.fieldInk.lineStyle(4, 0x1a1a1a, 0.85);
-    this.fieldInk.beginPath();
-    this.fieldInk.moveTo(ARENA.left + 8, ARENA.top);
-    this.fieldInk.lineTo(ARENA.left + 8, ARENA.bottom);
-    this.fieldInk.moveTo(ARENA.right - 8, ARENA.top);
-    this.fieldInk.lineTo(ARENA.right - 8, ARENA.bottom);
-    this.fieldInk.strokePath();
-
-    this.fieldInk.fillStyle(0x1a1a1a, 0.04);
-    this.fieldInk.fillRect(ARENA.left + 12, ARENA.top, ARENA.width - 24, 52);
-    this.fieldInk.fillRect(ARENA.left + 12, ARENA.bottom - 82, ARENA.width - 24, 82);
-    this.fieldInk.lineStyle(3, 0x1a1a1a, 0.32);
-    this.fieldInk.strokeCircle(LAUNCH_PAD.x, LAUNCH_PAD.y, LAUNCH_PAD.radius);
+    this.potassiumRenderer.drawField();
   }
 
   private createBanana(): void {
@@ -518,45 +453,12 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private createHud(): void {
-    this.hudText = createUiText(this, ARENA.left + 24, ARENA.top + 11, '', {
-      fontSize: '12px',
-      color: '#1a1a1a',
-      fontStyle: 'bold'
-    }).setDepth(1000);
-    this.scoreText = createUiText(this, GAME_DESIGN_WIDTH / 2, ARENA.top + 11, '', {
-      fontSize: '12px',
-      color: '#1a1a1a',
-      fontStyle: 'bold'
-    }).setOrigin(0.5, 0).setDepth(1000);
-    this.livesText = createUiText(this, ARENA.right - 24, ARENA.top + 11, '', {
-      fontSize: '12px',
-      color: '#1a1a1a',
-      fontStyle: 'bold'
-    }).setOrigin(1, 0).setDepth(1000);
+    this.potassiumRenderer.createHud();
     this.updateHud();
   }
 
   private createOverlays(): void {
-    this.overlayText = createUiText(this, GAME_DESIGN_WIDTH / 2, 245, 'POTASSIUM SLIP', {
-      fontSize: '32px',
-      color: '#1a1a1a',
-      fontStyle: 'bold',
-      wordWrap: { width: ARENA.width - 64, useAdvancedWrap: true }
-    }).setOrigin(0.5).setDepth(1010);
-
-    this.subOverlayText = createUiText(
-      this,
-      GAME_DESIGN_WIDTH / 2,
-      320,
-      'DRAG TOWARD A TARGET. RELEASE BANANA.\nHOLD ANYWHERE TO YO-YO IT HOME.\nCLEAR WAVES. STEAL THE CIRCUIT.',
-      {
-        fontSize: '14px',
-        color: '#1a1a1a',
-        align: 'center',
-        fontStyle: 'bold',
-        wordWrap: { width: ARENA.width - 70, useAdvancedWrap: true }
-      }
-    ).setOrigin(0.5).setDepth(1010);
+    this.potassiumRenderer.createStartOverlay();
   }
 
   private registerCollisions(): void {
@@ -640,8 +542,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   private startGame(): void {
     this.resetRunState();
     this.gameState = 'PLAYING';
-    this.overlayText.setVisible(false);
-    this.subOverlayText.setVisible(false);
+    this.potassiumRenderer.hideMainOverlay();
     this.clearTerminalOverlay();
     this.resetBoardObjects();
     bridgeActions.setSceneHintText('Drag toward a target • Hold to recall');
@@ -655,8 +556,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
     this.gameState = 'PLAYING';
     this.waveAdvancing = false;
     this.pendingRows = 0;
-    this.overlayText.setVisible(false);
-    this.subOverlayText.setVisible(false);
+    this.potassiumRenderer.hideMainOverlay();
     this.clearTerminalOverlay();
     this.resetBoardObjects();
     bridgeActions.setSceneHintText('Endless audit • The nonsense keeps filing');
@@ -873,104 +773,22 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private refreshBananaUpgradeVisuals(projectile: ProjectileSprite, options: { isClone?: boolean } = {}): void {
-    if (!projectile.active) return;
-    const isClone = options.isClone ?? projectile !== this.banana;
-    const isRecall = projectile === this.banana && ((projectile.getData('recallVisual') as boolean | undefined) ?? false);
-    projectile.setTexture(this.getSkillRank('poison') > 0 ? 'banana_peel_green' : 'banana_peel_yellow');
-    projectile.clearTint();
-    projectile.setAlpha(isClone ? 0.82 : isRecall ? 0.68 : 1);
-    this.destroyProjectileVisuals(projectile);
-
-    const behind = this.add.graphics().setDepth(projectile.depth - 1);
-    const front = this.add.graphics().setDepth(projectile.depth + 1);
-    this.drawBananaUpgradeAccents(behind, front, isClone);
-    projectile.setData('bananaVisuals', { behind, front } satisfies BananaVisuals);
-    this.positionBananaVisuals(projectile);
-  }
-
-  private drawBananaUpgradeAccents(
-    behind: Phaser.GameObjects.Graphics,
-    front: Phaser.GameObjects.Graphics,
-    isClone: boolean
-  ): void {
-    const scale = isClone ? 0.58 : 1;
-    const alphaScale = isClone ? 0.62 : 1;
-    const fireRank = this.getSkillRank('fire');
-    const explosionRank = this.getSkillRank('explosion');
-    const duplicateRank = this.getSkillRank('duplicate');
-    const ghostHorizontalRank = this.getSkillRank('ghostHorizontal');
-    const ghostVerticalRank = this.getSkillRank('ghostVertical');
-
-    if (duplicateRank > 0) {
-      behind.lineStyle((duplicateRank >= 2 ? 4 : 3) * scale, 0xfacc15, 0.28 * alphaScale);
-      behind.strokeEllipse(-16 * scale, 8 * scale, 26 * scale, 15 * scale);
-      behind.strokeEllipse(16 * scale, -7 * scale, 22 * scale, 13 * scale);
-    }
-
-    if (fireRank > 0) {
-      behind.lineStyle((fireRank >= 2 ? 6 : 4) * scale, 0xf97316, 0.55 * alphaScale);
-      behind.strokeCircle(0, 0, (fireRank >= 2 ? 36 : 32) * scale);
-      behind.lineStyle(2 * scale, 0xfacc15, 0.42 * alphaScale);
-      behind.strokeCircle(0, 0, 25 * scale);
-    }
-
-    if (ghostHorizontalRank > 0) {
-      front.lineStyle((ghostHorizontalRank >= 2 ? 5 : 3) * scale, 0x38bdf8, 0.56 * alphaScale);
-      front.beginPath();
-      front.moveTo(-34 * scale, 0);
-      front.lineTo(34 * scale, 0);
-      front.strokePath();
-    }
-
-    if (ghostVerticalRank > 0) {
-      front.lineStyle((ghostVerticalRank >= 2 ? 5 : 3) * scale, 0x60a5fa, 0.5 * alphaScale);
-      front.beginPath();
-      front.moveTo(0, -34 * scale);
-      front.lineTo(0, 34 * scale);
-      front.strokePath();
-    }
-
-    if (explosionRank > 0) {
-      const sparkScale = explosionRank >= 2 ? 1.12 : 1;
-      front.fillStyle(0xef4444, 0.86 * alphaScale);
-      front.lineStyle(2 * scale, 0x1a1a1a, 0.72 * alphaScale);
-      front.beginPath();
-      front.moveTo(22 * scale, -28 * scale);
-      front.lineTo(27 * scale * sparkScale, -14 * scale);
-      front.lineTo(38 * scale, -13 * scale);
-      front.lineTo(29 * scale, -6 * scale * sparkScale);
-      front.lineTo(33 * scale, 6 * scale);
-      front.lineTo(21 * scale, -2 * scale);
-      front.lineTo(11 * scale, 6 * scale);
-      front.lineTo(14 * scale, -8 * scale);
-      front.lineTo(4 * scale, -16 * scale);
-      front.lineTo(18 * scale, -17 * scale);
-      front.closePath();
-      front.fillPath();
-      front.strokePath();
-    }
-  }
-
-  private updateBananaUpgradeVisualPositions(): void {
-    this.positionBananaVisuals(this.banana);
-    this.clones.getChildren().forEach((gameObject) => {
-      this.positionBananaVisuals(gameObject as ProjectileSprite);
+    this.potassiumRenderer.refreshProjectileVisuals(projectile, this.skillRanks, {
+      isClone: options.isClone,
+      isMain: projectile === this.banana,
+      isRecall: projectile === this.banana && ((projectile.getData('recallVisual') as boolean | undefined) ?? false)
     });
   }
 
-  private positionBananaVisuals(projectile: ProjectileSprite): void {
-    const visuals = projectile.getData('bananaVisuals') as BananaVisuals | undefined;
-    if (!visuals) return;
-    visuals.behind.setPosition(projectile.x, projectile.y).setRotation(projectile.rotation).setVisible(projectile.active);
-    visuals.front.setPosition(projectile.x, projectile.y).setRotation(projectile.rotation).setVisible(projectile.active);
+  private updateBananaUpgradeVisualPositions(): void {
+    this.potassiumRenderer.positionProjectileVisuals(this.banana);
+    this.clones.getChildren().forEach((gameObject) => {
+      this.potassiumRenderer.positionProjectileVisuals(gameObject as ProjectileSprite);
+    });
   }
 
   private destroyProjectileVisuals(projectile?: ProjectileSprite): void {
-    if (!projectile) return;
-    const visuals = projectile.getData('bananaVisuals') as BananaVisuals | undefined;
-    visuals?.behind.destroy();
-    visuals?.front.destroy();
-    projectile.setData('bananaVisuals', undefined);
+    this.potassiumRenderer.destroyProjectileVisuals(projectile);
   }
 
   private destroyAllCloneVisuals(): void {
@@ -1068,15 +886,17 @@ export class PotassiumSlipScene extends Phaser.Scene {
     enemy.setData('occupiedColumns', kind === 'splitter' ? getPotassiumSplitterSpawnColumns(columnIndex) : [columnIndex]);
     enemy.setData('indestructible', config.indestructible ?? false);
     enemy.setData('splitsOnDeath', config.splitsOnDeath ?? false);
-    enemy.setData('damageState', 'healthy' satisfies EnemyHealthState);
-    enemy.setData('damageOverlay', this.createDamageOverlay(enemy));
+    let shieldSide: ShieldSide | undefined;
     if (config.shielded) {
-      const shieldSide = getPotassiumShieldSide(wave, rowIndex, columnIndex);
-      enemy.setData('shieldSide', shieldSide);
-      enemy.setData('shieldPlate', this.createShieldPlate(enemy, shieldSide));
+      shieldSide = getPotassiumShieldSide(wave, rowIndex, columnIndex);
     }
+    this.potassiumRenderer.createEnemyAttachments(enemy, {
+      kind,
+      label: config.label,
+      hp,
+      shieldSide
+    });
     if (kind === 'boss') {
-      enemy.setData('labelText', this.createEnemyLabel(enemy, config));
       enemy.setData('bossPhase', 1);
       enemy.setData('nextStoneAt', this.time.now + BOSS_STONE_INTERVAL_MS);
       enemy.setData('nextSummonAt', this.time.now + BOSS_SUMMON_INTERVAL_MS);
@@ -1090,36 +910,6 @@ export class PotassiumSlipScene extends Phaser.Scene {
       enemy.setImmovable(true);
     }
     this.fitEnemyBodyToOneCell(enemy, kind);
-  }
-
-  private createEnemyLabel(enemy: EnemySprite, config: EnemyConfig): Phaser.GameObjects.Text {
-    const label = createUiText(this, enemy.x, enemy.y - 34, `${config.label} ${config.hp}/${config.hp}`, {
-      fontSize: '9px',
-      color: '#1a1a1a',
-      fontStyle: 'bold',
-      align: 'center'
-    }).setOrigin(0.5).setDepth(900);
-    enemy.once(Phaser.GameObjects.Events.DESTROY, () => label.destroy());
-    return label;
-  }
-
-  private createDamageOverlay(enemy: EnemySprite): Phaser.GameObjects.Sprite {
-    const kind = enemy.getData('kind') as EnemyKind;
-    const overlay = this.add.sprite(enemy.x, enemy.y, kind === 'wall' ? 'potassium_wall_damage_cracked' : 'potassium_damage_cracked')
-      .setDepth(enemy.depth + 1)
-      .setOrigin(0.5)
-      .setVisible(false);
-    enemy.once(Phaser.GameObjects.Events.DESTROY, () => overlay.destroy());
-    return overlay;
-  }
-
-  private createShieldPlate(enemy: EnemySprite, side: ShieldSide): Phaser.GameObjects.Rectangle {
-    const plate = this.add.rectangle(enemy.x, enemy.y, 12, 12, 0x38bdf8, 0.4)
-      .setStrokeStyle(4, 0x1a1a1a, 0.9)
-      .setDepth(enemy.depth + 2);
-    enemy.once(Phaser.GameObjects.Events.DESTROY, () => plate.destroy());
-    this.positionShieldPlate(enemy, plate, side);
-    return plate;
   }
 
   private fitEnemyBodyToOneCell(enemy: EnemySprite, kind: EnemyKind): void {
@@ -1338,39 +1128,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private showDamageCue(enemy: EnemySprite, source: 'banana' | 'fire' | 'poison' | 'explosion' | 'ghost'): void {
-    this.showDamageRing(enemy, source);
-  }
-
-  private showDamageRing(enemy: EnemySprite, source: 'banana' | 'fire' | 'poison' | 'explosion' | 'ghost'): void {
-    const color = source === 'poison'
-      ? POISON_TINT
-      : source === 'fire'
-        ? 0xf97316
-        : source === 'explosion'
-          ? 0xef4444
-          : source === 'ghost'
-            ? 0x38bdf8
-            : 0x1a1a1a;
-    const radius = Math.max(18, enemy.displayWidth * 0.42);
-    const ring = this.add.circle(enemy.x, enemy.y, radius, color, 0.08)
-      .setStrokeStyle(3, color, 0.58)
-      .setDepth(930);
-    this.tweens.add({
-      targets: ring,
-      radius: radius + 10,
-      alpha: 0,
-      duration: 180,
-      ease: 'Sine.easeOut',
-      onComplete: () => ring.destroy()
-    });
-    this.tweens.add({
-      targets: enemy,
-      scaleX: enemy.scaleX * 1.06,
-      scaleY: enemy.scaleY * 1.06,
-      duration: 55,
-      yoyo: true,
-      ease: 'Sine.easeOut'
-    });
+    this.potassiumRenderer.showDamageCue(enemy, source);
   }
 
   private killEnemy(enemy: EnemySprite): void {
@@ -1442,7 +1200,10 @@ export class PotassiumSlipScene extends Phaser.Scene {
       this.refreshBananaUpgradeVisuals(clone, { isClone: true });
       this.time.delayedCall(lifetimeMs, () => {
         if (!clone.active) return;
-        const visuals = clone.getData('bananaVisuals') as BananaVisuals | undefined;
+        const visuals = clone.getData('bananaVisuals') as {
+          behind?: Phaser.GameObjects.Graphics;
+          front?: Phaser.GameObjects.Graphics;
+        } | undefined;
         this.tweens.add({
           targets: [clone, visuals?.behind, visuals?.front].filter(Boolean),
           alpha: 0,
@@ -1575,16 +1336,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
 
   private spawnGhostBeam(x: number, y: number, direction: 'horizontal' | 'vertical', effectMultiplier: number): void {
     const isHorizontal = direction === 'horizontal';
-    const width = isHorizontal ? ARENA.width - 42 : 24;
-    const height = isHorizontal ? 24 : ARENA.height - 128;
-    const beam = this.add.rectangle(
-      isHorizontal ? GAME_DESIGN_WIDTH / 2 : x,
-      isHorizontal ? y : ARENA.top + 92 + height / 2,
-      width,
-      height,
-      0x38bdf8,
-      0.24
-    ).setStrokeStyle(4, 0x1a1a1a, 0.82).setDepth(935);
+    this.potassiumRenderer.showGhostBeam({ x, y, direction, durationMs: GHOST_BEAM_LIFETIME_MS });
     const enemies = this.enemies.getChildren() as EnemySprite[];
     this.applyCombatCommands(resolvePotassiumGhostBeam({
       now: this.time.now,
@@ -1601,12 +1353,6 @@ export class PotassiumSlipScene extends Phaser.Scene {
       skillRanks: this.skillRanks,
       genericRanks: this.genericRanks
     }), this.createCombatContext(enemies));
-    this.tweens.add({
-      targets: beam,
-      alpha: 0,
-      duration: GHOST_BEAM_LIFETIME_MS,
-      onComplete: () => beam.destroy()
-    });
   }
 
   private spawnGhostStatusField(
@@ -1616,8 +1362,6 @@ export class PotassiumSlipScene extends Phaser.Scene {
     effectMultiplier: number
   ): void {
     const isHorizontal = direction === 'horizontal';
-    const width = isHorizontal ? ARENA.width - 42 : 24;
-    const height = isHorizontal ? 24 : ARENA.height - 128;
     if (this.getSkillRank('fire') > 0) {
       const patchCount = isHorizontal ? 5 : 7;
       for (let index = 0; index < patchCount; index += 1) {
@@ -1628,19 +1372,12 @@ export class PotassiumSlipScene extends Phaser.Scene {
       }
     }
     if (this.getSkillRank('poison') > 0) {
-      const field = this.add.rectangle(
-        direction === 'horizontal' ? GAME_DESIGN_WIDTH / 2 : x,
-        direction === 'horizontal' ? y : ARENA.top + 92 + height / 2,
-        width,
-        height,
-        POISON_TINT,
-        0.12
-      ).setStrokeStyle(2, POISON_TINT, 0.42).setDepth(934);
-      this.tweens.add({
-        targets: field,
-        alpha: 0,
-        duration: POTASSIUM_GHOST_STATUS_FIELD_LIFETIME_MS,
-        onComplete: () => field.destroy()
+      this.potassiumRenderer.showGhostStatusField({
+        x,
+        y,
+        direction,
+        poisonActive: true,
+        durationMs: POTASSIUM_GHOST_STATUS_FIELD_LIFETIME_MS
       });
     }
   }
@@ -1878,51 +1615,21 @@ export class PotassiumSlipScene extends Phaser.Scene {
     this.banana.setVelocity(0, 0);
     this.banana.setAngularVelocity(0);
     this.clearUpgradeChoiceOverlay();
-
-    this.upgradeChoiceBackdrop = this.add.rectangle(GAME_DESIGN_WIDTH / 2, 305, ARENA.width - 76, 176, 0xfbfbf9, 0.96)
-      .setStrokeStyle(5, 0x1a1a1a, 0.9)
-      .setDepth(1200);
-    this.upgradeChoiceTitle = createUiText(this, GAME_DESIGN_WIDTH / 2, 238, 'CHOOSE BANANA NONSENSE', {
-      fontSize: '15px',
-      color: '#1a1a1a',
-      fontStyle: 'bold',
-      align: 'center'
-    }).setOrigin(0.5).setDepth(1201);
-
-    const buttonWidth = 164;
-    const buttonHeight = 82;
-    const startX = choices.length === 1 ? GAME_DESIGN_WIDTH / 2 : GAME_DESIGN_WIDTH / 2 - 88;
-    this.upgradeChoiceButtons = choices.map((option, index) => {
+    this.potassiumRenderer.showUpgradeChoices(choices.map<PotassiumUpgradeChoiceView>((option) => {
       const config = isGenericDraftOption(option) ? GENERIC_UPGRADE_CONFIGS[option.kind] : UPGRADE_CONFIGS[option.kind];
-      const x = startX + index * 176;
-      const panel = this.add.rectangle(x, 312, buttonWidth, buttonHeight, 0xffffff, 0.92)
-        .setStrokeStyle(3, 0x1a1a1a, 0.75)
-        .setDepth(1201);
-      const label = createUiText(this, x, 286, getDraftOptionTitle(option), {
-        fontSize: '11px',
+      return {
+        option,
+        title: getDraftOptionTitle(option),
+        description: getDraftOptionDescription(option),
         color: config.color,
-        fontStyle: 'bold',
-        align: 'center',
-        wordWrap: { width: buttonWidth - 16, useAdvancedWrap: true }
-      }).setOrigin(0.5).setDepth(1202);
-      const description = createUiText(this, x, 326, getDraftOptionDescription(option), {
-        fontSize: '8px',
-        color: '#1a1a1a',
-        fontStyle: 'bold',
-        align: 'center',
-        wordWrap: { width: buttonWidth - 18, useAdvancedWrap: true }
-      }).setOrigin(0.5).setDepth(1202);
-      return { option, panel, label, description };
-    });
+      };
+    }));
   }
 
   private handleUpgradeChoicePointer(pointer: Phaser.Input.Pointer): void {
-    const choice = this.upgradeChoiceButtons.find((button) => {
-      const bounds = button.panel.getBounds();
-      return bounds.contains(pointer.x, pointer.y);
-    });
+    const choice = this.potassiumRenderer.getUpgradeChoiceAt(pointer.x, pointer.y);
     if (!choice) return;
-    this.applyDraftChoice(choice.option);
+    this.applyDraftChoice(choice);
     this.clearUpgradeChoiceOverlay();
     this.advanceToNextWave();
   }
@@ -1946,16 +1653,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private clearUpgradeChoiceOverlay(): void {
-    this.upgradeChoiceBackdrop?.destroy();
-    this.upgradeChoiceTitle?.destroy();
-    this.upgradeChoiceBackdrop = undefined;
-    this.upgradeChoiceTitle = undefined;
-    this.upgradeChoiceButtons.forEach((button) => {
-      button.panel.destroy();
-      button.label.destroy();
-      button.description.destroy();
-    });
-    this.upgradeChoiceButtons = [];
+    this.potassiumRenderer.clearUpgradeChoices();
   }
 
   private advanceToNextWave(): void {
@@ -1969,59 +1667,17 @@ export class PotassiumSlipScene extends Phaser.Scene {
 
   private updateEnemyVisuals(): void {
     this.enemies.getChildren().forEach((gameObject) => {
-      const enemy = gameObject as EnemySprite;
-      this.positionEnemyAttachments(enemy);
-      const label = enemy.getData('labelText') as Phaser.GameObjects.Text | undefined;
-      if (!label) return;
-      const hp = Math.ceil(enemy.getData('hp') as number);
-      const maxHp = enemy.getData('maxHp') as number;
-      label.setText(`${hp}/${maxHp}`);
-      this.positionFloatingLabel(label, enemy.x, enemy.y - 34 * enemy.scale);
+      this.potassiumRenderer.positionEnemyAttachments(gameObject as EnemySprite);
     });
   }
 
   private updateHud(): void {
     const wave = getPotassiumWave(this.wave);
-    this.hudText?.setText(`W${this.wave} ${wave.title}`);
-    this.scoreText?.setText(`Score ${this.score}`);
-    this.livesText?.setText(`Lives ${this.lives}`);
-  }
-
-  private positionEnemyAttachments(enemy: EnemySprite): void {
-    const overlay = enemy.getData('damageOverlay') as Phaser.GameObjects.Sprite | undefined;
-    if (overlay) {
-      const state = enemy.getData('damageState') as EnemyHealthState | undefined;
-      const kind = enemy.getData('kind') as EnemyKind;
-      const isWall = kind === 'wall';
-      overlay.setPosition(enemy.x, enemy.y)
-        .setScale(enemy.displayWidth / (isWall ? 80 : 76), enemy.displayHeight / 62)
-        .setRotation(enemy.rotation)
-        .setVisible(state === 'cracked' || state === 'critical');
-      overlay.setTexture(isWall
-        ? state === 'critical' ? 'potassium_wall_damage_critical' : 'potassium_wall_damage_cracked'
-        : state === 'critical' ? 'potassium_damage_critical' : 'potassium_damage_cracked');
-    }
-    const shieldPlate = enemy.getData('shieldPlate') as Phaser.GameObjects.Rectangle | undefined;
-    const shieldSide = enemy.getData('shieldSide') as ShieldSide | undefined;
-    if (shieldPlate && shieldSide) {
-      this.positionShieldPlate(enemy, shieldPlate, shieldSide);
-    }
-  }
-
-  private positionShieldPlate(enemy: EnemySprite, plate: Phaser.GameObjects.Rectangle, side: ShieldSide): void {
-    const width = Math.max(20, enemy.displayWidth * (side === 'bottom' ? 0.72 : 0.22));
-    const height = Math.max(12, enemy.displayHeight * (side === 'bottom' ? 0.2 : 0.72));
-    const offsetX = side === 'left' ? -enemy.displayWidth * 0.42 : side === 'right' ? enemy.displayWidth * 0.42 : 0;
-    const offsetY = side === 'bottom' ? enemy.displayHeight * 0.42 : 0;
-    plate.setPosition(enemy.x + offsetX, enemy.y + offsetY);
-    plate.setSize(width, height);
-  }
-
-  private positionFloatingLabel(label: Phaser.GameObjects.Text, x: number, y: number): void {
-    label.setPosition(
-      snapUiTextCoordinate(Phaser.Math.Clamp(x, SAFE.left, SAFE.right)),
-      snapUiTextCoordinate(Phaser.Math.Clamp(y, SAFE.labelTop, SAFE.bottom))
-    );
+    this.potassiumRenderer.updateHud({
+      waveLabel: `W${this.wave} ${wave.title}`,
+      score: this.score,
+      lives: this.lives
+    });
   }
 
   private getWaveHint(wave: number): string {
@@ -2052,8 +1708,11 @@ export class PotassiumSlipScene extends Phaser.Scene {
     }
     this.saveRunRecord('won');
     bridgeActions.setSceneHintText(null);
-    this.overlayText.setFontSize(26).setText('CIRCUIT ACQUIRED').setPosition(GAME_DESIGN_WIDTH / 2, 255).setVisible(true);
-    this.subOverlayText.setFontSize(15).setText(`Final Score: ${this.score}`).setPosition(GAME_DESIGN_WIDTH / 2, 308).setVisible(true);
+    this.potassiumRenderer.showOutcomeOverlay({
+      title: 'CIRCUIT ACQUIRED',
+      score: this.score,
+      titleFontSize: 26
+    });
     this.createTerminalOverlay('won');
   }
 
@@ -2069,8 +1728,11 @@ export class PotassiumSlipScene extends Phaser.Scene {
     this.clearUpgradeChoiceOverlay();
     this.saveRunRecord('game_over');
     bridgeActions.setSceneHintText(null);
-    this.overlayText.setFontSize(24).setText('BANANA BANKRUPTCY').setPosition(GAME_DESIGN_WIDTH / 2, 255).setVisible(true);
-    this.subOverlayText.setFontSize(15).setText(`Final Score: ${this.score}`).setPosition(GAME_DESIGN_WIDTH / 2, 308).setVisible(true);
+    this.potassiumRenderer.showOutcomeOverlay({
+      title: 'BANANA BANKRUPTCY',
+      score: this.score,
+      titleFontSize: 24
+    });
     this.createTerminalOverlay('game_over');
   }
 
@@ -2086,38 +1748,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private createTerminalOverlay(outcome: RunOutcome): void {
-    this.clearTerminalOverlay();
-    const buttons: Array<{ action: TerminalAction; label: string }> = outcome === 'won'
-      ? [
-        { action: 'endless', label: 'ENDLESS MODE' },
-        { action: 'return', label: 'RETURN TO CITY' }
-      ]
-      : [
-        { action: 'retry', label: 'RETRY' },
-        { action: 'return', label: 'RETURN TO CITY' }
-      ];
-    const startX = GAME_DESIGN_WIDTH / 2 - 88;
-    this.terminalButtons = buttons.map((button, index) => {
-      const x = startX + index * 176;
-      const panel = this.add.rectangle(x, 360, 156, 36, 0xffffff, 0.96)
-        .setStrokeStyle(3, 0x1a1a1a, 0.88)
-        .setDepth(1210);
-      const label = createUiText(this, x, 360, button.label, {
-        fontSize: '10px',
-        color: '#1a1a1a',
-        fontStyle: 'bold',
-        align: 'center'
-      }).setOrigin(0.5).setDepth(1211);
-      return { action: button.action, panel, label };
-    });
-
-    this.recordsText = createUiText(this, GAME_DESIGN_WIDTH / 2, 424, this.getRecordsOverlayText(), {
-      fontSize: '9px',
-      color: '#1a1a1a',
-      fontStyle: 'bold',
-      align: 'center',
-      wordWrap: { width: ARENA.width - 72, useAdvancedWrap: true }
-    }).setOrigin(0.5, 0).setDepth(1210);
+    this.potassiumRenderer.showTerminal(outcome, this.getRecordsOverlayText());
   }
 
   private getRecordsOverlayText(): string {
@@ -2132,11 +1763,11 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private handleTerminalPointer(pointer: Phaser.Input.Pointer): void {
-    const button = this.terminalButtons.find((candidate) => candidate.panel.getBounds().contains(pointer.x, pointer.y));
-    if (!button) return;
-    if (button.action === 'return') {
+    const action = this.potassiumRenderer.getTerminalActionAt(pointer.x, pointer.y);
+    if (!action) return;
+    if (action === 'return') {
       this.onClose?.();
-    } else if (button.action === 'retry') {
+    } else if (action === 'retry') {
       this.startGame();
     } else {
       this.startEndlessMode();
@@ -2144,316 +1775,7 @@ export class PotassiumSlipScene extends Phaser.Scene {
   }
 
   private clearTerminalOverlay(): void {
-    this.terminalButtons.forEach((button) => {
-      button.panel.destroy();
-      button.label.destroy();
-    });
-    this.terminalButtons = [];
-    this.recordsText?.destroy();
-    this.recordsText = undefined;
-  }
-
-  private createInternTexture(): void {
-    const g = this.make.graphics({ x: 0, y: 0 });
-    g.lineStyle(3, 0x1a1a1a, 1);
-    g.fillStyle(0xfacc15, 0.95);
-    g.fillEllipse(24, 24, 30, 24);
-    g.strokeEllipse(24, 24, 30, 24);
-    g.fillStyle(0x1a1a1a, 1);
-    g.fillCircle(18, 20, 2);
-    g.fillCircle(30, 20, 2);
-    for (let i = 0; i < 3; i += 1) {
-      g.beginPath();
-      g.moveTo(13 + i * 9, 32);
-      g.lineTo(8 + i * 9, 40);
-      g.moveTo(18 + i * 9, 32);
-      g.lineTo(22 + i * 9, 40);
-      g.strokePath();
-    }
-    g.generateTexture('potassium_enemy_intern', 48, 46);
-    g.destroy();
-  }
-
-  private createScopeTexture(): void {
-    const g = this.make.graphics({ x: 0, y: 0 });
-    g.fillStyle(0xa855f7, 0.85);
-    g.lineStyle(4, 0x1a1a1a, 1);
-    g.beginPath();
-    g.moveTo(34, 8);
-    g.lineTo(54, 14);
-    g.lineTo(61, 34);
-    g.lineTo(50, 56);
-    g.lineTo(28, 58);
-    g.lineTo(8, 46);
-    g.lineTo(10, 24);
-    g.lineTo(22, 10);
-    g.closePath();
-    g.fillPath();
-    g.strokePath();
-    g.fillStyle(0xffffff, 1);
-    g.fillCircle(28, 30, 8);
-    g.fillStyle(0x1a1a1a, 1);
-    g.fillCircle(30, 30, 3);
-    g.generateTexture('potassium_enemy_scope', 68, 64);
-    g.destroy();
-  }
-
-  private createMeetingTexture(): void {
-    const g = this.make.graphics({ x: 0, y: 0 });
-    g.fillStyle(0xe5e7eb, 1);
-    g.lineStyle(5, 0x1a1a1a, 1);
-    g.fillRoundedRect(4, 8, 70, 44, 4);
-    g.strokeRoundedRect(4, 8, 70, 44, 4);
-    g.lineStyle(2, 0x1a1a1a, 0.55);
-    g.beginPath();
-    g.moveTo(14, 22);
-    g.lineTo(64, 22);
-    g.moveTo(14, 34);
-    g.lineTo(52, 34);
-    g.strokePath();
-    g.generateTexture('potassium_enemy_meeting', 78, 60);
-    g.destroy();
-  }
-
-  private createDeadlineTexture(): void {
-    const g = this.make.graphics({ x: 0, y: 0 });
-    g.fillStyle(0xf97316, 0.9);
-    g.lineStyle(4, 0x1a1a1a, 1);
-    g.beginPath();
-    g.moveTo(28, 4);
-    g.lineTo(54, 46);
-    g.lineTo(28, 34);
-    g.lineTo(2, 46);
-    g.closePath();
-    g.fillPath();
-    g.strokePath();
-    g.lineStyle(3, 0x1a1a1a, 0.8);
-    g.beginPath();
-    g.moveTo(28, 34);
-    g.lineTo(28, 58);
-    g.strokePath();
-    g.generateTexture('potassium_enemy_deadline', 56, 62);
-    g.destroy();
-  }
-
-  private createWallTexture(): void {
-    const g = this.make.graphics({ x: 0, y: 0 });
-    g.fillStyle(0x8b5a2b, 0.96);
-    g.lineStyle(5, 0x1a1a1a, 1);
-    g.fillRoundedRect(5, 7, 70, 48, 4);
-    g.strokeRoundedRect(5, 7, 70, 48, 4);
-    g.fillStyle(0xb7793b, 0.96);
-    g.fillRect(10, 12, 60, 10);
-    g.fillRect(10, 26, 60, 10);
-    g.fillRect(10, 40, 60, 10);
-    g.lineStyle(2, 0x1a1a1a, 0.48);
-    g.beginPath();
-    g.moveTo(18, 13);
-    g.lineTo(12, 21);
-    g.moveTo(48, 26);
-    g.lineTo(60, 35);
-    g.moveTo(26, 42);
-    g.lineTo(18, 50);
-    g.strokePath();
-    g.fillStyle(0xfbfbf9, 0.5);
-    g.fillRect(14, 16, 18, 3);
-    g.fillRect(42, 44, 16, 3);
-    g.lineStyle(3, 0x1a1a1a, 0.75);
-    g.beginPath();
-    g.moveTo(12, 31);
-    g.lineTo(68, 31);
-    g.strokePath();
-    g.generateTexture('potassium_enemy_wall', 80, 62);
-    g.destroy();
-  }
-
-  private createHardWallTexture(): void {
-    const g = this.make.graphics({ x: 0, y: 0 });
-    g.fillStyle(0x1a1a1a, 0.08);
-    g.fillRoundedRect(7, 5, 66, 52, 5);
-    g.fillStyle(0xa8a29e, 1);
-    g.lineStyle(5, 0x1a1a1a, 1);
-    g.fillRoundedRect(5, 7, 70, 48, 5);
-    g.strokeRoundedRect(5, 7, 70, 48, 5);
-    g.lineStyle(3, 0x1a1a1a, 0.75);
-    g.beginPath();
-    g.moveTo(18, 17);
-    g.lineTo(62, 45);
-    g.moveTo(62, 17);
-    g.lineTo(18, 45);
-    g.strokePath();
-    g.fillStyle(0xfbfbf9, 0.68);
-    g.fillRect(22, 25, 36, 12);
-    g.generateTexture('potassium_enemy_hard_wall', 80, 62);
-    g.destroy();
-  }
-
-  private createSplitterTexture(): void {
-    const g = this.make.graphics({ x: 0, y: 0 });
-    g.fillStyle(0xfde68a, 0.96);
-    g.lineStyle(4, 0x1a1a1a, 1);
-    g.fillRoundedRect(7, 8, 112, 42, 6);
-    g.strokeRoundedRect(7, 8, 112, 42, 6);
-    g.fillStyle(0xfacc15, 0.82);
-    g.fillRoundedRect(12, 13, 48, 32, 4);
-    g.fillRoundedRect(66, 13, 48, 32, 4);
-    g.lineStyle(3, 0x1a1a1a, 0.85);
-    g.beginPath();
-    g.moveTo(63, 10);
-    g.lineTo(63, 50);
-    g.moveTo(24, 24);
-    g.lineTo(50, 24);
-    g.moveTo(76, 34);
-    g.lineTo(104, 34);
-    g.strokePath();
-    g.fillStyle(0x1a1a1a, 1);
-    g.fillCircle(29, 31, 3);
-    g.fillCircle(93, 27, 3);
-    g.generateTexture('potassium_enemy_splitter', 126, 58);
-    g.destroy();
-  }
-
-  private createShieldTexture(): void {
-    const g = this.make.graphics({ x: 0, y: 0 });
-    g.fillStyle(0xdbeafe, 0.96);
-    g.lineStyle(4, 0x1a1a1a, 1);
-    g.beginPath();
-    g.moveTo(34, 5);
-    g.lineTo(58, 18);
-    g.lineTo(52, 50);
-    g.lineTo(34, 60);
-    g.lineTo(16, 50);
-    g.lineTo(10, 18);
-    g.closePath();
-    g.fillPath();
-    g.strokePath();
-    g.fillStyle(0x38bdf8, 0.45);
-    g.fillRoundedRect(18, 38, 32, 10, 4);
-    g.lineStyle(2, 0x1a1a1a, 0.75);
-    g.strokeRoundedRect(18, 38, 32, 10, 4);
-    g.generateTexture('potassium_enemy_shield', 68, 66);
-    g.destroy();
-  }
-
-  private createBossTexture(): void {
-    const g = this.make.graphics({ x: 0, y: 0 });
-    g.fillStyle(0xffffff, 1);
-    g.lineStyle(6, 0x1a1a1a, 1);
-    g.fillRoundedRect(4, 10, 116, 70, 10);
-    g.strokeRoundedRect(4, 10, 116, 70, 10);
-    g.lineStyle(3, 0x1a1a1a, 0.55);
-    g.strokeCircle(34, 44, 14);
-    g.strokeCircle(88, 44, 14);
-    g.beginPath();
-    g.moveTo(45, 62);
-    g.lineTo(80, 62);
-    g.strokePath();
-    g.fillStyle(0xfacc15, 0.5);
-    g.fillRect(12, 16, 100, 12);
-    g.generateTexture('potassium_enemy_boss', 124, 90);
-    g.destroy();
-  }
-
-  private createDamageOverlayTextures(): void {
-    const cracked = this.make.graphics({ x: 0, y: 0 });
-    cracked.lineStyle(4, 0x1a1a1a, 0.9);
-    cracked.beginPath();
-    cracked.moveTo(22, 10);
-    cracked.lineTo(32, 22);
-    cracked.lineTo(27, 34);
-    cracked.moveTo(50, 18);
-    cracked.lineTo(42, 30);
-    cracked.lineTo(50, 42);
-    cracked.strokePath();
-    cracked.fillStyle(0xfbfbf9, 0.74);
-    cracked.fillRoundedRect(13, 43, 24, 8, 3);
-    cracked.lineStyle(2, 0x1a1a1a, 0.7);
-    cracked.strokeRoundedRect(13, 43, 24, 8, 3);
-    cracked.generateTexture('potassium_damage_cracked', 76, 62);
-    cracked.destroy();
-
-    const critical = this.make.graphics({ x: 0, y: 0 });
-    critical.lineStyle(4, 0x1a1a1a, 0.95);
-    critical.beginPath();
-    critical.moveTo(18, 8);
-    critical.lineTo(30, 20);
-    critical.lineTo(22, 34);
-    critical.lineTo(36, 48);
-    critical.moveTo(56, 12);
-    critical.lineTo(44, 24);
-    critical.lineTo(56, 38);
-    critical.moveTo(42, 8);
-    critical.lineTo(38, 18);
-    critical.lineTo(46, 27);
-    critical.strokePath();
-    critical.fillStyle(0xfbfbf9, 0.82);
-    critical.fillRoundedRect(10, 40, 28, 9, 3);
-    critical.fillRoundedRect(41, 31, 23, 9, 3);
-    critical.lineStyle(2, 0x1a1a1a, 0.75);
-    critical.strokeRoundedRect(10, 40, 28, 9, 3);
-    critical.strokeRoundedRect(41, 31, 23, 9, 3);
-    critical.generateTexture('potassium_damage_critical', 76, 62);
-    critical.destroy();
-  }
-
-  private createWallDamageOverlayTextures(): void {
-    const cracked = this.make.graphics({ x: 0, y: 0 });
-    cracked.lineStyle(4, 0x1a1a1a, 0.9);
-    cracked.beginPath();
-    cracked.moveTo(18, 11);
-    cracked.lineTo(29, 23);
-    cracked.lineTo(21, 34);
-    cracked.moveTo(55, 15);
-    cracked.lineTo(45, 27);
-    cracked.lineTo(57, 39);
-    cracked.strokePath();
-    cracked.lineStyle(3, 0xfbfbf9, 0.48);
-    cracked.beginPath();
-    cracked.moveTo(13, 47);
-    cracked.lineTo(28, 39);
-    cracked.moveTo(49, 48);
-    cracked.lineTo(68, 42);
-    cracked.strokePath();
-    cracked.generateTexture('potassium_wall_damage_cracked', 80, 62);
-    cracked.destroy();
-
-    const critical = this.make.graphics({ x: 0, y: 0 });
-    critical.lineStyle(4, 0x1a1a1a, 0.96);
-    critical.beginPath();
-    critical.moveTo(14, 8);
-    critical.lineTo(29, 21);
-    critical.lineTo(19, 32);
-    critical.lineTo(34, 47);
-    critical.moveTo(62, 8);
-    critical.lineTo(48, 22);
-    critical.lineTo(62, 37);
-    critical.moveTo(42, 12);
-    critical.lineTo(38, 27);
-    critical.lineTo(48, 43);
-    critical.strokePath();
-    critical.lineStyle(3, 0xfbfbf9, 0.55);
-    critical.beginPath();
-    critical.moveTo(9, 50);
-    critical.lineTo(25, 40);
-    critical.moveTo(29, 13);
-    critical.lineTo(42, 7);
-    critical.moveTo(51, 52);
-    critical.lineTo(73, 43);
-    critical.strokePath();
-    critical.generateTexture('potassium_wall_damage_critical', 80, 62);
-    critical.destroy();
-  }
-
-  private createFireTexture(): void {
-    const g = this.make.graphics({ x: 0, y: 0 });
-    g.fillStyle(0xf97316, 0.34);
-    g.lineStyle(3, 0x1a1a1a, 0.42);
-    g.fillEllipse(30, 18, 56, 24);
-    g.strokeEllipse(30, 18, 56, 24);
-    g.fillStyle(0xfacc15, 0.38);
-    g.fillEllipse(30, 16, 34, 14);
-    g.generateTexture('potassium_fire', 60, 36);
-    g.destroy();
+    this.potassiumRenderer.clearTerminal();
   }
 
   setPaused(paused: boolean): void {

--- a/src/runtime/potassiumSlipBoss.test.ts
+++ b/src/runtime/potassiumSlipBoss.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createPotassiumBossState,
+  getPotassiumBossPhase,
+  POTASSIUM_BOSS_PHASE_1_DRIFT,
+  POTASSIUM_BOSS_PHASE_2_DRIFT,
+  POTASSIUM_BOSS_PATROL_SPEED,
+  POTASSIUM_BOSS_STONE_DURATION_MS,
+  POTASSIUM_BOSS_STONE_INTERVAL_MS,
+  POTASSIUM_BOSS_SUMMON_INTERVAL_MS,
+  POTASSIUM_BOSS_SUMMON_VELOCITY_Y,
+  resolvePotassiumBossFrame,
+  type PotassiumBossFacts,
+  type PotassiumBossFrameInput
+} from './potassiumSlipBoss';
+
+describe('potassium slip boss', () => {
+  it('resolves phase 1, 2, and 3 from hp thresholds', () => {
+    expect(getPotassiumBossPhase(61, 100)).toBe(1);
+    expect(getPotassiumBossPhase(60, 100)).toBe(2);
+    expect(getPotassiumBossPhase(30, 100)).toBe(3);
+  });
+
+  it('emits phase transition commands with hints and camera shake', () => {
+    const result = resolvePotassiumBossFrame(frame({
+      boss: boss({ hp: 55, maxHp: 100 }),
+      state: createPotassiumBossState(1000)
+    }));
+
+    expect(result.state?.phase).toBe(2);
+    expect(result.commands).toEqual([
+      { type: 'setBossPhase', phase: 2 },
+      { type: 'shakeCamera', durationMs: 220, intensity: 0.007 },
+      { type: 'setBossHint', text: 'Boss phase 2 • Orbiting walls hate angles' },
+      { type: 'setBossVelocity', velocityY: POTASSIUM_BOSS_PHASE_2_DRIFT, velocityX: POTASSIUM_BOSS_PATROL_SPEED },
+      { type: 'spawnOrbitBlockers' },
+      { type: 'updateOrbitBlockers', now: 1000 },
+      { type: 'setStoneVisual', active: false }
+    ]);
+  });
+
+  it('emits phase 1 patrol velocity and drift', () => {
+    const result = resolvePotassiumBossFrame(frame({
+      boss: boss({ x: 360, velocityX: 0 }),
+      state: createPotassiumBossState(1000)
+    }));
+
+    expect(result.commands).toContainEqual({
+      type: 'setBossVelocity',
+      velocityY: POTASSIUM_BOSS_PHASE_1_DRIFT,
+      velocityX: POTASSIUM_BOSS_PATROL_SPEED
+    });
+  });
+
+  it('starts orbit blockers once and updates orbit every phase 2 frame', () => {
+    const first = resolvePotassiumBossFrame(frame({
+      boss: boss({ hp: 55, maxHp: 100, velocityX: 54 }),
+      state: createPotassiumBossState(1000)
+    }));
+    const second = resolvePotassiumBossFrame(frame({
+      now: 1016,
+      boss: boss({ hp: 55, maxHp: 100, velocityX: 54 }),
+      state: first.state
+    }));
+
+    expect(first.commands.filter((command) => command.type === 'spawnOrbitBlockers')).toHaveLength(1);
+    expect(second.commands.some((command) => command.type === 'spawnOrbitBlockers')).toBe(false);
+    expect(second.commands).toContainEqual({ type: 'updateOrbitBlockers', now: 1016 });
+  });
+
+  it('starts and ends stone windows on the existing interval and duration', () => {
+    const state = {
+      ...createPotassiumBossState(1000),
+      phase: 3 as const,
+      nextStoneAt: 5300
+    };
+    const started = resolvePotassiumBossFrame(frame({
+      now: 5300,
+      boss: boss({ hp: 25, maxHp: 100 }),
+      state
+    }));
+
+    expect(started.commands).toContainEqual({
+      type: 'startStone',
+      stoneUntil: 5300 + POTASSIUM_BOSS_STONE_DURATION_MS,
+      nextStoneAt: 5300 + POTASSIUM_BOSS_STONE_INTERVAL_MS
+    });
+    expect(started.commands).toContainEqual({ type: 'setStoneVisual', active: false });
+
+    const active = resolvePotassiumBossFrame(frame({
+      now: 5400,
+      boss: boss({ hp: 25, maxHp: 100 }),
+      state: started.state
+    }));
+    expect(active.commands).toContainEqual({ type: 'setStoneVisual', active: true });
+
+    const ended = resolvePotassiumBossFrame(frame({
+      now: 6650,
+      boss: boss({ hp: 25, maxHp: 100 }),
+      state: active.state
+    }));
+    expect(ended.commands).toContainEqual({ type: 'setStoneVisual', active: false });
+    expect(ended.commands).toContainEqual({ type: 'endStone' });
+    expect(ended.state?.stoneUntil).toBeUndefined();
+  });
+
+  it('emits summon facts on the existing interval', () => {
+    const state = {
+      ...createPotassiumBossState(1000),
+      phase: 3 as const,
+      nextSummonAt: 4600
+    };
+    const result = resolvePotassiumBossFrame(frame({
+      now: 4600,
+      boss: boss({ hp: 25, maxHp: 100, x: 500, y: 220 }),
+      state
+    }));
+
+    expect(result.commands).toContainEqual({
+      type: 'spawnSummons',
+      nextSummonAt: 4600 + POTASSIUM_BOSS_SUMMON_INTERVAL_MS,
+      summons: [
+        { kind: 'scope', column: 2, y: 296, velocityY: POTASSIUM_BOSS_SUMMON_VELOCITY_Y },
+        { kind: 'deadline', column: 3, y: 296, velocityY: POTASSIUM_BOSS_SUMMON_VELOCITY_Y }
+      ]
+    });
+  });
+
+  it('clears orbit blockers for missing or dying bosses', () => {
+    expect(resolvePotassiumBossFrame(frame({ boss: undefined })).commands).toEqual([
+      { type: 'clearOrbitBlockers' }
+    ]);
+    expect(resolvePotassiumBossFrame(frame({ boss: boss({ dying: true }) })).commands).toEqual([
+      { type: 'clearOrbitBlockers' }
+    ]);
+  });
+
+  it('returned state prevents duplicate one-shot phase and orbit commands', () => {
+    const first = resolvePotassiumBossFrame(frame({
+      boss: boss({ hp: 55, maxHp: 100 }),
+      state: createPotassiumBossState(1000)
+    }));
+    const second = resolvePotassiumBossFrame(frame({
+      now: 1032,
+      boss: boss({ hp: 55, maxHp: 100, velocityX: 54 }),
+      state: first.state
+    }));
+
+    expect(second.commands.some((command) => command.type === 'setBossPhase')).toBe(false);
+    expect(second.commands.some((command) => command.type === 'setBossHint')).toBe(false);
+    expect(second.commands.some((command) => command.type === 'spawnOrbitBlockers')).toBe(false);
+    expect(second.commands).toContainEqual({ type: 'updateOrbitBlockers', now: 1032 });
+  });
+});
+
+function frame(overrides: Partial<PotassiumBossFrameInput> = {}): PotassiumBossFrameInput {
+  return {
+    now: 1000,
+    state: createPotassiumBossState(1000),
+    boss: boss(),
+    patrolBounds: { left: 353, right: 647 },
+    summonLayout: {
+      arenaLeft: 275,
+      arenaWidth: 450,
+      safeTop: 58,
+      safeBottom: 484
+    },
+    ...overrides
+  };
+}
+
+function boss(overrides: Partial<PotassiumBossFacts> = {}): PotassiumBossFacts {
+  return {
+    active: true,
+    dying: false,
+    hp: 92,
+    maxHp: 92,
+    x: 500,
+    y: 190,
+    velocityX: 0,
+    ...overrides
+  };
+}

--- a/src/runtime/potassiumSlipBoss.ts
+++ b/src/runtime/potassiumSlipBoss.ts
@@ -1,0 +1,233 @@
+import {
+  getPotassiumSplitterSpawnColumns,
+  POTASSIUM_COLUMN_COUNT,
+  type PotassiumEnemyKind
+} from './potassiumSlipWaves';
+
+export type PotassiumBossPhase = 1 | 2 | 3;
+
+export interface PotassiumBossState {
+  phase: PotassiumBossPhase;
+  orbitStarted: boolean;
+  nextStoneAt: number;
+  stoneUntil?: number;
+  nextSummonAt: number;
+}
+
+export interface PotassiumBossFacts {
+  active: boolean;
+  dying: boolean;
+  hp: number;
+  maxHp: number;
+  x: number;
+  y: number;
+  velocityX: number;
+}
+
+export interface PotassiumBossPatrolBounds {
+  left: number;
+  right: number;
+}
+
+export interface PotassiumBossSummonLayout {
+  arenaLeft: number;
+  arenaWidth: number;
+  safeTop: number;
+  safeBottom: number;
+}
+
+export interface PotassiumBossSummonFacts {
+  kind: PotassiumEnemyKind;
+  column: number;
+  y: number;
+  velocityY: number;
+}
+
+export type PotassiumBossCommand =
+  | { type: 'setBossPhase'; phase: PotassiumBossPhase }
+  | { type: 'setBossVelocity'; velocityY: number; velocityX?: number; x?: number }
+  | { type: 'setBossHint'; text: string }
+  | { type: 'shakeCamera'; durationMs: number; intensity: number }
+  | { type: 'spawnOrbitBlockers' }
+  | { type: 'updateOrbitBlockers'; now: number }
+  | { type: 'startStone'; stoneUntil: number; nextStoneAt: number }
+  | { type: 'endStone' }
+  | { type: 'setStoneVisual'; active: boolean }
+  | { type: 'spawnSummons'; summons: PotassiumBossSummonFacts[]; nextSummonAt: number }
+  | { type: 'clearOrbitBlockers' };
+
+export interface PotassiumBossFrameInput {
+  now: number;
+  state?: PotassiumBossState;
+  boss?: PotassiumBossFacts;
+  patrolBounds: PotassiumBossPatrolBounds;
+  summonLayout: PotassiumBossSummonLayout;
+}
+
+export interface PotassiumBossResult {
+  state?: PotassiumBossState;
+  commands: PotassiumBossCommand[];
+}
+
+export const POTASSIUM_BOSS_PATROL_SPEED = 54;
+export const POTASSIUM_BOSS_PHASE_1_DRIFT = 4;
+export const POTASSIUM_BOSS_PHASE_2_DRIFT = 6;
+export const POTASSIUM_BOSS_PHASE_3_DRIFT = 3;
+export const POTASSIUM_BOSS_STONE_DURATION_MS = 1350;
+export const POTASSIUM_BOSS_STONE_INTERVAL_MS = 4300;
+export const POTASSIUM_BOSS_SUMMON_INTERVAL_MS = 3600;
+export const POTASSIUM_BOSS_SUMMON_VELOCITY_Y = 74;
+
+export function createPotassiumBossState(now: number): PotassiumBossState {
+  return {
+    phase: 1,
+    orbitStarted: false,
+    nextStoneAt: now + POTASSIUM_BOSS_STONE_INTERVAL_MS,
+    stoneUntil: undefined,
+    nextSummonAt: now + POTASSIUM_BOSS_SUMMON_INTERVAL_MS
+  };
+}
+
+export function resolvePotassiumBossFrame(input: PotassiumBossFrameInput): PotassiumBossResult {
+  const { boss } = input;
+  if (!boss || !boss.active || boss.dying) {
+    return { state: undefined, commands: [{ type: 'clearOrbitBlockers' }] };
+  }
+
+  let state = input.state ?? createPotassiumBossState(input.now);
+  const commands: PotassiumBossCommand[] = [];
+  const phase = getPotassiumBossPhase(boss.hp, boss.maxHp);
+
+  if (phase !== state.phase) {
+    commands.push({ type: 'setBossPhase', phase });
+    commands.push({ type: 'shakeCamera', durationMs: 220, intensity: 0.007 });
+    commands.push({
+      type: 'setBossHint',
+      text: phase === 2
+        ? 'Boss phase 2 • Orbiting walls hate angles'
+        : 'Boss phase 3 • Stone audits summon witnesses'
+    });
+    state = { ...state, phase };
+  }
+
+  commands.push(resolveBossPatrolCommand(boss, phase, input.patrolBounds));
+
+  if (phase >= 2 && !state.orbitStarted) {
+    commands.push({ type: 'spawnOrbitBlockers' });
+    state = { ...state, orbitStarted: true };
+  }
+  if (phase >= 2) {
+    commands.push({ type: 'updateOrbitBlockers', now: input.now });
+  }
+
+  if (phase >= 3) {
+    const stoneResult = resolveBossStone(input.now, state);
+    state = stoneResult.state;
+    commands.push(...stoneResult.commands);
+
+    if (input.now >= state.nextSummonAt) {
+      const nextSummonAt = input.now + POTASSIUM_BOSS_SUMMON_INTERVAL_MS;
+      commands.push({
+        type: 'spawnSummons',
+        summons: getPotassiumBossSummons(boss, input.summonLayout),
+        nextSummonAt
+      });
+      state = { ...state, nextSummonAt };
+    }
+  } else {
+    commands.push({ type: 'setStoneVisual', active: false });
+    if (state.stoneUntil !== undefined) {
+      commands.push({ type: 'endStone' });
+      state = { ...state, stoneUntil: undefined };
+    }
+  }
+
+  return { state, commands };
+}
+
+export function getPotassiumBossPhase(hp: number, maxHp: number): PotassiumBossPhase {
+  const ratio = maxHp > 0 ? hp / maxHp : 1;
+  if (ratio <= 0.3) return 3;
+  if (ratio <= 0.6) return 2;
+  return 1;
+}
+
+function resolveBossPatrolCommand(
+  boss: PotassiumBossFacts,
+  phase: PotassiumBossPhase,
+  bounds: PotassiumBossPatrolBounds
+): Extract<PotassiumBossCommand, { type: 'setBossVelocity' }> {
+  const command: Extract<PotassiumBossCommand, { type: 'setBossVelocity' }> = {
+    type: 'setBossVelocity',
+    velocityY: getBossDrift(phase)
+  };
+  if (boss.x <= bounds.left) {
+    command.x = bounds.left;
+    command.velocityX = POTASSIUM_BOSS_PATROL_SPEED;
+  } else if (boss.x >= bounds.right) {
+    command.x = bounds.right;
+    command.velocityX = -POTASSIUM_BOSS_PATROL_SPEED;
+  } else if (Math.abs(boss.velocityX) < 10) {
+    command.velocityX = POTASSIUM_BOSS_PATROL_SPEED;
+  }
+  return command;
+}
+
+function resolveBossStone(
+  now: number,
+  state: PotassiumBossState
+): { state: PotassiumBossState; commands: PotassiumBossCommand[] } {
+  if (state.stoneUntil !== undefined && state.stoneUntil > now) {
+    return {
+      state,
+      commands: [{ type: 'setStoneVisual', active: true }]
+    };
+  }
+
+  const commands: PotassiumBossCommand[] = [{ type: 'setStoneVisual', active: false }];
+  let nextState = state;
+  if (state.stoneUntil !== undefined) {
+    commands.push({ type: 'endStone' });
+    nextState = { ...nextState, stoneUntil: undefined };
+  }
+  if (now >= state.nextStoneAt) {
+    const stoneUntil = now + POTASSIUM_BOSS_STONE_DURATION_MS;
+    const nextStoneAt = now + POTASSIUM_BOSS_STONE_INTERVAL_MS;
+    commands.push({ type: 'startStone', stoneUntil, nextStoneAt });
+    nextState = { ...nextState, stoneUntil, nextStoneAt };
+  }
+  return { state: nextState, commands };
+}
+
+function getPotassiumBossSummons(
+  boss: PotassiumBossFacts,
+  layout: PotassiumBossSummonLayout
+): PotassiumBossSummonFacts[] {
+  const centerColumn = clampInteger(
+    Math.round(((boss.x - layout.arenaLeft) / layout.arenaWidth) * POTASSIUM_COLUMN_COUNT - 0.5),
+    0,
+    POTASSIUM_COLUMN_COUNT - 1
+  );
+  const columns = getPotassiumSplitterSpawnColumns(centerColumn);
+  const y = clampNumber(boss.y + 76, layout.safeTop + 24, layout.safeBottom - 120);
+  return columns.map((column, index) => ({
+    kind: index % 2 === 0 ? 'scope' : 'deadline',
+    column,
+    y,
+    velocityY: POTASSIUM_BOSS_SUMMON_VELOCITY_Y
+  }));
+}
+
+function getBossDrift(phase: PotassiumBossPhase): number {
+  if (phase === 1) return POTASSIUM_BOSS_PHASE_1_DRIFT;
+  if (phase === 2) return POTASSIUM_BOSS_PHASE_2_DRIFT;
+  return POTASSIUM_BOSS_PHASE_3_DRIFT;
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function clampInteger(value: number, min: number, max: number): number {
+  return Math.trunc(clampNumber(value, min, max));
+}

--- a/src/runtime/potassiumSlipCombat.test.ts
+++ b/src/runtime/potassiumSlipCombat.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+import {
+  POTASSIUM_FIRE_HIT_PATCH_LIFETIME_MS,
+  POTASSIUM_POISON_TICK_INTERVAL_MS,
+  resolvePotassiumDamage,
+  resolvePotassiumExplosion,
+  resolvePotassiumGhostBeam,
+  resolvePotassiumPoisonTick,
+  resolvePotassiumProjectileHit,
+  type PotassiumEnemyCombatFacts,
+  type PotassiumProjectileCombatFacts
+} from './potassiumSlipCombat';
+
+describe('potassium slip combat', () => {
+  it('resolves normal hit damage, deflection, and unlocked effects', () => {
+    expect(resolvePotassiumProjectileHit({
+      now: 1000,
+      enemy: enemy({ id: 'enemy-1', x: 300, y: 160 }),
+      projectile: projectile({ id: 'banana', x: 280, y: 150 }),
+      skillRanks: { poison: 1, explosion: 1, duplicate: 1, ghostHorizontal: 1 },
+      genericRanks: { damage: 1, cloneTime: 2 }
+    })).toEqual([
+      { type: 'damageEnemy', enemyId: 'enemy-1', amount: 1.12, source: 'banana' },
+      { type: 'ricochetProjectile', projectileId: 'banana', enemyId: 'enemy-1' },
+      {
+        type: 'applyPoison',
+        enemyId: 'enemy-1',
+        effectMultiplier: 1,
+        poisonMultiplier: 1,
+        expiresAt: 3500,
+        nextTickAt: 1500
+      },
+      { type: 'explodeAt', x: 300, y: 160, effectMultiplier: 1, radiusMultiplier: 1 },
+      { type: 'spawnBananaClones', count: 2, lifetimeMs: 3600 },
+      { type: 'spawnGhostBeam', x: 300, y: 160, direction: 'horizontal', effectMultiplier: 1 }
+    ]);
+  });
+
+  it('uses recall damage and recall velocity behavior', () => {
+    expect(resolvePotassiumProjectileHit({
+      now: 1000,
+      enemy: enemy({ id: 'enemy-1' }),
+      projectile: projectile({ id: 'banana', isRecall: true }),
+      skillRanks: { explosion: 1, duplicate: 1, ghostVertical: 1 },
+      genericRanks: {}
+    })).toEqual([
+      { type: 'damageEnemy', enemyId: 'enemy-1', amount: 0.65, source: 'banana' },
+      { type: 'boostRecallVelocity', projectileId: 'banana' }
+    ]);
+  });
+
+  it('blocks protected hits with cue and deflection commands', () => {
+    expect(resolvePotassiumProjectileHit({
+      now: 1000,
+      enemy: enemy({ id: 'shield', shieldSide: 'right', x: 300, y: 150 }),
+      projectile: projectile({ id: 'banana', x: 340, y: 152 }),
+      skillRanks: { poison: 1, explosion: 1 },
+      genericRanks: {}
+    })).toEqual([
+      { type: 'showDamageCue', enemyId: 'shield', source: 'ghost' },
+      { type: 'ricochetProjectile', projectileId: 'banana', enemyId: 'shield' }
+    ]);
+
+    expect(resolvePotassiumProjectileHit({
+      now: 1000,
+      enemy: enemy({ id: 'boss', kind: 'boss', stoneUntil: 1400 }),
+      projectile: projectile({ id: 'banana', isRecall: true }),
+      skillRanks: { poison: 1 },
+      genericRanks: {}
+    })).toEqual([
+      { type: 'showDamageCue', enemyId: 'boss', source: 'ghost' },
+      { type: 'boostRecallVelocity', projectileId: 'banana' }
+    ]);
+  });
+
+  it('adds fire patches for upgraded fire hits', () => {
+    expect(resolvePotassiumProjectileHit({
+      now: 1000,
+      enemy: enemy({ id: 'enemy-1', x: 320, y: 180 }),
+      projectile: projectile({ id: 'banana' }),
+      skillRanks: { fire: 2 },
+      genericRanks: {}
+    })).toContainEqual({
+      type: 'spawnFirePatch',
+      x: 320,
+      y: 180,
+      effectMultiplier: 1,
+      lifetimeMs: POTASSIUM_FIRE_HIT_PATCH_LIFETIME_MS,
+      scale: 0.7
+    });
+  });
+
+  it('applies explosion rank 2 status effects through explosion resolution', () => {
+    expect(resolvePotassiumExplosion({
+      now: 1000,
+      x: 300,
+      y: 160,
+      effectMultiplier: 1,
+      radiusMultiplier: 1,
+      hits: [{ enemy: enemy({ id: 'enemy-1', x: 310, y: 160 }), distance: 10 }],
+      skillRanks: { explosion: 2, poison: 1, fire: 1 },
+      genericRanks: {}
+    })).toEqual([
+      { type: 'damageEnemy', enemyId: 'enemy-1', amount: 2, source: 'explosion' },
+      {
+        type: 'applyPoison',
+        enemyId: 'enemy-1',
+        effectMultiplier: 1,
+        poisonMultiplier: 1,
+        expiresAt: 3500,
+        nextTickAt: 1500
+      },
+      {
+        type: 'spawnFirePatch',
+        x: 310,
+        y: 160,
+        effectMultiplier: 1,
+        lifetimeMs: POTASSIUM_FIRE_HIT_PATCH_LIFETIME_MS,
+        scale: 0.58
+      }
+    ]);
+  });
+
+  it('applies ghost rank 2 status effects through beam resolution', () => {
+    expect(resolvePotassiumGhostBeam({
+      now: 1000,
+      x: 300,
+      y: 160,
+      direction: 'horizontal',
+      effectMultiplier: 1,
+      hits: [{ enemy: enemy({ id: 'enemy-1', x: 310, y: 160 }), inBeam: true }],
+      skillRanks: { ghostHorizontal: 2, poison: 1 },
+      genericRanks: {}
+    })).toEqual([
+      { type: 'damageEnemy', enemyId: 'enemy-1', amount: 1, source: 'ghost' },
+      {
+        type: 'applyPoison',
+        enemyId: 'enemy-1',
+        effectMultiplier: 1,
+        poisonMultiplier: 1,
+        expiresAt: 3500,
+        nextTickAt: 1500
+      },
+      { type: 'spawnGhostStatusField', x: 300, y: 160, direction: 'horizontal', effectMultiplier: 1 }
+    ]);
+  });
+
+  it('ticks, expires, and spreads poison decisions', () => {
+    expect(resolvePotassiumPoisonTick({
+      now: 1000,
+      poisonUnlocked: true,
+      enemy: enemy({ id: 'enemy-1', poisonExpiresAt: 2000, poisonNextTickAt: 900, poisonMultiplier: 1.25 })
+    })).toEqual([
+      { type: 'setPoisonNextTickAt', enemyId: 'enemy-1', poisonNextTickAt: 1000 + POTASSIUM_POISON_TICK_INTERVAL_MS },
+      { type: 'damageEnemy', enemyId: 'enemy-1', amount: 1.25, source: 'poison' }
+    ]);
+
+    expect(resolvePotassiumPoisonTick({
+      now: 2100,
+      poisonUnlocked: true,
+      enemy: enemy({ id: 'enemy-1', poisonExpiresAt: 2000 })
+    })).toEqual([{ type: 'clearPoison', enemyId: 'enemy-1' }]);
+
+    expect(resolvePotassiumDamage({
+      now: 1000,
+      enemy: enemy({ id: 'enemy-1', hp: 1, poisonExpiresAt: 2000, poisonMultiplier: 2 }),
+      amount: 1,
+      source: 'banana',
+      skillRanks: { poison: 2 },
+      genericRanks: {}
+    })).toContainEqual({
+      type: 'spreadPoisonFrom',
+      x: 300,
+      y: 150,
+      effectMultiplier: 2,
+      sourceEnemyId: 'enemy-1'
+    });
+  });
+
+  it('cues indestructible enemies without hp loss or death', () => {
+    expect(resolvePotassiumDamage({
+      now: 1000,
+      enemy: enemy({ id: 'wall', indestructible: true, hp: 999 }),
+      amount: 20,
+      source: 'banana',
+      skillRanks: {},
+      genericRanks: {}
+    })).toEqual([{ type: 'showDamageCue', enemyId: 'wall', source: 'banana' }]);
+  });
+});
+
+function enemy(overrides: Partial<PotassiumEnemyCombatFacts> = {}): PotassiumEnemyCombatFacts {
+  return {
+    id: 'enemy',
+    kind: 'intern',
+    active: true,
+    dying: false,
+    hp: 3,
+    maxHp: 3,
+    x: 300,
+    y: 150,
+    indestructible: false,
+    splitsOnDeath: false,
+    ...overrides
+  };
+}
+
+function projectile(overrides: Partial<PotassiumProjectileCombatFacts> = {}): PotassiumProjectileCombatFacts {
+  return {
+    id: 'projectile',
+    isMain: true,
+    isRecall: false,
+    x: 280,
+    y: 150,
+    effectMultiplier: 1,
+    canApplyHitProcs: true,
+    canDuplicate: true,
+    explosionRadiusMultiplier: 1,
+    ...overrides
+  };
+}

--- a/src/runtime/potassiumSlipCombat.ts
+++ b/src/runtime/potassiumSlipCombat.ts
@@ -1,0 +1,432 @@
+import {
+  getPotassiumDuplicateCloneCount,
+  getPotassiumEnemyHealthState,
+  getPotassiumExplosionDamage,
+  getPotassiumGenericUpgradeRank,
+  getPotassiumScaledExplosionRadius,
+  getPotassiumSkillRank,
+  isPotassiumShieldedHit,
+  type PotassiumEnemyHealthState,
+  type PotassiumEnemyKind,
+  type PotassiumGenericUpgradeKind,
+  type PotassiumGenericUpgradeRanks,
+  type PotassiumShieldSide,
+  type PotassiumSkillRanks,
+  type PotassiumSkillRank,
+  type PotassiumUpgradeKind
+} from './potassiumSlipWaves';
+
+export type PotassiumDamageSource = 'banana' | 'fire' | 'poison' | 'explosion' | 'ghost';
+export type PotassiumGhostBeamDirection = 'horizontal' | 'vertical';
+
+export interface PotassiumEnemyCombatFacts {
+  id: string;
+  kind: PotassiumEnemyKind;
+  active: boolean;
+  dying: boolean;
+  hp: number;
+  maxHp: number;
+  x: number;
+  y: number;
+  indestructible: boolean;
+  splitsOnDeath: boolean;
+  poisonExpiresAt?: number;
+  poisonMultiplier?: number;
+  poisonNextTickAt?: number;
+  fireTickUntil?: number;
+  shieldSide?: PotassiumShieldSide;
+  stoneUntil?: number;
+}
+
+export interface PotassiumProjectileCombatFacts {
+  id: string;
+  isMain: boolean;
+  isRecall: boolean;
+  x: number;
+  y: number;
+  effectMultiplier: number;
+  canApplyHitProcs: boolean;
+  canDuplicate: boolean;
+  explosionRadiusMultiplier: number;
+}
+
+export interface PotassiumCombatRanks {
+  skillRanks: PotassiumSkillRanks;
+  genericRanks: PotassiumGenericUpgradeRanks;
+}
+
+export interface PotassiumProjectileHitInput extends PotassiumCombatRanks {
+  now: number;
+  enemy: PotassiumEnemyCombatFacts;
+  projectile: PotassiumProjectileCombatFacts;
+}
+
+export interface PotassiumDamageInput extends PotassiumCombatRanks {
+  now: number;
+  enemy: PotassiumEnemyCombatFacts;
+  amount: number;
+  source: PotassiumDamageSource;
+}
+
+export interface PotassiumPoisonTickInput {
+  now: number;
+  enemy: PotassiumEnemyCombatFacts;
+  poisonUnlocked: boolean;
+}
+
+export interface PotassiumExplosionHitFacts {
+  enemy: PotassiumEnemyCombatFacts;
+  distance: number;
+}
+
+export interface PotassiumExplosionInput extends PotassiumCombatRanks {
+  now: number;
+  x: number;
+  y: number;
+  effectMultiplier: number;
+  radiusMultiplier: number;
+  hits: readonly PotassiumExplosionHitFacts[];
+}
+
+export interface PotassiumGhostBeamHitFacts {
+  enemy: PotassiumEnemyCombatFacts;
+  inBeam: boolean;
+}
+
+export interface PotassiumGhostBeamInput extends PotassiumCombatRanks {
+  now: number;
+  x: number;
+  y: number;
+  direction: PotassiumGhostBeamDirection;
+  effectMultiplier: number;
+  hits: readonly PotassiumGhostBeamHitFacts[];
+}
+
+export interface PotassiumApplyPoisonCommand {
+  type: 'applyPoison';
+  enemyId: string;
+  effectMultiplier: number;
+  poisonMultiplier: number;
+  expiresAt: number;
+  nextTickAt?: number;
+}
+
+export interface PotassiumSpawnFirePatchCommand {
+  type: 'spawnFirePatch';
+  x: number;
+  y: number;
+  effectMultiplier: number;
+  lifetimeMs: number;
+  scale: number;
+}
+
+export type PotassiumCombatCommand =
+  | { type: 'damageEnemy'; enemyId: string; amount: number; source: PotassiumDamageSource }
+  | { type: 'setEnemyHp'; enemyId: string; hp: number; damageState: PotassiumEnemyHealthState }
+  | { type: 'setFireTickUntil'; enemyId: string; fireTickUntil: number }
+  | { type: 'setPoisonNextTickAt'; enemyId: string; poisonNextTickAt: number }
+  | { type: 'showDamageCue'; enemyId: string; source: PotassiumDamageSource }
+  | { type: 'ricochetProjectile'; projectileId: string; enemyId: string }
+  | { type: 'boostRecallVelocity'; projectileId: string }
+  | PotassiumApplyPoisonCommand
+  | { type: 'clearPoison'; enemyId: string }
+  | PotassiumSpawnFirePatchCommand
+  | { type: 'explodeAt'; x: number; y: number; effectMultiplier: number; radiusMultiplier: number }
+  | { type: 'spawnBananaClones'; count: number; lifetimeMs: number }
+  | { type: 'spawnGhostBeam'; x: number; y: number; direction: PotassiumGhostBeamDirection; effectMultiplier: number }
+  | { type: 'spawnGhostStatusField'; x: number; y: number; direction: PotassiumGhostBeamDirection; effectMultiplier: number }
+  | { type: 'spreadPoisonFrom'; x: number; y: number; effectMultiplier: number; sourceEnemyId: string }
+  | { type: 'spawnSplitterChildren'; enemyId: string }
+  | { type: 'killEnemy'; enemyId: string };
+
+export const POTASSIUM_RECALL_DAMAGE = 0.65;
+export const POTASSIUM_FIRE_TICK_COOLDOWN_MS = 420;
+export const POTASSIUM_POISON_TICK_INTERVAL_MS = 500;
+export const POTASSIUM_POISON_DURATION_MS = 2500;
+export const POTASSIUM_DUPLICATE_CLONE_LIFETIME_MS = 3000;
+export const POTASSIUM_FIRE_HIT_PATCH_LIFETIME_MS = 900;
+export const POTASSIUM_GHOST_STATUS_FIELD_LIFETIME_MS = 680;
+
+const POISON_UPGRADED_DAMAGE_MULTIPLIER = 1.25;
+
+export function resolvePotassiumProjectileHit(input: PotassiumProjectileHitInput): PotassiumCombatCommand[] {
+  const { enemy, projectile } = input;
+  if (!enemy.active) return [];
+
+  const commands: PotassiumCombatCommand[] = [];
+  const protectedHit = isStoneProtected(enemy, input.now) || isShieldProtectedHit(enemy, projectile);
+
+  if (protectedHit) {
+    commands.push({ type: 'showDamageCue', enemyId: enemy.id, source: 'ghost' });
+    commands.push(projectile.isRecall
+      ? { type: 'boostRecallVelocity', projectileId: projectile.id }
+      : { type: 'ricochetProjectile', projectileId: projectile.id, enemyId: enemy.id });
+    return commands;
+  }
+
+  commands.push({
+    type: 'damageEnemy',
+    enemyId: enemy.id,
+    amount: (projectile.isRecall ? POTASSIUM_RECALL_DAMAGE : 1) * projectile.effectMultiplier * getDamageMultiplier(input.genericRanks),
+    source: 'banana'
+  });
+  commands.push(projectile.isRecall
+    ? { type: 'boostRecallVelocity', projectileId: projectile.id }
+    : { type: 'ricochetProjectile', projectileId: projectile.id, enemyId: enemy.id });
+  commands.push(...resolveUnlockedHitEffects(input));
+  return commands;
+}
+
+export function resolvePotassiumDamage(input: PotassiumDamageInput): PotassiumCombatCommand[] {
+  const { enemy } = input;
+  if (!enemy.active || enemy.dying) return [];
+
+  const commands: PotassiumCombatCommand[] = [];
+  if (input.source === 'fire') {
+    if (enemy.fireTickUntil !== undefined && enemy.fireTickUntil > input.now) return [];
+    commands.push({ type: 'setFireTickUntil', enemyId: enemy.id, fireTickUntil: input.now + POTASSIUM_FIRE_TICK_COOLDOWN_MS });
+  }
+
+  if (enemy.indestructible) {
+    commands.push({ type: 'showDamageCue', enemyId: enemy.id, source: input.source });
+    return commands;
+  }
+
+  const hp = Math.max(0, enemy.hp - input.amount);
+  commands.push({
+    type: 'setEnemyHp',
+    enemyId: enemy.id,
+    hp,
+    damageState: getPotassiumEnemyHealthState(hp, enemy.maxHp)
+  });
+  commands.push({ type: 'showDamageCue', enemyId: enemy.id, source: input.source });
+
+  if (hp <= 0) {
+    commands.push(...resolveDeathCommands(input));
+  }
+  return commands;
+}
+
+export function resolvePotassiumPoisonTick(input: PotassiumPoisonTickInput): PotassiumCombatCommand[] {
+  const { enemy } = input;
+  if (!input.poisonUnlocked || !enemy.active || enemy.poisonExpiresAt === undefined) return [];
+  if (enemy.poisonExpiresAt <= input.now) {
+    return [{ type: 'clearPoison', enemyId: enemy.id }];
+  }
+  const nextTickAt = enemy.poisonNextTickAt ?? input.now;
+  if (nextTickAt > input.now) return [];
+  return [
+    { type: 'setPoisonNextTickAt', enemyId: enemy.id, poisonNextTickAt: input.now + POTASSIUM_POISON_TICK_INTERVAL_MS },
+    { type: 'damageEnemy', enemyId: enemy.id, amount: enemy.poisonMultiplier ?? 1, source: 'poison' }
+  ];
+}
+
+export function resolvePotassiumExplosion(input: PotassiumExplosionInput): PotassiumCombatCommand[] {
+  const rank = getSkillRank(input.skillRanks, 'explosion');
+  const radius = getPotassiumScaledExplosionRadius(rank, input.radiusMultiplier * getExplosionRadiusMultiplier(input.genericRanks));
+  return input.hits.flatMap(({ enemy, distance }) => {
+    const damage = getPotassiumExplosionDamage(distance, radius, input.effectMultiplier * getDamageMultiplier(input.genericRanks));
+    if (damage <= 0) return [];
+    const commands: PotassiumCombatCommand[] = [
+      { type: 'damageEnemy', enemyId: enemy.id, amount: damage, source: 'explosion' }
+    ];
+    if (rank >= 2) {
+      commands.push(...resolveStatusEffects({
+        enemy,
+        x: enemy.x,
+        y: enemy.y,
+        effectMultiplier: input.effectMultiplier,
+        allowExplosionStatus: true,
+        now: input.now,
+        skillRanks: input.skillRanks,
+        genericRanks: input.genericRanks
+      }));
+    }
+    return commands;
+  });
+}
+
+export function resolvePotassiumGhostBeam(input: PotassiumGhostBeamInput): PotassiumCombatCommand[] {
+  const rank = getSkillRank(input.skillRanks, input.direction === 'horizontal' ? 'ghostHorizontal' : 'ghostVertical');
+  const commands = input.hits.flatMap(({ enemy, inBeam }): PotassiumCombatCommand[] => {
+    if (!inBeam) return [];
+    const hitCommands: PotassiumCombatCommand[] = [
+      {
+        type: 'damageEnemy',
+        enemyId: enemy.id,
+        amount: input.effectMultiplier * getDamageMultiplier(input.genericRanks),
+        source: 'ghost'
+      }
+    ];
+    if (rank >= 2) {
+      hitCommands.push(...resolveStatusEffects({
+        enemy,
+        x: enemy.x,
+        y: enemy.y,
+        effectMultiplier: input.effectMultiplier,
+        allowExplosionStatus: false,
+        now: input.now,
+        skillRanks: input.skillRanks,
+        genericRanks: input.genericRanks
+      }));
+    }
+    return hitCommands;
+  });
+  if (rank >= 2) {
+    commands.push({
+      type: 'spawnGhostStatusField',
+      x: input.x,
+      y: input.y,
+      direction: input.direction,
+      effectMultiplier: input.effectMultiplier
+    });
+  }
+  return commands;
+}
+
+function resolveUnlockedHitEffects(input: PotassiumProjectileHitInput): PotassiumCombatCommand[] {
+  const { enemy, projectile } = input;
+  const commands: PotassiumCombatCommand[] = [];
+  if (projectile.canApplyHitProcs) {
+    commands.push(...resolveStatusEffects({
+      enemy,
+      x: enemy.x,
+      y: enemy.y,
+      effectMultiplier: projectile.effectMultiplier,
+      allowExplosionStatus: false,
+      now: input.now,
+      skillRanks: input.skillRanks,
+      genericRanks: input.genericRanks
+    }));
+  }
+
+  if (projectile.canApplyHitProcs && getSkillRank(input.skillRanks, 'fire') >= 2) {
+    commands.push({
+      type: 'spawnFirePatch',
+      x: enemy.x,
+      y: enemy.y,
+      effectMultiplier: projectile.effectMultiplier,
+      lifetimeMs: POTASSIUM_FIRE_HIT_PATCH_LIFETIME_MS,
+      scale: projectile.isMain ? 0.7 : 0.5
+    });
+  }
+  if (projectile.canApplyHitProcs && !projectile.isRecall && getSkillRank(input.skillRanks, 'explosion') > 0) {
+    commands.push({
+      type: 'explodeAt',
+      x: enemy.x,
+      y: enemy.y,
+      effectMultiplier: projectile.effectMultiplier,
+      radiusMultiplier: projectile.explosionRadiusMultiplier
+    });
+  }
+  if (!projectile.isRecall && projectile.canDuplicate && getSkillRank(input.skillRanks, 'duplicate') > 0) {
+    commands.push({
+      type: 'spawnBananaClones',
+      count: getPotassiumDuplicateCloneCount(getSkillRank(input.skillRanks, 'duplicate')),
+      lifetimeMs: POTASSIUM_DUPLICATE_CLONE_LIFETIME_MS + getGenericRank(input.genericRanks, 'cloneTime') * 300
+    });
+  }
+  if (!projectile.isRecall && getSkillRank(input.skillRanks, 'ghostHorizontal') > 0) {
+    commands.push({ type: 'spawnGhostBeam', x: enemy.x, y: enemy.y, direction: 'horizontal', effectMultiplier: projectile.effectMultiplier });
+  }
+  if (!projectile.isRecall && getSkillRank(input.skillRanks, 'ghostVertical') > 0) {
+    commands.push({ type: 'spawnGhostBeam', x: enemy.x, y: enemy.y, direction: 'vertical', effectMultiplier: projectile.effectMultiplier });
+  }
+  return commands;
+}
+
+function resolveStatusEffects(input: {
+  enemy: PotassiumEnemyCombatFacts;
+  x: number;
+  y: number;
+  effectMultiplier: number;
+  allowExplosionStatus: boolean;
+  now: number;
+} & PotassiumCombatRanks): PotassiumCombatCommand[] {
+  const commands: PotassiumCombatCommand[] = [];
+  if (getSkillRank(input.skillRanks, 'poison') > 0) {
+    commands.push(resolveApplyPoison(input.enemy, input.now, input.effectMultiplier, true, input.skillRanks, input.genericRanks));
+  }
+  if (input.allowExplosionStatus && getSkillRank(input.skillRanks, 'fire') > 0) {
+    commands.push({
+      type: 'spawnFirePatch',
+      x: input.x,
+      y: input.y,
+      effectMultiplier: input.effectMultiplier,
+      lifetimeMs: POTASSIUM_FIRE_HIT_PATCH_LIFETIME_MS,
+      scale: 0.58
+    });
+  }
+  return commands;
+}
+
+function resolveApplyPoison(
+  enemy: PotassiumEnemyCombatFacts,
+  now: number,
+  effectMultiplier: number,
+  applyRankBonus: boolean,
+  skillRanks: PotassiumSkillRanks,
+  genericRanks: PotassiumGenericUpgradeRanks
+): PotassiumApplyPoisonCommand {
+  const poisonMultiplier = applyRankBonus && getSkillRank(skillRanks, 'poison') >= 2
+    ? effectMultiplier * POISON_UPGRADED_DAMAGE_MULTIPLIER * getPoisonGenericMultiplier(genericRanks)
+    : effectMultiplier;
+  const nextTickAt = enemy.poisonNextTickAt === undefined || enemy.poisonNextTickAt < now
+    ? now + POTASSIUM_POISON_TICK_INTERVAL_MS
+    : undefined;
+  return {
+    type: 'applyPoison',
+    enemyId: enemy.id,
+    effectMultiplier,
+    poisonMultiplier: Math.max(enemy.poisonMultiplier ?? 0, poisonMultiplier),
+    expiresAt: Math.max(enemy.poisonExpiresAt ?? 0, now + POTASSIUM_POISON_DURATION_MS * poisonMultiplier),
+    nextTickAt
+  };
+}
+
+function resolveDeathCommands(input: PotassiumDamageInput): PotassiumCombatCommand[] {
+  const commands: PotassiumCombatCommand[] = [];
+  if (getSkillRank(input.skillRanks, 'poison') >= 2 && input.enemy.poisonExpiresAt !== undefined && input.enemy.poisonExpiresAt > input.now) {
+    commands.push({
+      type: 'spreadPoisonFrom',
+      x: input.enemy.x,
+      y: input.enemy.y,
+      effectMultiplier: input.enemy.poisonMultiplier ?? 1,
+      sourceEnemyId: input.enemy.id
+    });
+  }
+  if (input.enemy.splitsOnDeath) {
+    commands.push({ type: 'spawnSplitterChildren', enemyId: input.enemy.id });
+  }
+  commands.push({ type: 'killEnemy', enemyId: input.enemy.id });
+  return commands;
+}
+
+function isStoneProtected(enemy: PotassiumEnemyCombatFacts, now: number): boolean {
+  return enemy.kind === 'boss' && enemy.stoneUntil !== undefined && enemy.stoneUntil > now;
+}
+
+function isShieldProtectedHit(enemy: PotassiumEnemyCombatFacts, projectile: PotassiumProjectileCombatFacts): boolean {
+  if (!enemy.shieldSide) return false;
+  return isPotassiumShieldedHit(enemy.shieldSide, projectile.x - enemy.x, projectile.y - enemy.y);
+}
+
+function getSkillRank(skillRanks: PotassiumSkillRanks, upgrade: PotassiumUpgradeKind): PotassiumSkillRank {
+  return getPotassiumSkillRank(skillRanks, upgrade);
+}
+
+function getGenericRank(genericRanks: PotassiumGenericUpgradeRanks, upgrade: PotassiumGenericUpgradeKind): number {
+  return getPotassiumGenericUpgradeRank(genericRanks, upgrade);
+}
+
+function getDamageMultiplier(genericRanks: PotassiumGenericUpgradeRanks): number {
+  return 1 + getGenericRank(genericRanks, 'damage') * 0.12;
+}
+
+function getPoisonGenericMultiplier(genericRanks: PotassiumGenericUpgradeRanks): number {
+  return 1 + getGenericRank(genericRanks, 'poison') * 0.1;
+}
+
+function getExplosionRadiusMultiplier(genericRanks: PotassiumGenericUpgradeRanks): number {
+  return 1 + getGenericRank(genericRanks, 'explosion') * 0.06;
+}

--- a/src/runtime/potassiumSlipRenderer.ts
+++ b/src/runtime/potassiumSlipRenderer.ts
@@ -97,7 +97,6 @@ export class PotassiumSlipRenderer {
   ensureTextures(): void {
     if (!this.scene.textures.exists('potassium_enemy_intern')) this.createInternTexture();
     if (!this.scene.textures.exists('potassium_enemy_scope')) this.createScopeTexture();
-    if (!this.scene.textures.exists('potassium_enemy_meeting')) this.createMeetingTexture();
     if (!this.scene.textures.exists('potassium_enemy_deadline')) this.createDeadlineTexture();
     if (!this.scene.textures.exists('potassium_enemy_wall')) this.createWallTexture();
     if (!this.scene.textures.exists('potassium_enemy_hard_wall')) this.createHardWallTexture();
@@ -314,6 +313,8 @@ export class PotassiumSlipRenderer {
     config: PotassiumEnemyAttachmentConfig
   ): void {
     enemy.setData('damageState', 'healthy' satisfies PotassiumEnemyHealthState);
+    enemy.setData('damageCueBaseScaleX', enemy.scaleX);
+    enemy.setData('damageCueBaseScaleY', enemy.scaleY);
     enemy.setData('damageOverlay', this.createDamageOverlay(enemy));
     if (config.shieldSide) {
       enemy.setData('shieldSide', config.shieldSide);
@@ -377,14 +378,26 @@ export class PotassiumSlipRenderer {
       ease: 'Sine.easeOut',
       onComplete: () => ring.destroy()
     });
-    this.scene.tweens.add({
+    const baseScaleX = (enemy.getData('damageCueBaseScaleX') as number | undefined) ?? enemy.scaleX;
+    const baseScaleY = (enemy.getData('damageCueBaseScaleY') as number | undefined) ?? enemy.scaleY;
+    const previousPulse = enemy.getData('damageCueTween') as Phaser.Tweens.Tween | undefined;
+    previousPulse?.stop();
+    enemy.setScale(baseScaleX, baseScaleY);
+    const pulse = this.scene.tweens.add({
       targets: enemy,
-      scaleX: enemy.scaleX * 1.06,
-      scaleY: enemy.scaleY * 1.06,
+      scaleX: baseScaleX * 1.06,
+      scaleY: baseScaleY * 1.06,
       duration: 55,
       yoyo: true,
-      ease: 'Sine.easeOut'
+      ease: 'Sine.easeOut',
+      onComplete: () => {
+        if (enemy.active && !enemy.getData('dying')) {
+          enemy.setScale(baseScaleX, baseScaleY);
+        }
+        enemy.setData('damageCueTween', undefined);
+      }
     });
+    enemy.setData('damageCueTween', pulse);
   }
 
   refreshProjectileVisuals(
@@ -641,23 +654,6 @@ export class PotassiumSlipRenderer {
     g.destroy();
   }
 
-  private createMeetingTexture(): void {
-    const g = this.scene.make.graphics({ x: 0, y: 0 });
-    g.fillStyle(0xe5e7eb, 1);
-    g.lineStyle(5, 0x1a1a1a, 1);
-    g.fillRoundedRect(4, 8, 70, 44, 4);
-    g.strokeRoundedRect(4, 8, 70, 44, 4);
-    g.lineStyle(2, 0x1a1a1a, 0.55);
-    g.beginPath();
-    g.moveTo(14, 22);
-    g.lineTo(64, 22);
-    g.moveTo(14, 34);
-    g.lineTo(52, 34);
-    g.strokePath();
-    g.generateTexture('potassium_enemy_meeting', 78, 60);
-    g.destroy();
-  }
-
   private createDeadlineTexture(): void {
     const g = this.scene.make.graphics({ x: 0, y: 0 });
     g.fillStyle(0xf97316, 0.9);
@@ -714,19 +710,26 @@ export class PotassiumSlipRenderer {
     const g = this.scene.make.graphics({ x: 0, y: 0 });
     g.fillStyle(0x1a1a1a, 0.08);
     g.fillRoundedRect(7, 5, 66, 52, 5);
-    g.fillStyle(0xa8a29e, 1);
+    g.fillStyle(0xfbfbf9, 1);
     g.lineStyle(5, 0x1a1a1a, 1);
     g.fillRoundedRect(5, 7, 70, 48, 5);
     g.strokeRoundedRect(5, 7, 70, 48, 5);
-    g.lineStyle(3, 0x1a1a1a, 0.75);
+    g.fillStyle(0x1a1a1a, 0.12);
+    g.fillRoundedRect(11, 13, 58, 36, 4);
+    g.lineStyle(3, 0x1a1a1a, 0.9);
     g.beginPath();
     g.moveTo(18, 17);
     g.lineTo(62, 45);
     g.moveTo(62, 17);
     g.lineTo(18, 45);
     g.strokePath();
-    g.fillStyle(0xfbfbf9, 0.68);
-    g.fillRect(22, 25, 36, 12);
+    g.fillStyle(0xfacc15, 0.9);
+    g.fillRoundedRect(19, 23, 42, 16, 3);
+    g.lineStyle(2, 0x1a1a1a, 0.95);
+    g.strokeRoundedRect(19, 23, 42, 16, 3);
+    g.fillStyle(0x1a1a1a, 1);
+    g.fillRect(31, 27, 4, 8);
+    g.fillRect(45, 27, 4, 8);
     g.generateTexture('potassium_enemy_hard_wall', 80, 62);
     g.destroy();
   }

--- a/src/runtime/potassiumSlipRenderer.ts
+++ b/src/runtime/potassiumSlipRenderer.ts
@@ -1,0 +1,905 @@
+import * as Phaser from 'phaser';
+import { GAME_DESIGN_WIDTH } from './config';
+import { createUiText, snapUiTextCoordinate } from './text/createUiText';
+import type {
+  PotassiumDraftOption,
+  PotassiumEnemyHealthState,
+  PotassiumEnemyKind,
+  PotassiumShieldSide,
+  PotassiumSkillRanks,
+  PotassiumSkillRank,
+  PotassiumUpgradeKind
+} from './potassiumSlipWaves';
+
+export type PotassiumTerminalAction = 'retry' | 'return' | 'endless';
+
+export interface PotassiumRendererRect {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+
+export interface PotassiumRendererSafeRect {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  labelTop: number;
+}
+
+export interface PotassiumRendererLaunchPad {
+  x: number;
+  y: number;
+  radius: number;
+}
+
+export interface PotassiumRendererLayout {
+  arena: PotassiumRendererRect;
+  safe: PotassiumRendererSafeRect;
+  launchPad: PotassiumRendererLaunchPad;
+}
+
+export interface PotassiumUpgradeChoiceView {
+  option: PotassiumDraftOption;
+  title: string;
+  description: string;
+  color: string;
+}
+
+interface UpgradeChoiceButton {
+  option: PotassiumDraftOption;
+  panel: Phaser.GameObjects.Rectangle;
+  label: Phaser.GameObjects.Text;
+  description: Phaser.GameObjects.Text;
+}
+
+interface TerminalButton {
+  action: PotassiumTerminalAction;
+  panel: Phaser.GameObjects.Rectangle;
+  label: Phaser.GameObjects.Text;
+}
+
+interface BananaVisuals {
+  behind: Phaser.GameObjects.Graphics;
+  front: Phaser.GameObjects.Graphics;
+}
+
+export interface PotassiumEnemyAttachmentConfig {
+  kind: PotassiumEnemyKind;
+  label: string;
+  hp: number;
+  shieldSide?: PotassiumShieldSide;
+}
+
+export class PotassiumSlipRenderer {
+  private readonly scene: Phaser.Scene;
+  private readonly layout: PotassiumRendererLayout;
+  private fieldInk?: Phaser.GameObjects.Graphics;
+  private hudText?: Phaser.GameObjects.Text;
+  private scoreText?: Phaser.GameObjects.Text;
+  private livesText?: Phaser.GameObjects.Text;
+  private overlayText?: Phaser.GameObjects.Text;
+  private subOverlayText?: Phaser.GameObjects.Text;
+  private upgradeChoiceButtons: UpgradeChoiceButton[] = [];
+  private upgradeChoiceBackdrop?: Phaser.GameObjects.Rectangle;
+  private upgradeChoiceTitle?: Phaser.GameObjects.Text;
+  private terminalButtons: TerminalButton[] = [];
+  private recordsText?: Phaser.GameObjects.Text;
+
+  constructor(scene: Phaser.Scene, layout: PotassiumRendererLayout) {
+    this.scene = scene;
+    this.layout = layout;
+  }
+
+  ensureTextures(): void {
+    if (!this.scene.textures.exists('potassium_enemy_intern')) this.createInternTexture();
+    if (!this.scene.textures.exists('potassium_enemy_scope')) this.createScopeTexture();
+    if (!this.scene.textures.exists('potassium_enemy_meeting')) this.createMeetingTexture();
+    if (!this.scene.textures.exists('potassium_enemy_deadline')) this.createDeadlineTexture();
+    if (!this.scene.textures.exists('potassium_enemy_wall')) this.createWallTexture();
+    if (!this.scene.textures.exists('potassium_enemy_hard_wall')) this.createHardWallTexture();
+    if (!this.scene.textures.exists('potassium_enemy_splitter')) this.createSplitterTexture();
+    if (!this.scene.textures.exists('potassium_enemy_shield')) this.createShieldTexture();
+    if (!this.scene.textures.exists('potassium_damage_cracked') || !this.scene.textures.exists('potassium_damage_critical')) {
+      if (this.scene.textures.exists('potassium_damage_cracked')) this.scene.textures.remove('potassium_damage_cracked');
+      if (this.scene.textures.exists('potassium_damage_critical')) this.scene.textures.remove('potassium_damage_critical');
+      this.createDamageOverlayTextures();
+    }
+    if (!this.scene.textures.exists('potassium_wall_damage_cracked') || !this.scene.textures.exists('potassium_wall_damage_critical')) {
+      if (this.scene.textures.exists('potassium_wall_damage_cracked')) this.scene.textures.remove('potassium_wall_damage_cracked');
+      if (this.scene.textures.exists('potassium_wall_damage_critical')) this.scene.textures.remove('potassium_wall_damage_critical');
+      this.createWallDamageOverlayTextures();
+    }
+    if (!this.scene.textures.exists('potassium_enemy_boss')) this.createBossTexture();
+    if (!this.scene.textures.exists('potassium_fire')) this.createFireTexture();
+  }
+
+  drawField(): void {
+    const { arena, launchPad } = this.layout;
+    this.fieldInk = this.scene.add.graphics().setDepth(1);
+    this.fieldInk.fillStyle(0xfbfbf9, 1);
+    this.fieldInk.fillRect(arena.left, arena.top, arena.width, arena.height);
+    this.fieldInk.lineStyle(2, 0x1a1a1a, 0.2);
+    for (let y = 72; y < arena.bottom - 70; y += 48) {
+      this.fieldInk.beginPath();
+      this.fieldInk.moveTo(arena.left + 14, y);
+      this.fieldInk.lineTo(arena.right - 14, y + Phaser.Math.Between(-2, 2));
+      this.fieldInk.strokePath();
+    }
+
+    this.fieldInk.lineStyle(4, 0x1a1a1a, 0.85);
+    this.fieldInk.beginPath();
+    this.fieldInk.moveTo(arena.left + 8, arena.top);
+    this.fieldInk.lineTo(arena.left + 8, arena.bottom);
+    this.fieldInk.moveTo(arena.right - 8, arena.top);
+    this.fieldInk.lineTo(arena.right - 8, arena.bottom);
+    this.fieldInk.strokePath();
+
+    this.fieldInk.fillStyle(0x1a1a1a, 0.04);
+    this.fieldInk.fillRect(arena.left + 12, arena.top, arena.width - 24, 52);
+    this.fieldInk.fillRect(arena.left + 12, arena.bottom - 82, arena.width - 24, 82);
+    this.fieldInk.lineStyle(3, 0x1a1a1a, 0.32);
+    this.fieldInk.strokeCircle(launchPad.x, launchPad.y, launchPad.radius);
+  }
+
+  createHud(): void {
+    const { arena } = this.layout;
+    this.hudText = createUiText(this.scene, arena.left + 24, arena.top + 11, '', {
+      fontSize: '12px',
+      color: '#1a1a1a',
+      fontStyle: 'bold'
+    }).setDepth(1000);
+    this.scoreText = createUiText(this.scene, GAME_DESIGN_WIDTH / 2, arena.top + 11, '', {
+      fontSize: '12px',
+      color: '#1a1a1a',
+      fontStyle: 'bold'
+    }).setOrigin(0.5, 0).setDepth(1000);
+    this.livesText = createUiText(this.scene, arena.right - 24, arena.top + 11, '', {
+      fontSize: '12px',
+      color: '#1a1a1a',
+      fontStyle: 'bold'
+    }).setOrigin(1, 0).setDepth(1000);
+  }
+
+  updateHud(input: { waveLabel: string; score: number; lives: number }): void {
+    this.hudText?.setText(input.waveLabel);
+    this.scoreText?.setText(`Score ${input.score}`);
+    this.livesText?.setText(`Lives ${input.lives}`);
+  }
+
+  createStartOverlay(): void {
+    const { arena } = this.layout;
+    this.overlayText = createUiText(this.scene, GAME_DESIGN_WIDTH / 2, 245, 'POTASSIUM SLIP', {
+      fontSize: '32px',
+      color: '#1a1a1a',
+      fontStyle: 'bold',
+      wordWrap: { width: arena.width - 64, useAdvancedWrap: true }
+    }).setOrigin(0.5).setDepth(1010);
+
+    this.subOverlayText = createUiText(
+      this.scene,
+      GAME_DESIGN_WIDTH / 2,
+      320,
+      'DRAG TOWARD A TARGET. RELEASE BANANA.\nHOLD ANYWHERE TO YO-YO IT HOME.\nCLEAR WAVES. STEAL THE CIRCUIT.',
+      {
+        fontSize: '14px',
+        color: '#1a1a1a',
+        align: 'center',
+        fontStyle: 'bold',
+        wordWrap: { width: arena.width - 70, useAdvancedWrap: true }
+      }
+    ).setOrigin(0.5).setDepth(1010);
+  }
+
+  hideMainOverlay(): void {
+    this.overlayText?.setVisible(false);
+    this.subOverlayText?.setVisible(false);
+  }
+
+  showOutcomeOverlay(input: { title: string; score: number; titleFontSize: number }): void {
+    this.overlayText?.setFontSize(input.titleFontSize).setText(input.title).setPosition(GAME_DESIGN_WIDTH / 2, 255).setVisible(true);
+    this.subOverlayText?.setFontSize(15).setText(`Final Score: ${input.score}`).setPosition(GAME_DESIGN_WIDTH / 2, 308).setVisible(true);
+  }
+
+  showUpgradeChoices(choices: PotassiumUpgradeChoiceView[]): void {
+    const { arena } = this.layout;
+    this.clearUpgradeChoices();
+    this.upgradeChoiceBackdrop = this.scene.add.rectangle(GAME_DESIGN_WIDTH / 2, 305, arena.width - 76, 176, 0xfbfbf9, 0.96)
+      .setStrokeStyle(5, 0x1a1a1a, 0.9)
+      .setDepth(1200);
+    this.upgradeChoiceTitle = createUiText(this.scene, GAME_DESIGN_WIDTH / 2, 238, 'CHOOSE BANANA NONSENSE', {
+      fontSize: '15px',
+      color: '#1a1a1a',
+      fontStyle: 'bold',
+      align: 'center'
+    }).setOrigin(0.5).setDepth(1201);
+
+    const buttonWidth = 164;
+    const buttonHeight = 82;
+    const startX = choices.length === 1 ? GAME_DESIGN_WIDTH / 2 : GAME_DESIGN_WIDTH / 2 - 88;
+    this.upgradeChoiceButtons = choices.map((choice, index) => {
+      const x = startX + index * 176;
+      const panel = this.scene.add.rectangle(x, 312, buttonWidth, buttonHeight, 0xffffff, 0.92)
+        .setStrokeStyle(3, 0x1a1a1a, 0.75)
+        .setDepth(1201);
+      const label = createUiText(this.scene, x, 286, choice.title, {
+        fontSize: '11px',
+        color: choice.color,
+        fontStyle: 'bold',
+        align: 'center',
+        wordWrap: { width: buttonWidth - 16, useAdvancedWrap: true }
+      }).setOrigin(0.5).setDepth(1202);
+      const description = createUiText(this.scene, x, 326, choice.description, {
+        fontSize: '8px',
+        color: '#1a1a1a',
+        fontStyle: 'bold',
+        align: 'center',
+        wordWrap: { width: buttonWidth - 18, useAdvancedWrap: true }
+      }).setOrigin(0.5).setDepth(1202);
+      return { option: choice.option, panel, label, description };
+    });
+  }
+
+  getUpgradeChoiceAt(x: number, y: number): PotassiumDraftOption | undefined {
+    return this.upgradeChoiceButtons.find((button) => button.panel.getBounds().contains(x, y))?.option;
+  }
+
+  clearUpgradeChoices(): void {
+    this.upgradeChoiceBackdrop?.destroy();
+    this.upgradeChoiceTitle?.destroy();
+    this.upgradeChoiceBackdrop = undefined;
+    this.upgradeChoiceTitle = undefined;
+    this.upgradeChoiceButtons.forEach((button) => {
+      button.panel.destroy();
+      button.label.destroy();
+      button.description.destroy();
+    });
+    this.upgradeChoiceButtons = [];
+  }
+
+  showTerminal(outcome: 'won' | 'game_over', records: string): void {
+    this.clearTerminal();
+    const buttons: Array<{ action: PotassiumTerminalAction; label: string }> = outcome === 'won'
+      ? [
+        { action: 'endless', label: 'ENDLESS MODE' },
+        { action: 'return', label: 'RETURN TO CITY' }
+      ]
+      : [
+        { action: 'retry', label: 'RETRY' },
+        { action: 'return', label: 'RETURN TO CITY' }
+      ];
+    const startX = GAME_DESIGN_WIDTH / 2 - 88;
+    this.terminalButtons = buttons.map((button, index) => {
+      const x = startX + index * 176;
+      const panel = this.scene.add.rectangle(x, 360, 156, 36, 0xffffff, 0.96)
+        .setStrokeStyle(3, 0x1a1a1a, 0.88)
+        .setDepth(1210);
+      const label = createUiText(this.scene, x, 360, button.label, {
+        fontSize: '10px',
+        color: '#1a1a1a',
+        fontStyle: 'bold',
+        align: 'center'
+      }).setOrigin(0.5).setDepth(1211);
+      return { action: button.action, panel, label };
+    });
+
+    this.recordsText = createUiText(this.scene, GAME_DESIGN_WIDTH / 2, 424, records, {
+      fontSize: '9px',
+      color: '#1a1a1a',
+      fontStyle: 'bold',
+      align: 'center',
+      wordWrap: { width: this.layout.arena.width - 72, useAdvancedWrap: true }
+    }).setOrigin(0.5, 0).setDepth(1210);
+  }
+
+  getTerminalActionAt(x: number, y: number): PotassiumTerminalAction | undefined {
+    return this.terminalButtons.find((candidate) => candidate.panel.getBounds().contains(x, y))?.action;
+  }
+
+  clearTerminal(): void {
+    this.terminalButtons.forEach((button) => {
+      button.panel.destroy();
+      button.label.destroy();
+    });
+    this.terminalButtons = [];
+    this.recordsText?.destroy();
+    this.recordsText = undefined;
+  }
+
+  createEnemyAttachments(
+    enemy: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody,
+    config: PotassiumEnemyAttachmentConfig
+  ): void {
+    enemy.setData('damageState', 'healthy' satisfies PotassiumEnemyHealthState);
+    enemy.setData('damageOverlay', this.createDamageOverlay(enemy));
+    if (config.shieldSide) {
+      enemy.setData('shieldSide', config.shieldSide);
+      enemy.setData('shieldPlate', this.createShieldPlate(enemy, config.shieldSide));
+    }
+    if (config.kind === 'boss') {
+      enemy.setData('labelText', this.createEnemyLabel(enemy, config.label, config.hp));
+    }
+  }
+
+  positionEnemyAttachments(enemy: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody): void {
+    const overlay = enemy.getData('damageOverlay') as Phaser.GameObjects.Sprite | undefined;
+    if (overlay) {
+      const state = enemy.getData('damageState') as PotassiumEnemyHealthState | undefined;
+      const kind = enemy.getData('kind') as PotassiumEnemyKind;
+      const isWall = kind === 'wall';
+      overlay.setPosition(enemy.x, enemy.y)
+        .setScale(enemy.displayWidth / (isWall ? 80 : 76), enemy.displayHeight / 62)
+        .setRotation(enemy.rotation)
+        .setVisible(state === 'cracked' || state === 'critical');
+      overlay.setTexture(isWall
+        ? state === 'critical' ? 'potassium_wall_damage_critical' : 'potassium_wall_damage_cracked'
+        : state === 'critical' ? 'potassium_damage_critical' : 'potassium_damage_cracked');
+    }
+    const shieldPlate = enemy.getData('shieldPlate') as Phaser.GameObjects.Rectangle | undefined;
+    const shieldSide = enemy.getData('shieldSide') as PotassiumShieldSide | undefined;
+    if (shieldPlate && shieldSide) {
+      this.positionShieldPlate(enemy, shieldPlate, shieldSide);
+    }
+    const label = enemy.getData('labelText') as Phaser.GameObjects.Text | undefined;
+    if (label) {
+      const hp = Math.ceil(enemy.getData('hp') as number);
+      const maxHp = enemy.getData('maxHp') as number;
+      label.setText(`${hp}/${maxHp}`);
+      this.positionFloatingLabel(label, enemy.x, enemy.y - 34 * enemy.scale);
+    }
+  }
+
+  showDamageCue(
+    enemy: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody,
+    source: 'banana' | 'fire' | 'poison' | 'explosion' | 'ghost'
+  ): void {
+    const color = source === 'poison'
+      ? 0x65a30d
+      : source === 'fire'
+        ? 0xf97316
+        : source === 'explosion'
+          ? 0xef4444
+          : source === 'ghost'
+            ? 0x38bdf8
+            : 0x1a1a1a;
+    const radius = Math.max(18, enemy.displayWidth * 0.42);
+    const ring = this.scene.add.circle(enemy.x, enemy.y, radius, color, 0.08)
+      .setStrokeStyle(3, color, 0.58)
+      .setDepth(930);
+    this.scene.tweens.add({
+      targets: ring,
+      radius: radius + 10,
+      alpha: 0,
+      duration: 180,
+      ease: 'Sine.easeOut',
+      onComplete: () => ring.destroy()
+    });
+    this.scene.tweens.add({
+      targets: enemy,
+      scaleX: enemy.scaleX * 1.06,
+      scaleY: enemy.scaleY * 1.06,
+      duration: 55,
+      yoyo: true,
+      ease: 'Sine.easeOut'
+    });
+  }
+
+  refreshProjectileVisuals(
+    projectile: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody,
+    skillRanks: PotassiumSkillRanks,
+    options: { isClone?: boolean; isMain?: boolean; isRecall?: boolean } = {}
+  ): void {
+    if (!projectile.active) return;
+    const isMain = options.isMain ?? false;
+    const isClone = options.isClone ?? !isMain;
+    const isRecall = options.isRecall ?? false;
+    projectile.setTexture(getSkillRank(skillRanks, 'poison') > 0 ? 'banana_peel_green' : 'banana_peel_yellow');
+    projectile.clearTint();
+    projectile.setAlpha(isClone ? 0.82 : isRecall ? 0.68 : 1);
+    this.destroyProjectileVisuals(projectile);
+
+    const behind = this.scene.add.graphics().setDepth(projectile.depth - 1);
+    const front = this.scene.add.graphics().setDepth(projectile.depth + 1);
+    this.drawBananaUpgradeAccents(behind, front, skillRanks, isClone);
+    projectile.setData('bananaVisuals', { behind, front } satisfies BananaVisuals);
+    this.positionProjectileVisuals(projectile);
+  }
+
+  positionProjectileVisuals(projectile: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody): void {
+    const visuals = projectile.getData('bananaVisuals') as BananaVisuals | undefined;
+    if (!visuals) return;
+    visuals.behind.setPosition(projectile.x, projectile.y).setRotation(projectile.rotation).setVisible(projectile.active);
+    visuals.front.setPosition(projectile.x, projectile.y).setRotation(projectile.rotation).setVisible(projectile.active);
+  }
+
+  destroyProjectileVisuals(projectile?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody): void {
+    if (!projectile) return;
+    const visuals = projectile.getData('bananaVisuals') as BananaVisuals | undefined;
+    visuals?.behind.destroy();
+    visuals?.front.destroy();
+    projectile.setData('bananaVisuals', undefined);
+  }
+
+  showGhostStatusField(input: {
+    x: number;
+    y: number;
+    direction: 'horizontal' | 'vertical';
+    poisonActive: boolean;
+    durationMs: number;
+  }): void {
+    if (!input.poisonActive) return;
+    const isHorizontal = input.direction === 'horizontal';
+    const width = isHorizontal ? this.layout.arena.width - 42 : 24;
+    const height = isHorizontal ? 24 : this.layout.arena.height - 128;
+    const field = this.scene.add.rectangle(
+      input.direction === 'horizontal' ? GAME_DESIGN_WIDTH / 2 : input.x,
+      input.direction === 'horizontal' ? input.y : this.layout.arena.top + 92 + height / 2,
+      width,
+      height,
+      0x65a30d,
+      0.12
+    ).setStrokeStyle(2, 0x65a30d, 0.42).setDepth(934);
+    this.scene.tweens.add({
+      targets: field,
+      alpha: 0,
+      duration: input.durationMs,
+      onComplete: () => field.destroy()
+    });
+  }
+
+  showGhostBeam(input: {
+    x: number;
+    y: number;
+    direction: 'horizontal' | 'vertical';
+    durationMs: number;
+  }): void {
+    const isHorizontal = input.direction === 'horizontal';
+    const width = isHorizontal ? this.layout.arena.width - 42 : 24;
+    const height = isHorizontal ? 24 : this.layout.arena.height - 128;
+    const beam = this.scene.add.rectangle(
+      isHorizontal ? GAME_DESIGN_WIDTH / 2 : input.x,
+      isHorizontal ? input.y : this.layout.arena.top + 92 + height / 2,
+      width,
+      height,
+      0x38bdf8,
+      0.24
+    ).setStrokeStyle(4, 0x1a1a1a, 0.82).setDepth(935);
+    this.scene.tweens.add({
+      targets: beam,
+      alpha: 0,
+      duration: input.durationMs,
+      onComplete: () => beam.destroy()
+    });
+  }
+
+  private createEnemyLabel(
+    enemy: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody,
+    labelText: string,
+    hp: number
+  ): Phaser.GameObjects.Text {
+    const label = createUiText(this.scene, enemy.x, enemy.y - 34, `${labelText} ${hp}/${hp}`, {
+      fontSize: '9px',
+      color: '#1a1a1a',
+      fontStyle: 'bold',
+      align: 'center'
+    }).setOrigin(0.5).setDepth(900);
+    enemy.once(Phaser.GameObjects.Events.DESTROY, () => label.destroy());
+    return label;
+  }
+
+  private createDamageOverlay(enemy: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody): Phaser.GameObjects.Sprite {
+    const kind = enemy.getData('kind') as PotassiumEnemyKind;
+    const overlay = this.scene.add.sprite(enemy.x, enemy.y, kind === 'wall' ? 'potassium_wall_damage_cracked' : 'potassium_damage_cracked')
+      .setDepth(enemy.depth + 1)
+      .setOrigin(0.5)
+      .setVisible(false);
+    enemy.once(Phaser.GameObjects.Events.DESTROY, () => overlay.destroy());
+    return overlay;
+  }
+
+  private createShieldPlate(
+    enemy: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody,
+    side: PotassiumShieldSide
+  ): Phaser.GameObjects.Rectangle {
+    const plate = this.scene.add.rectangle(enemy.x, enemy.y, 12, 12, 0x38bdf8, 0.4)
+      .setStrokeStyle(4, 0x1a1a1a, 0.9)
+      .setDepth(enemy.depth + 2);
+    enemy.once(Phaser.GameObjects.Events.DESTROY, () => plate.destroy());
+    this.positionShieldPlate(enemy, plate, side);
+    return plate;
+  }
+
+  private positionShieldPlate(
+    enemy: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody,
+    plate: Phaser.GameObjects.Rectangle,
+    side: PotassiumShieldSide
+  ): void {
+    const width = Math.max(20, enemy.displayWidth * (side === 'bottom' ? 0.72 : 0.22));
+    const height = Math.max(12, enemy.displayHeight * (side === 'bottom' ? 0.2 : 0.72));
+    const offsetX = side === 'left' ? -enemy.displayWidth * 0.42 : side === 'right' ? enemy.displayWidth * 0.42 : 0;
+    const offsetY = side === 'bottom' ? enemy.displayHeight * 0.42 : 0;
+    plate.setPosition(enemy.x + offsetX, enemy.y + offsetY);
+    plate.setSize(width, height);
+  }
+
+  private positionFloatingLabel(label: Phaser.GameObjects.Text, x: number, y: number): void {
+    label.setPosition(
+      snapUiTextCoordinate(Phaser.Math.Clamp(x, this.layout.safe.left, this.layout.safe.right)),
+      snapUiTextCoordinate(Phaser.Math.Clamp(y, this.layout.safe.labelTop, this.layout.safe.bottom))
+    );
+  }
+
+  private drawBananaUpgradeAccents(
+    behind: Phaser.GameObjects.Graphics,
+    front: Phaser.GameObjects.Graphics,
+    skillRanks: PotassiumSkillRanks,
+    isClone: boolean
+  ): void {
+    const scale = isClone ? 0.58 : 1;
+    const alphaScale = isClone ? 0.62 : 1;
+    const fireRank = getSkillRank(skillRanks, 'fire');
+    const explosionRank = getSkillRank(skillRanks, 'explosion');
+    const duplicateRank = getSkillRank(skillRanks, 'duplicate');
+    const ghostHorizontalRank = getSkillRank(skillRanks, 'ghostHorizontal');
+    const ghostVerticalRank = getSkillRank(skillRanks, 'ghostVertical');
+
+    if (duplicateRank > 0) {
+      behind.lineStyle((duplicateRank >= 2 ? 4 : 3) * scale, 0xfacc15, 0.28 * alphaScale);
+      behind.strokeEllipse(-16 * scale, 8 * scale, 26 * scale, 15 * scale);
+      behind.strokeEllipse(16 * scale, -7 * scale, 22 * scale, 13 * scale);
+    }
+
+    if (fireRank > 0) {
+      behind.lineStyle((fireRank >= 2 ? 6 : 4) * scale, 0xf97316, 0.55 * alphaScale);
+      behind.strokeCircle(0, 0, (fireRank >= 2 ? 36 : 32) * scale);
+      behind.lineStyle(2 * scale, 0xfacc15, 0.42 * alphaScale);
+      behind.strokeCircle(0, 0, 25 * scale);
+    }
+
+    if (ghostHorizontalRank > 0) {
+      front.lineStyle((ghostHorizontalRank >= 2 ? 5 : 3) * scale, 0x38bdf8, 0.56 * alphaScale);
+      front.beginPath();
+      front.moveTo(-34 * scale, 0);
+      front.lineTo(34 * scale, 0);
+      front.strokePath();
+    }
+
+    if (ghostVerticalRank > 0) {
+      front.lineStyle((ghostVerticalRank >= 2 ? 5 : 3) * scale, 0x60a5fa, 0.5 * alphaScale);
+      front.beginPath();
+      front.moveTo(0, -34 * scale);
+      front.lineTo(0, 34 * scale);
+      front.strokePath();
+    }
+
+    if (explosionRank > 0) {
+      const sparkScale = explosionRank >= 2 ? 1.12 : 1;
+      front.fillStyle(0xef4444, 0.86 * alphaScale);
+      front.lineStyle(2 * scale, 0x1a1a1a, 0.72 * alphaScale);
+      front.beginPath();
+      front.moveTo(22 * scale, -28 * scale);
+      front.lineTo(27 * scale * sparkScale, -14 * scale);
+      front.lineTo(38 * scale, -13 * scale);
+      front.lineTo(29 * scale, -6 * scale * sparkScale);
+      front.lineTo(33 * scale, 6 * scale);
+      front.lineTo(21 * scale, -2 * scale);
+      front.lineTo(11 * scale, 6 * scale);
+      front.lineTo(14 * scale, -8 * scale);
+      front.lineTo(4 * scale, -16 * scale);
+      front.lineTo(18 * scale, -17 * scale);
+      front.closePath();
+      front.fillPath();
+      front.strokePath();
+    }
+  }
+
+  private createInternTexture(): void {
+    const g = this.scene.make.graphics({ x: 0, y: 0 });
+    g.lineStyle(3, 0x1a1a1a, 1);
+    g.fillStyle(0xfacc15, 0.95);
+    g.fillEllipse(24, 24, 30, 24);
+    g.strokeEllipse(24, 24, 30, 24);
+    g.fillStyle(0x1a1a1a, 1);
+    g.fillCircle(18, 20, 2);
+    g.fillCircle(30, 20, 2);
+    for (let i = 0; i < 3; i += 1) {
+      g.beginPath();
+      g.moveTo(13 + i * 9, 32);
+      g.lineTo(8 + i * 9, 40);
+      g.moveTo(18 + i * 9, 32);
+      g.lineTo(22 + i * 9, 40);
+      g.strokePath();
+    }
+    g.generateTexture('potassium_enemy_intern', 48, 46);
+    g.destroy();
+  }
+
+  private createScopeTexture(): void {
+    const g = this.scene.make.graphics({ x: 0, y: 0 });
+    g.fillStyle(0xa855f7, 0.85);
+    g.lineStyle(4, 0x1a1a1a, 1);
+    g.beginPath();
+    g.moveTo(34, 8);
+    g.lineTo(54, 14);
+    g.lineTo(61, 34);
+    g.lineTo(50, 56);
+    g.lineTo(28, 58);
+    g.lineTo(8, 46);
+    g.lineTo(10, 24);
+    g.lineTo(22, 10);
+    g.closePath();
+    g.fillPath();
+    g.strokePath();
+    g.fillStyle(0xffffff, 1);
+    g.fillCircle(28, 30, 8);
+    g.fillStyle(0x1a1a1a, 1);
+    g.fillCircle(30, 30, 3);
+    g.generateTexture('potassium_enemy_scope', 68, 64);
+    g.destroy();
+  }
+
+  private createMeetingTexture(): void {
+    const g = this.scene.make.graphics({ x: 0, y: 0 });
+    g.fillStyle(0xe5e7eb, 1);
+    g.lineStyle(5, 0x1a1a1a, 1);
+    g.fillRoundedRect(4, 8, 70, 44, 4);
+    g.strokeRoundedRect(4, 8, 70, 44, 4);
+    g.lineStyle(2, 0x1a1a1a, 0.55);
+    g.beginPath();
+    g.moveTo(14, 22);
+    g.lineTo(64, 22);
+    g.moveTo(14, 34);
+    g.lineTo(52, 34);
+    g.strokePath();
+    g.generateTexture('potassium_enemy_meeting', 78, 60);
+    g.destroy();
+  }
+
+  private createDeadlineTexture(): void {
+    const g = this.scene.make.graphics({ x: 0, y: 0 });
+    g.fillStyle(0xf97316, 0.9);
+    g.lineStyle(4, 0x1a1a1a, 1);
+    g.beginPath();
+    g.moveTo(28, 4);
+    g.lineTo(54, 46);
+    g.lineTo(28, 34);
+    g.lineTo(2, 46);
+    g.closePath();
+    g.fillPath();
+    g.strokePath();
+    g.lineStyle(3, 0x1a1a1a, 0.8);
+    g.beginPath();
+    g.moveTo(28, 34);
+    g.lineTo(28, 58);
+    g.strokePath();
+    g.generateTexture('potassium_enemy_deadline', 56, 62);
+    g.destroy();
+  }
+
+  private createWallTexture(): void {
+    const g = this.scene.make.graphics({ x: 0, y: 0 });
+    g.fillStyle(0x8b5a2b, 0.96);
+    g.lineStyle(5, 0x1a1a1a, 1);
+    g.fillRoundedRect(5, 7, 70, 48, 4);
+    g.strokeRoundedRect(5, 7, 70, 48, 4);
+    g.fillStyle(0xb7793b, 0.96);
+    g.fillRect(10, 12, 60, 10);
+    g.fillRect(10, 26, 60, 10);
+    g.fillRect(10, 40, 60, 10);
+    g.lineStyle(2, 0x1a1a1a, 0.48);
+    g.beginPath();
+    g.moveTo(18, 13);
+    g.lineTo(12, 21);
+    g.moveTo(48, 26);
+    g.lineTo(60, 35);
+    g.moveTo(26, 42);
+    g.lineTo(18, 50);
+    g.strokePath();
+    g.fillStyle(0xfbfbf9, 0.5);
+    g.fillRect(14, 16, 18, 3);
+    g.fillRect(42, 44, 16, 3);
+    g.lineStyle(3, 0x1a1a1a, 0.75);
+    g.beginPath();
+    g.moveTo(12, 31);
+    g.lineTo(68, 31);
+    g.strokePath();
+    g.generateTexture('potassium_enemy_wall', 80, 62);
+    g.destroy();
+  }
+
+  private createHardWallTexture(): void {
+    const g = this.scene.make.graphics({ x: 0, y: 0 });
+    g.fillStyle(0x1a1a1a, 0.08);
+    g.fillRoundedRect(7, 5, 66, 52, 5);
+    g.fillStyle(0xa8a29e, 1);
+    g.lineStyle(5, 0x1a1a1a, 1);
+    g.fillRoundedRect(5, 7, 70, 48, 5);
+    g.strokeRoundedRect(5, 7, 70, 48, 5);
+    g.lineStyle(3, 0x1a1a1a, 0.75);
+    g.beginPath();
+    g.moveTo(18, 17);
+    g.lineTo(62, 45);
+    g.moveTo(62, 17);
+    g.lineTo(18, 45);
+    g.strokePath();
+    g.fillStyle(0xfbfbf9, 0.68);
+    g.fillRect(22, 25, 36, 12);
+    g.generateTexture('potassium_enemy_hard_wall', 80, 62);
+    g.destroy();
+  }
+
+  private createSplitterTexture(): void {
+    const g = this.scene.make.graphics({ x: 0, y: 0 });
+    g.fillStyle(0xfde68a, 0.96);
+    g.lineStyle(4, 0x1a1a1a, 1);
+    g.fillRoundedRect(7, 8, 112, 42, 6);
+    g.strokeRoundedRect(7, 8, 112, 42, 6);
+    g.fillStyle(0xfacc15, 0.82);
+    g.fillRoundedRect(12, 13, 48, 32, 4);
+    g.fillRoundedRect(66, 13, 48, 32, 4);
+    g.lineStyle(3, 0x1a1a1a, 0.85);
+    g.beginPath();
+    g.moveTo(63, 10);
+    g.lineTo(63, 50);
+    g.moveTo(24, 24);
+    g.lineTo(50, 24);
+    g.moveTo(76, 34);
+    g.lineTo(104, 34);
+    g.strokePath();
+    g.fillStyle(0x1a1a1a, 1);
+    g.fillCircle(29, 31, 3);
+    g.fillCircle(93, 27, 3);
+    g.generateTexture('potassium_enemy_splitter', 126, 58);
+    g.destroy();
+  }
+
+  private createShieldTexture(): void {
+    const g = this.scene.make.graphics({ x: 0, y: 0 });
+    g.fillStyle(0xdbeafe, 0.96);
+    g.lineStyle(4, 0x1a1a1a, 1);
+    g.beginPath();
+    g.moveTo(34, 5);
+    g.lineTo(58, 18);
+    g.lineTo(52, 50);
+    g.lineTo(34, 60);
+    g.lineTo(16, 50);
+    g.lineTo(10, 18);
+    g.closePath();
+    g.fillPath();
+    g.strokePath();
+    g.fillStyle(0x38bdf8, 0.45);
+    g.fillRoundedRect(18, 38, 32, 10, 4);
+    g.lineStyle(2, 0x1a1a1a, 0.75);
+    g.strokeRoundedRect(18, 38, 32, 10, 4);
+    g.generateTexture('potassium_enemy_shield', 68, 66);
+    g.destroy();
+  }
+
+  private createBossTexture(): void {
+    const g = this.scene.make.graphics({ x: 0, y: 0 });
+    g.fillStyle(0xffffff, 1);
+    g.lineStyle(6, 0x1a1a1a, 1);
+    g.fillRoundedRect(4, 10, 116, 70, 10);
+    g.strokeRoundedRect(4, 10, 116, 70, 10);
+    g.lineStyle(3, 0x1a1a1a, 0.55);
+    g.strokeCircle(34, 44, 14);
+    g.strokeCircle(88, 44, 14);
+    g.beginPath();
+    g.moveTo(45, 62);
+    g.lineTo(80, 62);
+    g.strokePath();
+    g.fillStyle(0xfacc15, 0.5);
+    g.fillRect(12, 16, 100, 12);
+    g.generateTexture('potassium_enemy_boss', 124, 90);
+    g.destroy();
+  }
+
+  private createDamageOverlayTextures(): void {
+    const cracked = this.scene.make.graphics({ x: 0, y: 0 });
+    cracked.lineStyle(4, 0x1a1a1a, 0.9);
+    cracked.beginPath();
+    cracked.moveTo(22, 10);
+    cracked.lineTo(32, 22);
+    cracked.lineTo(27, 34);
+    cracked.moveTo(50, 18);
+    cracked.lineTo(42, 30);
+    cracked.lineTo(50, 42);
+    cracked.strokePath();
+    cracked.fillStyle(0xfbfbf9, 0.74);
+    cracked.fillRoundedRect(13, 43, 24, 8, 3);
+    cracked.lineStyle(2, 0x1a1a1a, 0.7);
+    cracked.strokeRoundedRect(13, 43, 24, 8, 3);
+    cracked.generateTexture('potassium_damage_cracked', 76, 62);
+    cracked.destroy();
+
+    const critical = this.scene.make.graphics({ x: 0, y: 0 });
+    critical.lineStyle(4, 0x1a1a1a, 0.95);
+    critical.beginPath();
+    critical.moveTo(18, 8);
+    critical.lineTo(30, 20);
+    critical.lineTo(22, 34);
+    critical.lineTo(36, 48);
+    critical.moveTo(56, 12);
+    critical.lineTo(44, 24);
+    critical.lineTo(56, 38);
+    critical.moveTo(42, 8);
+    critical.lineTo(38, 18);
+    critical.lineTo(46, 27);
+    critical.strokePath();
+    critical.fillStyle(0xfbfbf9, 0.82);
+    critical.fillRoundedRect(10, 40, 28, 9, 3);
+    critical.fillRoundedRect(41, 31, 23, 9, 3);
+    critical.lineStyle(2, 0x1a1a1a, 0.75);
+    critical.strokeRoundedRect(10, 40, 28, 9, 3);
+    critical.strokeRoundedRect(41, 31, 23, 9, 3);
+    critical.generateTexture('potassium_damage_critical', 76, 62);
+    critical.destroy();
+  }
+
+  private createWallDamageOverlayTextures(): void {
+    const cracked = this.scene.make.graphics({ x: 0, y: 0 });
+    cracked.lineStyle(4, 0x1a1a1a, 0.9);
+    cracked.beginPath();
+    cracked.moveTo(18, 11);
+    cracked.lineTo(29, 23);
+    cracked.lineTo(21, 34);
+    cracked.moveTo(55, 15);
+    cracked.lineTo(45, 27);
+    cracked.lineTo(57, 39);
+    cracked.strokePath();
+    cracked.lineStyle(3, 0xfbfbf9, 0.48);
+    cracked.beginPath();
+    cracked.moveTo(13, 47);
+    cracked.lineTo(28, 39);
+    cracked.moveTo(49, 48);
+    cracked.lineTo(68, 42);
+    cracked.strokePath();
+    cracked.generateTexture('potassium_wall_damage_cracked', 80, 62);
+    cracked.destroy();
+
+    const critical = this.scene.make.graphics({ x: 0, y: 0 });
+    critical.lineStyle(4, 0x1a1a1a, 0.96);
+    critical.beginPath();
+    critical.moveTo(14, 8);
+    critical.lineTo(29, 21);
+    critical.lineTo(19, 32);
+    critical.lineTo(34, 47);
+    critical.moveTo(62, 8);
+    critical.lineTo(48, 22);
+    critical.lineTo(62, 37);
+    critical.moveTo(42, 12);
+    critical.lineTo(38, 27);
+    critical.lineTo(48, 43);
+    critical.strokePath();
+    critical.lineStyle(3, 0xfbfbf9, 0.55);
+    critical.beginPath();
+    critical.moveTo(9, 50);
+    critical.lineTo(25, 40);
+    critical.moveTo(29, 13);
+    critical.lineTo(42, 7);
+    critical.moveTo(51, 52);
+    critical.lineTo(73, 43);
+    critical.strokePath();
+    critical.generateTexture('potassium_wall_damage_critical', 80, 62);
+    critical.destroy();
+  }
+
+  private createFireTexture(): void {
+    const g = this.scene.make.graphics({ x: 0, y: 0 });
+    g.fillStyle(0xf97316, 0.34);
+    g.lineStyle(3, 0x1a1a1a, 0.42);
+    g.fillEllipse(30, 18, 56, 24);
+    g.strokeEllipse(30, 18, 56, 24);
+    g.fillStyle(0xfacc15, 0.38);
+    g.fillEllipse(30, 16, 34, 14);
+    g.generateTexture('potassium_fire', 60, 36);
+    g.destroy();
+  }
+}
+
+function getSkillRank(skillRanks: PotassiumSkillRanks, upgrade: PotassiumUpgradeKind): PotassiumSkillRank {
+  return skillRanks[upgrade] ?? 0;
+}

--- a/src/runtime/potassiumSlipRenderer.ts
+++ b/src/runtime/potassiumSlipRenderer.ts
@@ -716,20 +716,13 @@ export class PotassiumSlipRenderer {
     g.strokeRoundedRect(5, 7, 70, 48, 5);
     g.fillStyle(0x1a1a1a, 0.12);
     g.fillRoundedRect(11, 13, 58, 36, 4);
-    g.lineStyle(3, 0x1a1a1a, 0.9);
+    g.lineStyle(6, 0x1a1a1a, 0.92);
     g.beginPath();
     g.moveTo(18, 17);
     g.lineTo(62, 45);
     g.moveTo(62, 17);
     g.lineTo(18, 45);
     g.strokePath();
-    g.fillStyle(0xfacc15, 0.9);
-    g.fillRoundedRect(19, 23, 42, 16, 3);
-    g.lineStyle(2, 0x1a1a1a, 0.95);
-    g.strokeRoundedRect(19, 23, 42, 16, 3);
-    g.fillStyle(0x1a1a1a, 1);
-    g.fillRect(31, 27, 4, 8);
-    g.fillRect(45, 27, 4, 8);
     g.generateTexture('potassium_enemy_hard_wall', 80, 62);
     g.destroy();
   }

--- a/src/runtime/potassiumSlipSession.test.ts
+++ b/src/runtime/potassiumSlipSession.test.ts
@@ -150,6 +150,23 @@ describe('potassium slip session', () => {
     expect(result.commands).toContainEqual({ type: 'advanceWaveAfterDelay', wave: 3 });
   });
 
+  it('keeps wave advancement guarded after a draft choice until the next wave spawns', () => {
+    const draft = resolvePotassiumDraftChoice({
+      ...createPotassiumSession(),
+      gameState: 'UPGRADE',
+      wave: 1
+    }, { kind: 'fire', action: 'unlock' });
+
+    expect(draft.state.waveAdvancing).toBe(true);
+
+    const clear = resolvePotassiumWaveClear({
+      state: draft.state,
+      hasLivingEnemies: false
+    });
+
+    expect(clear.commands).toEqual([]);
+  });
+
   it('updates generic bonus life drafts and emits HUD and hint commands', () => {
     const result = resolvePotassiumDraftChoice({
       ...createPotassiumSession(),

--- a/src/runtime/potassiumSlipSession.test.ts
+++ b/src/runtime/potassiumSlipSession.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createPotassiumSession,
+  markPotassiumRowSpawned,
+  resolvePotassiumDraftChoice,
+  resolvePotassiumEnemyEscaped,
+  resolvePotassiumEnemyKilled,
+  resolvePotassiumOutcome,
+  resolvePotassiumTerminalAction,
+  resolvePotassiumWaveClear,
+  showPotassiumDraftChoices,
+  spawnPotassiumWave,
+  startPotassiumCampaign,
+  startPotassiumEndless,
+  type PotassiumSessionCommand,
+  type PotassiumSessionState
+} from './potassiumSlipSession';
+import {
+  POTASSIUM_BOSS_WAVE,
+  POTASSIUM_ENDLESS_START_WAVE,
+  POTASSIUM_UPGRADES
+} from './potassiumSlipWaves';
+
+describe('potassium slip session', () => {
+  it('starts a fresh campaign with board reset, hint, wave spawn, and HUD commands', () => {
+    const previous = {
+      ...createPotassiumSession(),
+      score: 99,
+      lives: 1,
+      gameState: 'GAME_OVER' as const
+    };
+
+    const result = startPotassiumCampaign(previous);
+
+    expect(result.state).toMatchObject({
+      gameState: 'PLAYING',
+      score: 0,
+      lives: 5,
+      wave: 1,
+      runMode: 'campaign',
+      skillRanks: {},
+      genericRanks: {}
+    });
+    expect(commandTypes(result.commands)).toEqual([
+      'hideMainOverlay',
+      'clearTerminal',
+      'resetBoard',
+      'setHint',
+      'spawnWave',
+      'updateHud'
+    ]);
+    expect(result.commands).toContainEqual({ type: 'setHint', text: 'Drag toward a target • Hold to recall' });
+    expect(result.commands).toContainEqual({ type: 'spawnWave', wave: 1 });
+  });
+
+  it('only starts endless after a won campaign and spawns the endless start wave', () => {
+    const blocked = startPotassiumEndless(createPotassiumSession());
+    expect(blocked.commands).toEqual([]);
+
+    const won = resolvePotassiumOutcome({
+      ...createPotassiumSession(),
+      gameState: 'PLAYING',
+      score: 25,
+      wave: POTASSIUM_BOSS_WAVE
+    }, 'won', '2026-05-03T00:00:00.000Z').state;
+
+    const result = startPotassiumEndless(won);
+
+    expect(result.state).toMatchObject({
+      gameState: 'PLAYING',
+      runMode: 'endless',
+      wave: POTASSIUM_BOSS_WAVE
+    });
+    expect(result.commands).toContainEqual({ type: 'spawnWave', wave: POTASSIUM_ENDLESS_START_WAVE });
+    expect(result.commands).toContainEqual({ type: 'setHint', text: 'Endless audit • The nonsense keeps filing' });
+  });
+
+  it('spawns boss waves without scheduling rows', () => {
+    const result = spawnPotassiumWave({
+      ...createPotassiumSession(),
+      gameState: 'PLAYING'
+    }, POTASSIUM_BOSS_WAVE);
+
+    expect(result.state).toMatchObject({
+      wave: POTASSIUM_BOSS_WAVE,
+      pendingRows: 0,
+      waveAdvancing: false
+    });
+    expect(commandTypes(result.commands)).toEqual(['spawnBoss', 'setHint', 'updateHud']);
+    expect(result.commands).toContainEqual({ type: 'setHint', text: 'Boss wave • Stop the audit before it lands' });
+  });
+
+  it('waits for pending rows and living enemies before scheduling upgrades', () => {
+    const playing = spawnPotassiumWave({
+      ...createPotassiumSession(),
+      gameState: 'PLAYING'
+    }, 1).state;
+    const rowSpawned = markPotassiumRowSpawned(playing).state;
+
+    expect(resolvePotassiumWaveClear({ state: rowSpawned, hasLivingEnemies: false }).commands).toEqual([]);
+    const noPendingRows = { ...rowSpawned, pendingRows: 0 };
+    expect(resolvePotassiumWaveClear({ state: noPendingRows, hasLivingEnemies: true }).commands).toEqual([]);
+
+    const clear = resolvePotassiumWaveClear({ state: noPendingRows, hasLivingEnemies: false });
+    expect(clear.state.waveAdvancing).toBe(true);
+    expect(commandTypes(clear.commands)).toEqual(['setHint', 'scheduleUpgradeChoices']);
+  });
+
+  it('falls back to generic drafts when all skill choices are maxed', () => {
+    const maxedSkills = Object.fromEntries(POTASSIUM_UPGRADES.map((upgrade) => [upgrade, 2]));
+    const state: PotassiumSessionState = {
+      ...createPotassiumSession(),
+      gameState: 'PLAYING',
+      wave: 3,
+      skillRanks: maxedSkills,
+      genericRanks: {
+        damage: 1,
+        poison: 1,
+        explosion: 1,
+        cloneTime: 1,
+        bananaSpeed: 1,
+        bonusLife: 1
+      }
+    };
+
+    const result = showPotassiumDraftChoices(state);
+
+    expect(result.state.gameState).toBe('UPGRADE');
+    expect(result.commands.some((command) => command.type === 'showUpgradeChoices')).toBe(true);
+  });
+
+  it('updates skill drafts and emits projectile visual refresh, HUD, hint, and wave advance commands', () => {
+    const result = resolvePotassiumDraftChoice({
+      ...createPotassiumSession(),
+      gameState: 'UPGRADE',
+      wave: 2
+    }, { kind: 'fire', action: 'unlock' });
+
+    expect(result.state).toMatchObject({
+      gameState: 'PLAYING',
+      skillRanks: { fire: 1 }
+    });
+    expect(commandTypes(result.commands)).toEqual([
+      'setHint',
+      'refreshProjectileVisuals',
+      'clearUpgradeChoices',
+      'advanceWaveAfterDelay',
+      'updateHud'
+    ]);
+    expect(result.commands).toContainEqual({ type: 'advanceWaveAfterDelay', wave: 3 });
+  });
+
+  it('updates generic bonus life drafts and emits HUD and hint commands', () => {
+    const result = resolvePotassiumDraftChoice({
+      ...createPotassiumSession(),
+      gameState: 'UPGRADE',
+      wave: 4,
+      lives: 2
+    }, { type: 'generic', kind: 'bonusLife' });
+
+    expect(result.state.lives).toBe(3);
+    expect(result.state.genericRanks).toEqual({ bonusLife: 1 });
+    expect(result.commands).toContainEqual({ type: 'setHint', text: 'Bonus Life stacked • Endless paperwork trembles' });
+    expect(result.commands).toContainEqual({ type: 'advanceWaveAfterDelay', wave: 5 });
+    expect(result.commands.at(-1)?.type).toBe('updateHud');
+  });
+
+  it('adds enemy score and resolves boss kills as wins', () => {
+    const intern = resolvePotassiumEnemyKilled({
+      ...createPotassiumSession(),
+      gameState: 'PLAYING',
+      score: 2
+    }, 3, 'intern');
+    expect(intern.state.score).toBe(5);
+    expect(intern.commands).toEqual([
+      {
+        type: 'updateHud',
+        hud: expect.objectContaining({ score: 5, lives: 5 })
+      }
+    ]);
+
+    const boss = resolvePotassiumEnemyKilled({
+      ...intern.state,
+      wave: POTASSIUM_BOSS_WAVE,
+      runRecordCompletedAt: '2026-05-03T00:00:00.000Z'
+    }, 12, 'boss');
+    expect(boss.state.gameState).toBe('WON');
+    expect(commandTypes(boss.commands)).toContain('collectCircuit');
+    expect(boss.commands).toContainEqual({ type: 'showTerminal', outcome: 'won' });
+  });
+
+  it('decrements lives for normal escapes and resolves boss escapes as game over', () => {
+    const escaped = resolvePotassiumEnemyEscaped({
+      ...createPotassiumSession(),
+      gameState: 'PLAYING',
+      lives: 2
+    }, 'intern');
+    expect(escaped.state.lives).toBe(1);
+    expect(escaped.state.gameState).toBe('PLAYING');
+
+    const lethal = resolvePotassiumEnemyEscaped(escaped.state, 'deadline');
+    expect(lethal.state.gameState).toBe('GAME_OVER');
+    expect(lethal.commands).toContainEqual({ type: 'showTerminal', outcome: 'game_over' });
+
+    const boss = resolvePotassiumEnemyEscaped({
+      ...createPotassiumSession(),
+      gameState: 'PLAYING',
+      lives: 5
+    }, 'boss');
+    expect(boss.state.lives).toBe(0);
+    expect(boss.state.gameState).toBe('GAME_OVER');
+  });
+
+  it('saves campaign wins and continued endless game overs with the same completedAt', () => {
+    const completedAt = '2026-05-03T00:00:00.000Z';
+    const campaign = resolvePotassiumOutcome({
+      ...createPotassiumSession(),
+      gameState: 'PLAYING',
+      score: 25,
+      wave: POTASSIUM_BOSS_WAVE
+    }, 'won', completedAt);
+
+    expect(campaign.commands).toContainEqual({ type: 'collectCircuit' });
+    expect(campaign.commands).toContainEqual({
+      type: 'saveRunRecord',
+      record: {
+        score: 25,
+        wave: POTASSIUM_BOSS_WAVE,
+        mode: 'campaign',
+        outcome: 'won',
+        completedAt
+      }
+    });
+
+    const endless = resolvePotassiumOutcome({
+      ...campaign.state,
+      gameState: 'PLAYING',
+      runMode: 'endless',
+      score: 80,
+      wave: 14
+    }, 'game_over');
+
+    expect(endless.commands).not.toContainEqual({ type: 'collectCircuit' });
+    expect(endless.commands).toContainEqual({
+      type: 'saveRunRecord',
+      record: {
+        score: 80,
+        wave: 14,
+        mode: 'endless',
+        outcome: 'game_over',
+        completedAt
+      }
+    });
+  });
+
+  it('resolves terminal actions to retry, endless, or close commands', () => {
+    const won = {
+      ...createPotassiumSession(),
+      gameState: 'WON' as const
+    };
+    expect(resolvePotassiumTerminalAction(won, 'return').commands).toEqual([{ type: 'closeScene' }]);
+    expect(resolvePotassiumTerminalAction(won, 'retry').commands).toContainEqual({ type: 'spawnWave', wave: 1 });
+    expect(resolvePotassiumTerminalAction(won, 'endless').commands).toContainEqual({
+      type: 'spawnWave',
+      wave: POTASSIUM_ENDLESS_START_WAVE
+    });
+  });
+});
+
+function commandTypes(commands: readonly PotassiumSessionCommand[]): string[] {
+  return commands.map((command) => command.type);
+}

--- a/src/runtime/potassiumSlipSession.test.ts
+++ b/src/runtime/potassiumSlipSession.test.ts
@@ -3,6 +3,7 @@ import {
   createPotassiumSession,
   markPotassiumRowSpawned,
   resolvePotassiumDraftChoice,
+  resolvePotassiumDevSkipWave,
   resolvePotassiumEnemyEscaped,
   resolvePotassiumEnemyKilled,
   resolvePotassiumOutcome,
@@ -104,6 +105,25 @@ describe('potassium slip session', () => {
     const clear = resolvePotassiumWaveClear({ state: noPendingRows, hasLivingEnemies: false });
     expect(clear.state.waveAdvancing).toBe(true);
     expect(commandTypes(clear.commands)).toEqual(['setHint', 'scheduleUpgradeChoices']);
+  });
+
+  it('dev wave skip guards current wave and schedules draft choices', () => {
+    const result = resolvePotassiumDevSkipWave({
+      ...createPotassiumSession(),
+      gameState: 'PLAYING',
+      wave: 5,
+      pendingRows: 3
+    });
+
+    expect(result.state).toMatchObject({
+      pendingRows: 0,
+      waveAdvancing: true
+    });
+    expect(commandTypes(result.commands)).toEqual([
+      'setHint',
+      'scheduleUpgradeChoices',
+      'updateHud'
+    ]);
   });
 
   it('falls back to generic drafts when all skill choices are maxed', () => {

--- a/src/runtime/potassiumSlipSession.ts
+++ b/src/runtime/potassiumSlipSession.ts
@@ -1,0 +1,502 @@
+import {
+  applyPotassiumDraftOption,
+  applyPotassiumGenericDraftOption,
+  getPotassiumDraftChoices,
+  getPotassiumGenericUpgradeRank,
+  getPotassiumSkillRank,
+  getPotassiumWave,
+  isPotassiumBossWave,
+  POTASSIUM_ENDLESS_START_WAVE,
+  type PotassiumDraftOption,
+  type PotassiumEnemyKind,
+  type PotassiumGenericDraftOption,
+  type PotassiumGenericUpgradeKind,
+  type PotassiumGenericUpgradeRanks,
+  type PotassiumSkillRanks,
+  type PotassiumUpgradeKind,
+  type PotassiumWaveCell
+} from './potassiumSlipWaves';
+import type {
+  PotassiumRunMode,
+  PotassiumRunOutcome,
+  PotassiumRunRecord
+} from './potassiumSlipLeaderboard';
+
+export type PotassiumSessionGameState = 'START' | 'PLAYING' | 'UPGRADE' | 'WON' | 'GAME_OVER';
+export type PotassiumTerminalAction = 'return' | 'retry' | 'endless';
+
+export interface PotassiumSessionState {
+  gameState: PotassiumSessionGameState;
+  score: number;
+  lives: number;
+  wave: number;
+  waveAdvancing: boolean;
+  pendingRows: number;
+  skillRanks: PotassiumSkillRanks;
+  genericRanks: PotassiumGenericUpgradeRanks;
+  runMode: PotassiumRunMode;
+  runRecordCompletedAt?: string;
+}
+
+export interface PotassiumHudFacts {
+  waveLabel: string;
+  score: number;
+  lives: number;
+}
+
+export interface PotassiumDraftChoiceView {
+  option: PotassiumDraftOption;
+  title: string;
+  description: string;
+  color: string;
+}
+
+export type PotassiumSessionCommand =
+  | { type: 'resetBoard' }
+  | { type: 'hideMainOverlay' }
+  | { type: 'clearTerminal' }
+  | { type: 'clearUpgradeChoices' }
+  | { type: 'setHint'; text: string | null }
+  | { type: 'spawnWave'; wave: number }
+  | { type: 'spawnBoss' }
+  | { type: 'scheduleWaveRows'; rows: readonly PotassiumWaveCell[][] }
+  | { type: 'scheduleUpgradeChoices' }
+  | { type: 'showUpgradeChoices'; choices: readonly PotassiumDraftChoiceView[] }
+  | { type: 'advanceWaveAfterDelay'; wave: number }
+  | { type: 'refreshProjectileVisuals' }
+  | { type: 'updateHud'; hud: PotassiumHudFacts }
+  | { type: 'collectCircuit' }
+  | { type: 'saveRunRecord'; record: PotassiumRunRecord }
+  | { type: 'showOutcome'; title: string; score: number; titleFontSize: number }
+  | { type: 'showTerminal'; outcome: PotassiumRunOutcome }
+  | { type: 'closeScene' }
+  | { type: 'stopBanana' }
+  | { type: 'clearBoardForOutcome' };
+
+export interface PotassiumSessionResult {
+  state: PotassiumSessionState;
+  commands: PotassiumSessionCommand[];
+}
+
+interface PotassiumWaveClearInput {
+  state: PotassiumSessionState;
+  hasLivingEnemies: boolean;
+}
+
+const LIVES_INITIAL = 5;
+
+const GENERIC_UPGRADE_CONFIGS: Record<PotassiumGenericUpgradeKind, { label: string; color: string; description: string }> = {
+  damage: {
+    label: 'Damage +',
+    color: '#1a1a1a',
+    description: '+12% banana and beam damage.'
+  },
+  poison: {
+    label: 'Poison +',
+    color: '#65a30d',
+    description: '+10% poison tick strength.'
+  },
+  explosion: {
+    label: 'Explosion +',
+    color: '#ef4444',
+    description: '+6% blast radius.'
+  },
+  cloneTime: {
+    label: 'Clone Time +',
+    color: '#facc15',
+    description: '+300ms clone lifetime.'
+  },
+  bananaSpeed: {
+    label: 'Banana Speed +',
+    color: '#38bdf8',
+    description: '+5% launch speed.'
+  },
+  bonusLife: {
+    label: 'Bonus Life',
+    color: '#a855f7',
+    description: '+1 life right now.'
+  }
+};
+
+const UPGRADE_CONFIGS: Record<PotassiumUpgradeKind, { label: string; color: string; description: string }> = {
+  fire: {
+    label: 'Fire Trail',
+    color: '#f97316',
+    description: 'Moving bananas leave hot nonsense.'
+  },
+  poison: {
+    label: 'Poison Damage',
+    color: '#65a30d',
+    description: 'Hits tick for 1 dmg every 500ms.'
+  },
+  explosion: {
+    label: 'Explosion Damage',
+    color: '#ef4444',
+    description: 'Every hit pops nearby paperwork.'
+  },
+  duplicate: {
+    label: 'Duplicate',
+    color: '#facc15',
+    description: 'Main hits spawn two tiny bananas.'
+  },
+  ghostHorizontal: {
+    label: 'Horizontal Ghost',
+    color: '#38bdf8',
+    description: 'Hits sweep a blue row beam.'
+  },
+  ghostVertical: {
+    label: 'Vertical Ghost',
+    color: '#60a5fa',
+    description: 'Hits sweep a blue column beam.'
+  }
+};
+
+export function createPotassiumSession(): PotassiumSessionState {
+  return {
+    gameState: 'START',
+    score: 0,
+    lives: LIVES_INITIAL,
+    wave: 1,
+    waveAdvancing: false,
+    pendingRows: 0,
+    skillRanks: {},
+    genericRanks: {},
+    runMode: 'campaign',
+    runRecordCompletedAt: undefined
+  };
+}
+
+export function startPotassiumCampaign(state: PotassiumSessionState): PotassiumSessionResult {
+  void state;
+  const nextState = {
+    ...createPotassiumSession(),
+    gameState: 'PLAYING' as const
+  };
+  return withHud(nextState, [
+    { type: 'hideMainOverlay' },
+    { type: 'clearTerminal' },
+    { type: 'resetBoard' },
+    { type: 'setHint', text: 'Drag toward a target • Hold to recall' },
+    { type: 'spawnWave', wave: 1 }
+  ]);
+}
+
+export function startPotassiumEndless(state: PotassiumSessionState): PotassiumSessionResult {
+  if (state.gameState !== 'WON') return { state, commands: [] };
+  const nextState: PotassiumSessionState = {
+    ...state,
+    gameState: 'PLAYING',
+    runMode: 'endless',
+    waveAdvancing: false,
+    pendingRows: 0
+  };
+  return withHud(nextState, [
+    { type: 'hideMainOverlay' },
+    { type: 'clearTerminal' },
+    { type: 'resetBoard' },
+    { type: 'setHint', text: 'Endless audit • The nonsense keeps filing' },
+    { type: 'spawnWave', wave: POTASSIUM_ENDLESS_START_WAVE }
+  ]);
+}
+
+export function spawnPotassiumWave(state: PotassiumSessionState, waveNumber: number): PotassiumSessionResult {
+  const wave = getPotassiumWave(waveNumber);
+  const nextState: PotassiumSessionState = {
+    ...state,
+    wave: waveNumber,
+    waveAdvancing: false,
+    pendingRows: isPotassiumBossWave(waveNumber) ? 0 : wave.rows.length
+  };
+  if (isPotassiumBossWave(waveNumber)) {
+    return withHud(nextState, [
+      { type: 'spawnBoss' },
+      { type: 'setHint', text: 'Boss wave • Stop the audit before it lands' }
+    ]);
+  }
+  return withHud(nextState, [
+    { type: 'scheduleWaveRows', rows: wave.rows },
+    { type: 'setHint', text: `${wave.title}: ${getWaveHint(waveNumber)}` }
+  ]);
+}
+
+export function markPotassiumRowSpawned(state: PotassiumSessionState): PotassiumSessionResult {
+  return {
+    state: {
+      ...state,
+      pendingRows: Math.max(0, state.pendingRows - 1)
+    },
+    commands: []
+  };
+}
+
+export function resolvePotassiumWaveClear(input: PotassiumWaveClearInput): PotassiumSessionResult {
+  const { state } = input;
+  if (state.waveAdvancing || state.gameState !== 'PLAYING' || isPotassiumBossWave(state.wave)) {
+    return { state, commands: [] };
+  }
+  if (state.pendingRows > 0 || input.hasLivingEnemies) {
+    return { state, commands: [] };
+  }
+  const nextState = {
+    ...state,
+    waveAdvancing: true
+  };
+  return {
+    state: nextState,
+    commands: [
+      { type: 'setHint', text: 'Wave clear • Choose fresh banana nonsense' },
+      { type: 'scheduleUpgradeChoices' }
+    ]
+  };
+}
+
+export function showPotassiumDraftChoices(state: PotassiumSessionState): PotassiumSessionResult {
+  const choices = getPotassiumDraftChoices(state.skillRanks, state.genericRanks, state.wave);
+  if (choices.length === 0) {
+    return advancePotassiumWave(state);
+  }
+  const nextState = {
+    ...state,
+    gameState: 'UPGRADE' as const
+  };
+  return {
+    state: nextState,
+    commands: [
+      { type: 'stopBanana' },
+      { type: 'clearUpgradeChoices' },
+      { type: 'showUpgradeChoices', choices: choices.map(getDraftChoiceView) }
+    ]
+  };
+}
+
+export function resolvePotassiumDraftChoice(
+  state: PotassiumSessionState,
+  option: PotassiumDraftOption
+): PotassiumSessionResult {
+  if (isGenericDraftOption(option)) {
+    const genericRanks = applyPotassiumGenericDraftOption(state.genericRanks, option);
+    const nextState = {
+      ...state,
+      genericRanks,
+      lives: option.kind === 'bonusLife' ? state.lives + 1 : state.lives
+    };
+    return withHud(advancePotassiumWaveState(nextState), [
+      { type: 'setHint', text: `${GENERIC_UPGRADE_CONFIGS[option.kind].label} stacked • Endless paperwork trembles` },
+      { type: 'clearUpgradeChoices' },
+      { type: 'advanceWaveAfterDelay', wave: state.wave + 1 }
+    ]);
+  }
+
+  const skillRanks = applyPotassiumDraftOption(state.skillRanks, option);
+  const nextState = advancePotassiumWaveState({
+    ...state,
+    skillRanks
+  });
+  const actionLabel = option.action === 'unlock' ? 'unlocked' : 'upgraded';
+  return withHud(nextState, [
+    { type: 'setHint', text: `${UPGRADE_CONFIGS[option.kind].label} ${actionLabel} • It stacks forever` },
+    { type: 'refreshProjectileVisuals' },
+    { type: 'clearUpgradeChoices' },
+    { type: 'advanceWaveAfterDelay', wave: state.wave + 1 }
+  ]);
+}
+
+export function resolvePotassiumEnemyKilled(
+  state: PotassiumSessionState,
+  enemyScore: number,
+  enemyKind: PotassiumEnemyKind
+): PotassiumSessionResult {
+  const nextState = {
+    ...state,
+    score: state.score + enemyScore
+  };
+  if (enemyKind === 'boss') {
+    return resolvePotassiumOutcome(nextState, 'won');
+  }
+  return withHud(nextState);
+}
+
+export function resolvePotassiumEnemyEscaped(
+  state: PotassiumSessionState,
+  enemyKind: PotassiumEnemyKind
+): PotassiumSessionResult {
+  if (enemyKind === 'boss') {
+    return resolvePotassiumOutcome({ ...state, lives: 0 }, 'game_over');
+  }
+  const nextState = {
+    ...state,
+    lives: state.lives - 1
+  };
+  if (nextState.lives <= 0) {
+    return resolvePotassiumOutcome(nextState, 'game_over');
+  }
+  return withHud(nextState);
+}
+
+export function resolvePotassiumOutcome(
+  state: PotassiumSessionState,
+  outcome: PotassiumRunOutcome,
+  completedAt: string = state.runRecordCompletedAt ?? new Date().toISOString()
+): PotassiumSessionResult {
+  const nextState = {
+    ...state,
+    gameState: outcome === 'won' ? 'WON' as const : 'GAME_OVER' as const,
+    runRecordCompletedAt: completedAt
+  };
+  const record: PotassiumRunRecord = {
+    score: nextState.score,
+    wave: nextState.wave,
+    mode: nextState.runMode,
+    outcome,
+    completedAt
+  };
+  const commands: PotassiumSessionCommand[] = [
+    { type: 'clearBoardForOutcome' },
+    { type: 'clearUpgradeChoices' }
+  ];
+  if (outcome === 'won' && nextState.runMode === 'campaign') {
+    commands.push({ type: 'collectCircuit' });
+  }
+  commands.push(
+    { type: 'saveRunRecord', record },
+    { type: 'setHint', text: null },
+    {
+      type: 'showOutcome',
+      title: outcome === 'won' ? 'CIRCUIT ACQUIRED' : 'BANANA BANKRUPTCY',
+      score: nextState.score,
+      titleFontSize: outcome === 'won' ? 26 : 24
+    },
+    { type: 'showTerminal', outcome }
+  );
+  return { state: nextState, commands };
+}
+
+export function resolvePotassiumTerminalAction(
+  state: PotassiumSessionState,
+  action: PotassiumTerminalAction
+): PotassiumSessionResult {
+  if (action === 'return') {
+    return { state, commands: [{ type: 'closeScene' }] };
+  }
+  if (action === 'retry') {
+    return startPotassiumCampaign(state);
+  }
+  return startPotassiumEndless(state);
+}
+
+export function getPotassiumSessionHud(state: PotassiumSessionState): PotassiumHudFacts {
+  const wave = getPotassiumWave(state.wave);
+  return {
+    waveLabel: `W${state.wave} ${wave.title}`,
+    score: state.score,
+    lives: state.lives
+  };
+}
+
+export function getPotassiumSessionSkillRank(
+  state: PotassiumSessionState,
+  upgrade: PotassiumUpgradeKind
+): 0 | 1 | 2 {
+  return getPotassiumSkillRank(state.skillRanks, upgrade);
+}
+
+export function getPotassiumSessionGenericRank(
+  state: PotassiumSessionState,
+  upgrade: PotassiumGenericUpgradeKind
+): number {
+  return getPotassiumGenericUpgradeRank(state.genericRanks, upgrade);
+}
+
+function advancePotassiumWave(state: PotassiumSessionState): PotassiumSessionResult {
+  const nextState = advancePotassiumWaveState(state);
+  return {
+    state: nextState,
+    commands: [{ type: 'advanceWaveAfterDelay', wave: state.wave + 1 }]
+  };
+}
+
+function advancePotassiumWaveState(state: PotassiumSessionState): PotassiumSessionState {
+  return {
+    ...state,
+    gameState: 'PLAYING',
+    waveAdvancing: false
+  };
+}
+
+function withHud(
+  state: PotassiumSessionState,
+  commands: PotassiumSessionCommand[] = []
+): PotassiumSessionResult {
+  return {
+    state,
+    commands: [
+      ...commands,
+      { type: 'updateHud', hud: getPotassiumSessionHud(state) }
+    ]
+  };
+}
+
+function isGenericDraftOption(option: PotassiumDraftOption): option is PotassiumGenericDraftOption {
+  return option.type === 'generic';
+}
+
+function getDraftChoiceView(option: PotassiumDraftOption): PotassiumDraftChoiceView {
+  const config = isGenericDraftOption(option) ? GENERIC_UPGRADE_CONFIGS[option.kind] : UPGRADE_CONFIGS[option.kind];
+  return {
+    option,
+    title: getDraftOptionTitle(option),
+    description: getDraftOptionDescription(option),
+    color: config.color
+  };
+}
+
+function getDraftOptionDescription(option: PotassiumDraftOption): string {
+  if (isGenericDraftOption(option)) return GENERIC_UPGRADE_CONFIGS[option.kind].description;
+  if (option.kind === 'fire') {
+    return option.action === 'unlock'
+      ? 'Moving bananas leave fire.'
+      : 'Hits drop extra fire patches.';
+  }
+  if (option.kind === 'poison') {
+    return option.action === 'unlock'
+      ? 'Hits poison enemies over time.'
+      : 'Poisoned enemies spread on death.';
+  }
+  if (option.kind === 'explosion') {
+    return option.action === 'unlock'
+      ? 'Hits explode with falloff damage.'
+      : 'Bigger blasts apply statuses.';
+  }
+  if (option.kind === 'duplicate') {
+    return option.action === 'unlock'
+      ? 'Main hits spawn 2 small bananas.'
+      : 'Clones apply half-strength procs and spawn +1.';
+  }
+  if (option.kind === 'ghostHorizontal') {
+    return option.action === 'unlock'
+      ? 'Hits fire a blue row beam.'
+      : 'Row beams apply statuses.';
+  }
+  return option.action === 'unlock'
+    ? 'Hits fire a blue column beam.'
+    : 'Column beams apply statuses.';
+}
+
+function getDraftOptionTitle(option: PotassiumDraftOption): string {
+  if (isGenericDraftOption(option)) return GENERIC_UPGRADE_CONFIGS[option.kind].label;
+  const label = UPGRADE_CONFIGS[option.kind].label;
+  return option.action === 'upgrade' ? `${label} +` : label;
+}
+
+function getWaveHint(wave: number): string {
+  if (wave > 11) return 'endless paperwork escalation';
+  if (wave === 1) return 'launch and bounce';
+  if (wave === 2) return 'multi-hit blobs';
+  if (wave === 3) return 'walls block angles';
+  if (wave === 4) return 'walls block angles';
+  if (wave === 5) return 'splitter memos make smaller problems';
+  if (wave === 6) return 'stack your choices';
+  if (wave === 7) return 'shield plates reject bad angles';
+  if (wave >= 8 && wave <= 10) return 'hard walls ignore banana law';
+  return 'boss time';
+}

--- a/src/runtime/potassiumSlipSession.ts
+++ b/src/runtime/potassiumSlipSession.ts
@@ -419,7 +419,7 @@ function advancePotassiumWaveState(state: PotassiumSessionState): PotassiumSessi
   return {
     ...state,
     gameState: 'PLAYING',
-    waveAdvancing: false
+    waveAdvancing: true
   };
 }
 

--- a/src/runtime/potassiumSlipSession.ts
+++ b/src/runtime/potassiumSlipSession.ts
@@ -250,6 +250,21 @@ export function resolvePotassiumWaveClear(input: PotassiumWaveClearInput): Potas
   };
 }
 
+export function resolvePotassiumDevSkipWave(state: PotassiumSessionState): PotassiumSessionResult {
+  if (state.gameState !== 'PLAYING' || isPotassiumBossWave(state.wave)) {
+    return { state, commands: [] };
+  }
+  const nextState = {
+    ...state,
+    pendingRows: 0,
+    waveAdvancing: true
+  };
+  return withHud(nextState, [
+    { type: 'setHint', text: 'Dev skip • Choose a test upgrade' },
+    { type: 'scheduleUpgradeChoices' }
+  ]);
+}
+
 export function showPotassiumDraftChoices(state: PotassiumSessionState): PotassiumSessionResult {
   const choices = getPotassiumDraftChoices(state.skillRanks, state.genericRanks, state.wave);
   if (choices.length === 0) {

--- a/src/runtime/potassiumSlipWaves.test.ts
+++ b/src/runtime/potassiumSlipWaves.test.ts
@@ -73,6 +73,17 @@ describe('potassium slip waves', () => {
     expect(getPotassiumWave(4).rows.flat()).not.toContain('shield');
   });
 
+  it('leans more on unbreakable walls in later pressure waves', () => {
+    expect(countKind(getPotassiumWave(9).rows, 'hardWall')).toBeGreaterThan(
+      countKind(getPotassiumWave(8).rows, 'hardWall')
+    );
+  });
+
+  it('spreads late unbreakable walls across multiple columns', () => {
+    expect(occupiedColumns(getPotassiumWave(9).rows, 'hardWall').size).toBeGreaterThanOrEqual(3);
+    expect(occupiedColumns(getPotassiumWave(10).rows, 'hardWall').size).toBeGreaterThanOrEqual(3);
+  });
+
   it('defines readable enemy helper behavior', () => {
     expect(getPotassiumEnemyHealthState(7, 10)).toBe('healthy');
     expect(getPotassiumEnemyHealthState(6, 10)).toBe('cracked');
@@ -185,4 +196,18 @@ function getNonBossRows(): PotassiumWaveCell[][] {
 
 function countEnemies(rows: readonly PotassiumWaveCell[][]): number {
   return rows.flat().filter((cell) => cell !== null).length;
+}
+
+function countKind(rows: readonly PotassiumWaveCell[][], kind: PotassiumWaveCell): number {
+  return rows.flat().filter((cell) => cell === kind).length;
+}
+
+function occupiedColumns(rows: readonly PotassiumWaveCell[][], kind: PotassiumWaveCell): Set<number> {
+  const columns = new Set<number>();
+  rows.forEach((row) => {
+    row.forEach((cell, column) => {
+      if (cell === kind) columns.add(column);
+    });
+  });
+  return columns;
 }

--- a/src/runtime/potassiumSlipWaves.test.ts
+++ b/src/runtime/potassiumSlipWaves.test.ts
@@ -61,7 +61,6 @@ describe('potassium slip waves', () => {
     expect(getUnlockedPotassiumEnemies(1)).toEqual(['intern']);
     expect(getUnlockedPotassiumEnemies(2)).toContain('scope');
     expect(getUnlockedPotassiumEnemies(3)).toContain('wall');
-    expect(getUnlockedPotassiumEnemies(5)).toContain('meeting');
     expect(getUnlockedPotassiumEnemies(5)).toContain('splitter');
     expect(getUnlockedPotassiumEnemies(7)).toContain('deadline');
     expect(getUnlockedPotassiumEnemies(8)).toContain('shield');

--- a/src/runtime/potassiumSlipWaves.ts
+++ b/src/runtime/potassiumSlipWaves.ts
@@ -356,8 +356,8 @@ function buildTemplateRow(template: RowTemplate, wave: number, rowIndex: number)
       placeEnemyInRow(row, (deadlineLane + 4) % POTASSIUM_COLUMN_COUNT, 'deadline');
     }
   } else {
-    const lanes = [0, 1, 3, 4].filter((lane) => lane !== ((wave + rowIndex) % POTASSIUM_COLUMN_COUNT));
-    lanes.slice(0, wave >= 8 ? 4 : 3).forEach((lane, index) => {
+    const lanes = getPressureLanes(wave, rowIndex);
+    lanes.forEach((lane, index) => {
       placeEnemyInRow(row, lane, pickPressureEnemy(wave, rowIndex + index));
     });
   }
@@ -389,12 +389,26 @@ function pickBasicEnemy(wave: number, seed: number): PotassiumEnemyKind {
 }
 
 function pickPressureEnemy(wave: number, seed: number): PotassiumEnemyKind {
+  if (wave >= 9 && (wave + seed) % 3 === 0) return 'hardWall';
+  if (wave >= 8 && (wave + seed) % 7 === 0) return 'hardWall';
   const pool: PotassiumEnemyKind[] = wave >= 8
-    ? ['scope', 'deadline', 'hardWall', 'wall', 'splitter', 'shield']
+    ? ['scope', 'deadline', 'wall', 'splitter', 'shield']
     : wave >= 7
       ? ['scope', 'deadline', 'wall', 'splitter', 'shield']
       : ['intern', 'scope', 'wall', 'splitter'];
   return pool[(seed * 3 + wave) % pool.length];
+}
+
+function getPressureLanes(wave: number, rowIndex: number): number[] {
+  const reservedLane = (wave * 2 + rowIndex) % POTASSIUM_COLUMN_COUNT;
+  const lanes = emptyRow()
+    .map((_, lane) => lane)
+    .filter((lane) => lane !== reservedLane);
+  const offset = (wave + rowIndex) % lanes.length;
+  return [
+    ...lanes.slice(offset),
+    ...lanes.slice(0, offset)
+  ].slice(0, wave >= 8 ? 4 : 3);
 }
 
 function pickLane(wave: number, rowIndex: number, salt: number): number {

--- a/src/runtime/potassiumSlipWaves.ts
+++ b/src/runtime/potassiumSlipWaves.ts
@@ -1,7 +1,6 @@
 export type PotassiumEnemyKind =
   | 'intern'
   | 'scope'
-  | 'meeting'
   | 'deadline'
   | 'wall'
   | 'hardWall'
@@ -384,17 +383,17 @@ function placeEnemyInRow(row: PotassiumWaveCell[], lane: number, kind: Potassium
 function pickBasicEnemy(wave: number, seed: number): PotassiumEnemyKind {
   if (wave <= 1) return 'intern';
   if (wave <= 4) return (seed + wave) % 3 === 0 ? 'scope' : 'intern';
-  if (wave <= 6) return ['intern', 'scope', 'meeting', 'splitter'][(seed + wave) % 4] as PotassiumEnemyKind;
-  if (wave <= 7) return ['intern', 'scope', 'meeting', 'deadline', 'splitter'][(seed + wave) % 5] as PotassiumEnemyKind;
-  return ['intern', 'scope', 'meeting', 'deadline', 'splitter', 'shield'][(seed + wave) % 6] as PotassiumEnemyKind;
+  if (wave <= 6) return ['intern', 'scope', 'splitter'][(seed + wave) % 3] as PotassiumEnemyKind;
+  if (wave <= 7) return ['intern', 'scope', 'deadline', 'splitter'][(seed + wave) % 4] as PotassiumEnemyKind;
+  return ['intern', 'scope', 'deadline', 'splitter', 'shield'][(seed + wave) % 5] as PotassiumEnemyKind;
 }
 
 function pickPressureEnemy(wave: number, seed: number): PotassiumEnemyKind {
   const pool: PotassiumEnemyKind[] = wave >= 8
-    ? ['scope', 'meeting', 'deadline', 'wall', 'hardWall', 'splitter', 'shield']
+    ? ['scope', 'deadline', 'hardWall', 'wall', 'splitter', 'shield']
     : wave >= 7
-      ? ['scope', 'meeting', 'deadline', 'wall', 'splitter', 'shield']
-      : ['intern', 'scope', 'meeting', 'wall', 'splitter'];
+      ? ['scope', 'deadline', 'wall', 'splitter', 'shield']
+      : ['intern', 'scope', 'wall', 'splitter'];
   return pool[(seed * 3 + wave) % pool.length];
 }
 


### PR DESCRIPTION
## Summary
- Extract Potassium combat, session flow, boss encounter logic, and renderer responsibilities into focused runtime modules.
- Simplify Potassium wave generation and late-stage blocker behavior, including clearer unbreakable wall visuals and less repetitive late-wave spawning.
- Add and update runtime tests for combat, session, boss, and wave behavior.

## Testing
- `npm test` for the Potassium runtime suites and full project coverage
- `npm run lint`
- `npm run build`