### PR TITLE
Add Ridge trail cards and Stampede sketch prototype

### DIFF
--- a/docs/game-design/README.md
+++ b/docs/game-design/README.md
@@ -8,6 +8,9 @@ This directory separates shipped player-facing behavior from future design conce
 - **[Potassium Slip Manual](./potassium-slip.md)**: Focused guide for the Potassium Slip mini-game.
 - **[Sketchbook Ridge Summit](./sketchbook-ridge-summit.md)**: Post-competition production vision and development plan for the Ridge overworld and opt-in mini-games.
 - **[Sketchbook Ridge Milestone Plan](./sketchbook-ridge-milestone-plan.md)**: Implementation milestone, branch, ownership, and issue-planning map for Ridge Summit.
+- **[Sketchbook Ridge M3 Visual Pack](./sketchbook-ridge-m3-visual-pack.md)**: Rade/Milena visual direction for Cicka, NPCs, landmarks, stickers, and M4 placeholders.
+- **[Sketchbook Ridge M3 Overlay Pack](./sketchbook-ridge-m3-overlay-pack.md)**: Aleksandra's Trail Card, Manual Page, mobile readability, and monochrome reward-state spec.
+- **[Sketchbook Ridge M3 Audio Pack](./sketchbook-ridge-m3-audio-pack.md)**: Django's Ridge, Cicka, Potassium acknowledgement, Stampede, and Telegraph audio direction.
 - **[AI Game Design Competition Archive](./ai-competition/README.md)**: Closed provenance for the competition that produced the current Ridge Summit direction.
 
 ## Core Pillars

--- a/docs/game-design/potassium-slip.md
+++ b/docs/game-design/potassium-slip.md
@@ -33,6 +33,22 @@ Clear 10 procedural campaign waves, defeat the boss on wave 11, and collect the 
 - **Endless:** Wave 12+ continues the same run with existing score, lives, skills, and escalating procedural waves.
 - **Records:** Finished runs are saved to a local top-5 leaderboard in browser storage.
 
+## Ridge Anchor Contract
+
+Potassium Slip is the existing arcade anchor for Sketchbook Ridge. It owns the
+ricochet lane and should remain the benchmark for a deep opt-in mini-game, not
+the template every future mini-game must match.
+
+The Circuit is Potassium's durable world reward and the alternate key for the
+first Relay Spire gate. Future Ridge gate code should check existing inventory
+ownership with `isItemOwned('circuit')`, or the equivalent bridge inventory read,
+instead of adding a separate Ridge progress flag such as `circuitOwned`.
+
+Ridge signs, Trail Cards, NPCs, and stickers may acknowledge Potassium and the
+Circuit, but Potassium run behavior should stay scene-owned: fresh-start entry,
+campaign victory grants the Circuit once, and endless mode continues only inside
+the Potassium scene.
+
 ## Enemies
 
 - **Intern Bug:** Basic small target.

--- a/docs/game-design/sketchbook-ridge-m3-audio-pack.md
+++ b/docs/game-design/sketchbook-ridge-m3-audio-pack.md
@@ -1,0 +1,256 @@
+# Sketchbook Ridge M3 Audio Direction Pack
+
+Owner mode: Django, Music / Sound Designer.
+
+Purpose: implementation-facing audio research for the Ridge, Cicka, Potassium
+acknowledgements, Stampede Sketch, and Telegraph Terrace. This is a spec pack,
+not final asset direction.
+
+Active references:
+
+- `sketchbook-ridge-summit.md`: low-cortisol Ridge, high-spice mini-games,
+  stickers/world memory, Cicka as resident.
+- `style-guide.md`: off-white paper, black ink, stepped handmade feel.
+- `A Short Hike`: calm musical-map layering and movement reward.
+- `Vampire Survivors`: one-stick focus, rapid reward ticks, power spiral.
+- `Clair Obscur`: timing is readable through combined visual and audio cues.
+- `Tunic`: tiny audio motifs can imply hidden knowledge, but Ridge should avoid
+  cryptography homework.
+- `Ball x Pit`: dense action needs EQ thinning, instance limiting, and short
+  cooldowns so the mix stays legible.
+
+## Audio Thesis
+
+- The Ridge should sound like a quiet sketchbook desk that learned to breathe:
+  paper, pencil, muted strings, tiny room tone, and sparse handmade melody.
+- Music should reward movement and landmarks with small layers, not a full
+  dynamic score engine in v1.
+- Mini-games can be louder and more rhythmic, but they should return the player
+  to a calmer Ridge bed without emotional whiplash.
+- Cicka is a resident with opinions, not a UI mascot; her sounds should feel
+  close, dry, and specific.
+- Timing audio can support mastery, but every Telegraph cue needs a primary
+  visual read and an assist-mode fallback.
+
+## Ridge Overworld Loop
+
+Goal: a short seamless loop that can run for several minutes without demanding
+attention. Think "desk at midnight" more than "forest soundtrack."
+
+Palette options:
+
+1. Paper guitar
+   - Nylon or soft electric guitar harmonics.
+   - Sparse two-note motif around open strings.
+   - Gentle pencil taps as irregular percussion.
+   - Best if the Ridge should feel warm and personal.
+
+2. Margin piano
+   - Felt piano or toy piano, very few notes.
+   - Low paper-rustle bed and distant room air.
+   - Occasional reversed pencil scrape into landmark stingers.
+   - Best if the Ridge should feel more reflective.
+
+3. Ink music box
+   - Plucked kalimba/music-box tones with rounded attacks.
+   - Tiny brushed percussion, no bright chimes.
+   - Good for Manual Page and Relay Spire adjacency.
+   - Risk: can become too cute if overused.
+
+Quiet handmade tone rules:
+
+- Keep the main loop narrow and dry; avoid cinematic reverb, huge pads, EDM
+  risers, and glossy trailer percussion.
+- Use imperfect attacks: finger noise, pick scrape, pencil tick, chair creak,
+  soft page turn.
+- Avoid animal/cartoon libraries for Cicka and avoid generic mobile-game
+  reward blips for stamps.
+- One memorable interval is enough. The Ridge motif should be hummable but not
+  attention-seeking.
+
+Layering rules for v1:
+
+- Base layer: always-on low-volume loop, 45-90 seconds, no hard cadence.
+- Movement layer: add a soft pulse only when walking/sprinting for more than
+  1.5 seconds; fade out over 0.5-1.0 seconds when idle.
+- Landmark layer: one short local motif for Relay Spire, Cicka perch, and each
+  Trail Card prop. Trigger once per approach, then cooldown.
+- Reward layer: stamps/manual pages add a one-shot plus a very subtle permanent
+  mix change on the Ridge return, such as an extra pencil counterline.
+- Do not crossfade by exact X coordinate in v1. Use explicit trigger zones and
+  simple gain ramps.
+
+## Cicka SFX Language
+
+Cicka sounds should communicate posture, punctuation, and intent before any
+translator fantasy exists.
+
+Core kit:
+
+- `cicka_meow_notice_01`: short, upward, curious. Used near hidden marks.
+- `cicka_meow_disagree_01`: clipped and dry. Used when blocking or judging.
+- `cicka_meow_satisfied_01`: low, tiny chirrup. Used after a stamp/world change.
+- `cicka_purr_loop_soft_01`: optional near perch only; very quiet, not constant.
+- `cicka_paw_tap_01`: paper tap with claw detail; used for paw-print marks.
+- `cicka_hop_paper_01`: small body thump plus paper rustle.
+
+Rules:
+
+- Cicka should be mostly close-mic, mono or narrow stereo, and quieter than UI
+  confirmation sounds.
+- Use silence as part of the joke. A suspicious turn can be funnier than a meow.
+- Keep repeated meows rate-limited; max one vocal every 4-6 seconds unless the
+  player deliberately interacts.
+- Translator subtitles can reinterpret the same meow later, but the raw sound
+  should still work without text.
+
+## Potassium Acknowledgement Micro-Pack
+
+This pack acknowledges Potassium Slip from the Ridge without changing
+Potassium's scene-owned run behavior, controls, boss, upgrades, or presentation.
+
+Allowed sounds:
+
+- Ridge Trail Card hover/open: a tiny rubbery banana squeak under the paper UI.
+- Circuit acknowledgement: short contact-clean chime plus paper stamp thump.
+- Potassium sign/NPC line: muted office intercom tick or clipboard clack.
+- Return from Potassium with Circuit: one celebratory but restrained two-hit
+  stinger, then immediately settle back into Ridge loop.
+
+Do not:
+
+- Replace Potassium's future in-scene SFX palette from this pack.
+- Add ricochet-heavy sounds to the Ridge; Potassium owns that lane.
+- Make the Circuit stinger louder than a Stampede clear.
+- Add stored Ridge flags for Circuit audio. Implementation should read existing
+  inventory ownership, same as the Ridge gate direction.
+
+Suggested names:
+
+- `ridge_potassium_trailcard_open_01`
+- `ridge_potassium_circuit_ack_01`
+- `ridge_potassium_sign_clack_01`
+- `ridge_potassium_return_circuit_01`
+
+## Stampede Sketch Prototype Audio
+
+The first prototype should prove movement feel before building a dense combat
+mix. Start with simple generated Web Audio or placeholder assets, then replace
+only the sounds that carry the loop.
+
+Movement-only state:
+
+- Player move: optional soft paper-footstep tick, gated by speed and capped to
+  4-6 ticks per second.
+- Enemy proximity: low ink-pressure loop that fades in when the nearest swarm is
+  close. Keep it tonal/noisy, not scary.
+- Near miss: very short brush whoosh, cooldown 250-400 ms.
+- Damage/fail: paper crumple plus low thud, no harsh buzzer.
+- Timer last 10 seconds: add pencil-tap pulse, not an alarm.
+
+Later auto-attack/enemy/XP states:
+
+- Auto-attack fire: quiet, frequent sounds with strict instance limits. The
+  player should feel attacks exist without hearing every projectile.
+- Enemy hit: one family of ink splats with random pitch and 40-80 ms cooldown.
+- Enemy pop: brighter paper tear/snap, limited to 2-4 overlapping instances.
+- XP pickup: tiny ascending pencil/glass tick. Batch pickups into short rolls
+  instead of one sound per orb when many are collected.
+- Level up: paper fan + stamp thump + one clear pitch rise.
+- Upgrade choice: UI should quiet the action bed by 3-6 dB while the overlay is
+  open, then restore quickly.
+
+Mix target:
+
+- Movement and proximity should be readable at low volume.
+- XP and level-up sounds can be more rewarding, but never casino-bright.
+- Late-run density should be felt through rhythm and texture, not through
+  unlimited overlapping SFX.
+
+## Telegraph Timing Cue Notes
+
+Telegraph Terrace should treat audio as a timing helper, not the truth source.
+The primary cue is visual: pose, impact line, screen rhythm, or button affordance
+must communicate the timing window without sound.
+
+Cue shape:
+
+- Wind-up: soft inhale/brush pull, starts with the visual anticipation pose.
+- Ready cue: small high-mid tick or stick click 120-180 ms before the ideal
+  parry point for early patterns.
+- Impact point: dry slap/clack exactly on the parry frame, paired with a visual
+  flash/ink contact.
+- Perfect parry: crisp ring plus 80-120 ms ducked ambience, never too bright.
+- Miss: muted body/paper thud, short recovery, no shame buzzer.
+- Tempo gain: low upward pulse after the successful defense resolves.
+
+Assist mode concerns:
+
+- Assist timing can widen the input window and optionally move the ready cue
+  earlier, but it should also update the visual cue. Do not make assist an
+  audio-only metronome.
+- Provide a reduced-cue option if repeated ticks feel stressful on mobile.
+- Keep attack patterns learnable with screen muted.
+- Avoid cue language where higher pitch always means "press now"; players with
+  limited hearing still need shape, motion, and contrast.
+
+## Web Audio Implementation Constraints For V1
+
+Keep v1 boring technically so the project can ship the feel.
+
+- Create or resume `AudioContext` only after a player gesture. Mobile browsers
+  may keep it suspended until touch/click.
+- Keep Web Audio adapters scene-owned at first, or under `src/game/adapters`
+  once at least two scenes share the same need. Do not put browser audio code in
+  `src/game/core`.
+- No full dynamic music graph in v1. Use named loops, one-shots, simple gain
+  ramps, and per-sound cooldowns.
+- Prefer short compressed assets for final SFX (`.ogg` with fallback only if the
+  target browser check proves it necessary). Generated oscillators are fine for
+  prototype beeps but should not define final Ridge tone.
+- Decode/load audio during scene preload or first intentional entry, not during
+  per-frame update.
+- Every repeating or dense cue needs an instance limit and a cooldown.
+- React overlays should request audio through bridge/adapter-facing actions only
+  if needed later; do not import Phaser into React overlays.
+- When overlays pause a scene, action SFX should stop or duck with the scene.
+  UI confirmation sounds may continue if they are overlay-owned.
+
+Asset naming ideas:
+
+- Pattern: `scene_subject_action_variant`.
+- Use lowercase ASCII, underscores, and two-digit variants.
+- Examples:
+  - `ridge_loop_paper_guitar_01`
+  - `ridge_layer_walk_pencil_01`
+  - `ridge_landmark_relay_spire_01`
+  - `cicka_meow_notice_01`
+  - `stampede_enemy_pop_03`
+  - `stampede_xp_roll_01`
+  - `telegraph_parry_perfect_01`
+  - `telegraph_attack_ready_tick_01`
+
+Volume and mix rules:
+
+- Start with conservative defaults: music around -18 dBFS perceived, common SFX
+  around -12 dBFS, reward stingers around -9 dBFS.
+- Reserve the loudest moment for clear/finale confirmations, not hover sounds.
+- Duck music 3-6 dB under Trail Cards, Manual Pages, upgrade choices, and result
+  overlays.
+- Cicka vocals should sit below UI confirms and above ambience.
+- Timing cues should sit above music but below damage/fail sounds.
+- Add master mute/volume before adding per-category sliders. Per-category mix
+  can wait until dense mini-games prove the need.
+
+## Open Taste Questions For Danilo
+
+- Should the Ridge base loop lean more "paper guitar", "margin piano", or "ink
+  music box"?
+- Should Cicka's raw voice be based on real Cicka-like reference recordings if
+  available, or should it stay designed/abstract?
+- How silly should Potassium acknowledgement be on the Ridge: almost hidden,
+  obviously banana-coded, or office-law absurd?
+- For Telegraph, should the ideal cue feel more like Muay Thai pad work, a
+  rhythm-game click, or a manga impact beat?
+- On return after a first clear, should the permanent Ridge mix change be
+  noticeable, or only felt subconsciously?

--- a/docs/game-design/sketchbook-ridge-m3-overlay-pack.md
+++ b/docs/game-design/sketchbook-ridge-m3-overlay-pack.md
@@ -1,0 +1,231 @@
+# Sketchbook Ridge M3 Overlay Pack
+
+> Aleksandra's overlay and manual-page visual readability pack for M3.
+> This is a practical spec for Trail Cards, Manual Pages, and monochrome
+> reward/locked language. It should guide implementation without creating final
+> art pressure.
+
+## Scope
+
+Use this pack with:
+
+- `docs/game-design/sketchbook-ridge-summit.md`
+- `docs/game-design/sketchbook-ridge-milestone-plan.md`
+- `docs/design/style-guide.md`
+- `.agents/rules/30-react-overlays.md`
+- the current `OverlayDialogFrame`, `DialogCard`, `TrailCardOverlay`, and
+  `ManualPageOverlay` implementation
+
+Do not use archived competition docs as active source of truth.
+
+## Overlay Thesis
+
+- Overlays are pause-breath moments from the Ridge, not separate app screens.
+- Every overlay must read in black and white at phone distance before it earns
+  extra personality.
+- Trail Cards answer one opt-in question: what is this, how long is it, what
+  might I get, and can I enter now?
+- Manual Pages are one-screen "re-see" clues: one idea, one little margin
+  human moment, no lore dump.
+- Paper texture, ink weight, dashed borders, hatching, stamps, and negative
+  space carry state. Color must not carry meaning.
+
+## Implementation Anchors
+
+- React owns overlays through `OverlayHost` and `overlayRegistry`.
+- Phaser scenes own triggers and return behavior.
+- Overlay state must move through the bridge. Do not add Phaser imports,
+  window backdoors, local overlay maps, or polling.
+- The outer frame is `OverlayDialogFrame` -> `DialogCard`: thick black border,
+  off-white paper, hard offset shadow, `max-width: 600px`, and
+  `max-height: 92dvh`.
+- Inner overlay sections should be lightweight paper scraps, not nested shared
+  `Card` or `DialogCard` components.
+
+## Trail Card Visual Spec
+
+### Current Disabled State
+
+Purpose: make the mini-game invitation feel real while honestly saying the
+scene is not wired yet.
+
+- Composition: title in the `DialogCard` heading, then four flat scraps:
+  mood, time, reward, unavailable.
+- Mood: full width, normal sentence case, one sentence.
+- Time and reward: two columns on desktop, stacked on mobile.
+- Unavailable: full width, dashed border, light paper fill, no warning color.
+- Actions: `Back to Ridge` remains secondary. `Enter` remains present but
+  disabled so the future action is visible without being fake.
+- Disabled affordance: use opacity, dashed outline, and/or hatching. Do not use
+  red, yellow, blur, or low-contrast gray text.
+- Tone: copy should feel like a trail sign, not a ticket blocker.
+
+Recommended disabled visual order:
+
+1. Mood scrap.
+2. Time and reward scraps.
+3. Dashed unavailable scrap.
+4. Back and disabled Enter buttons.
+
+### Future Enabled State
+
+Purpose: once a mini-game is wired, the same card becomes a clean opt-in
+launcher.
+
+- Replace the unavailable scrap with a readiness scrap only when useful:
+  `Ready`, `New`, `Replay`, or `Cleared`.
+- Make `Enter` the only filled-ink primary button. `Back to Ridge` stays
+  secondary.
+- If icons are added, use the existing button `icon` prop with a small Lucide
+  icon such as play/door/arrow. Keep the text label for clarity.
+- Completion should not turn the card colorful. Use a stamped mark, filled pip,
+  check stroke, or small tilted paper tab.
+- Replays should still show the reward state: `Stamp owned`, `Glide pip owned`,
+  or `Manual page found`.
+- If a requirement is missing, keep the enabled layout but change the action
+  state to locked rather than inventing a second card layout.
+
+## Manual Page Visual Spec
+
+Manual Pages are not encyclopedia entries. They are evidence that the world can
+be re-read.
+
+### Clue Panel
+
+- The clue panel is the primary reading surface and should occupy most of the
+  overlay body.
+- Use one strong paper area with a thin ink border, notebook rule lines,
+  binder holes, torn-edge marks, or a dog-eared corner.
+- Keep the clue in one or two short sentences. The player should understand the
+  hint without scrolling or parsing a paragraph.
+- Use high-contrast ink. Any existing colored notebook rule should become black
+  ink at reduced opacity before final polish.
+- The clue can be poetic, but it must still point at one route, sign, mechanic,
+  or reward condition.
+
+### Margin Note
+
+- The margin note is flavor, not required instruction.
+- It can sit below the clue on mobile and to the side only if desktop space
+  makes that cleaner.
+- Treat it as handwriting: smaller, looser, funny-sad, and disposable.
+- Do not put critical puzzle information only in the margin note.
+- Use dashed border, tape marks, paw print, or a folded scrap edge instead of a
+  nested card.
+
+### One-Screen Readability
+
+- Default Manual Pages should fit without scrolling at 360 x 640 CSS pixels.
+- Scrolling is acceptable only as an emergency fallback for localization or
+  browser chrome, not as the designed reading mode.
+- The title, clue, margin note, and close button must all be visible together
+  on common phone sizes.
+- The close button must never overlap the title text. Long titles should wrap
+  under the reserved close-button space.
+
+## Mobile Readability And Copy Budgets
+
+Design against 360 x 640, 390 x 844, 768 x 1024, and 1280 x 720.
+
+Trail Card budgets:
+
+- Title: 28 characters target, 36 maximum.
+- Mood: 70 characters target, 95 maximum.
+- Time: 18 characters target, 24 maximum.
+- Reward: 24 characters target, 32 maximum.
+- Unavailable or locked reason: 64 characters target, 88 maximum.
+- Button labels: 14 characters target.
+
+Manual Page budgets:
+
+- Title: 32 characters target, 42 maximum.
+- Clue panel: 110 characters target, 150 maximum.
+- Margin note: 64 characters target, 90 maximum.
+- Labels: 12 characters target.
+
+Typography constraints:
+
+- Do not scale font size with viewport width.
+- Avoid uppercase for multi-sentence reading text.
+- Use handwriting-style text for titles, labels, and margin flavor only. Dense
+  clue reading needs clean, bold, high-contrast text.
+- Preserve `overflow-wrap: anywhere` or equivalent protection for user-visible
+  copy.
+- Minimum touch target for primary actions: 44 x 44 CSS pixels.
+
+## Paper-Cut Component Rules
+
+- Only the outer overlay is a `DialogCard`.
+- Do not place `Card`, `DialogCard`, or a second shadowed surface inside the
+  overlay body.
+- Inner sections are scraps: `section`, `aside`, `dl`, or `div` with a thin
+  border, dashed border, notebook line, tape mark, or simple paper fill.
+- Inner scraps should use small radius only, roughly 4px to 8px. The outer
+  `DialogCard` may keep its current larger radius.
+- Keep the hard offset shadow on the outer frame only. Inner shadows make the
+  overlay feel like cards inside cards.
+- Use `#1a1a1a`, `#fbfbf9`, `#f4f1ea`, `#e8e5df`, white transparency, and ink
+  opacity before introducing any new values.
+- If a repeated shadow, border, or paper value spreads, promote it to shared UI
+  tokens rather than scattering arbitrary classes.
+- Hatching can be CSS, but it must stay subtle and monochrome.
+- A scrap can overlap the clue panel by a few pixels only if it never covers
+  text or controls on mobile.
+
+## Reward And Locked Vocabulary
+
+Use monochrome only. State should survive grayscale, low saturation, and quick
+phone glances.
+
+Rewards:
+
+- Stamp: tilted rubber-stamp outline, heavy ink border, label such as `STAMPED`
+  or the hobby name.
+- Sticker: cut-paper silhouette with thick ink outline, white fill, tiny lifted
+  corner, and no colored fill.
+- Manual Page: dog-eared page, binder holes, notebook lines, or torn strip.
+- Glide Pip: small feather/pip mark. Empty outline means unearned, filled ink
+  means owned.
+- Shortcut: dashed blocked route becomes patched tape, solid arrow, or opened
+  seam.
+- Circuit: black circuit trace with white negative-space spark or banana shape.
+- Cicka Note: paw print, scratch tick, or tiny `meow` bubble near the relevant
+  clue.
+
+Locked or unavailable:
+
+- Dashed border, cross-hatching, hollow stamp, or taped-over action area.
+- Plain copy: `Not wired yet`, `Needs a stamp`, `Find the page first`.
+- Keep text contrast high. Do not use disabled opacity so aggressively that the
+  reason becomes hard to read.
+- No padlock color coding. If a lock icon appears, pair it with text.
+
+## QA Checklist
+
+- Open Ridge with a fast dev route such as `?startScene=ridge`.
+- Open each Trail Card target: Stampede Sketch, Telegraph Terrace, Domino Desk.
+- Open at least one Manual Page fixture or trigger once available.
+- Review 360 x 640, 390 x 844, 768 x 1024, and 1280 x 720 viewports.
+- Confirm there is no horizontal scroll.
+- Confirm normal-budget copy fits without overlay body scrolling.
+- Confirm long title and long locked reason wrap without covering the close
+  button, action buttons, or following scraps.
+- Confirm touch targets are at least 44 x 44 CSS pixels.
+- Confirm the disabled Enter state is visible, understandable, and clearly not
+  clickable.
+- Confirm keyboard focus, Escape/back behavior, and close return to the Ridge.
+- Confirm opening an overlay pauses scene input through the bridge/lifecycle
+  path.
+- Confirm screenshots still communicate reward/locked state in grayscale.
+- Confirm no nested `Card` or `DialogCard` was introduced inside overlay bodies.
+- Confirm no overlay imports Phaser or bypasses the bridge.
+
+## Open Taste Questions For Danilo
+
+- Should Manual Pages feel cleaner, like a field guide, or messier, like a page
+  torn from a private notebook?
+- Should stamps feel official and bureaucratic, or affectionate and doodled?
+- How direct should reward previews be: exact reward names or poetic hints?
+- How silly can margin notes get before they start weakening the clue?
+- Should Cicka marks be rare special tells, or a common clue-language across the
+  Ridge?

--- a/docs/game-design/sketchbook-ridge-m3-visual-pack.md
+++ b/docs/game-design/sketchbook-ridge-m3-visual-pack.md
@@ -1,0 +1,201 @@
+# Sketchbook Ridge M3 Visual Pack
+
+Rade visual direction with Milena character input. This pack is implementation
+guidance, not a final art bible. M4 should be able to ship rough placeholders
+from these specs without waiting for polished drawings.
+
+Active sources: `sketchbook-ridge-summit.md`, `sketchbook-ridge-milestone-plan.md`,
+`docs/design/style-guide.md`, current runtime docs, scoped agent rules, and
+selected research summaries for A Short Hike, Tunic, Vampire Survivors, Clair
+Obscur, Divinity: Original Sin 2, and fighting game feel. Archived competition
+docs are not used as active source of truth.
+
+## Visual Thesis
+
+- The Ridge is a playable sketchbook page: off-white paper, black ink,
+  readable silhouettes, and sticker changes that make the same route feel
+  remembered.
+- Manga influence should appear through composition, negative space, bold ink
+  shapes, and funny-sad margin notes, not expensive frame counts or detailed
+  comic panels everywhere.
+- Every NPC and landmark must read as a silhouette before copy explains it.
+  Text is a bonus, not the first affordance.
+- Art should be modular: base silhouettes, stamp overlays, paper scraps,
+  paw marks, arrows, tape, and ink stains should recombine instead of requiring
+  bespoke redraws.
+- Roughness is allowed when it is intentional and readable. Smudgy, charming,
+  and stepped beats polished-but-generic.
+
+## Global Art Rules
+
+- Palette: paper background plus black ink only. Value comes from line weight,
+  fill density, hatching, stipple, and torn-paper masks.
+- Perspective: 2D side-view with landmark silhouettes staged like a compact
+  ridge trail. Background detail must not compete with interactables.
+- Animation: stepped 10-12 FPS feeling. For M4, static poses plus 1-2 idle
+  swaps are acceptable.
+- Line hierarchy: thick outer contour for foreground interactables, medium
+  contour for NPCs, thin broken lines for background and memory marks.
+- Interaction affordance: wobble, paper lift, ink jitter, or sticker shimmer.
+  Avoid color-dependent signals.
+
+## NPC Silhouette Sheet Spec
+
+Each NPC should have one neutral silhouette, one interaction pose, and one
+post-reward variant. Sheet should work as black shapes on paper before details
+are added.
+
+| NPC | Silhouette Read | Function Read | Required Motifs | Avoid |
+| --- | --- | --- | --- | --- |
+| Cicka | Small low cat shape, tail doing the sentence, ears sharp | Resident, notice-guide, secret marker | Tail punctuation, loaf mass, tiny paws, blink slits | Mascot face, oversized UI pet, human-like talking poses |
+| Ridge Guide | Upright friendly guide with soft triangle poncho or jacket, signpost lean | Orientation and gentle encouragement | Hiking stick or folded map, slightly worried posture, font-license anxiety in props | Tutorial lecturer, generic park ranger, big dialogue-tree stance |
+| Potassium Compliance Officer | Clipboard rectangle plus banana-law cap, stiff side profile | Absurd authority for Potassium hints | Clipboard, tiny badge, caution tape, one pointing hand | Police realism, threatening authority, second ricochet mascot |
+| TODO: AI | Training dummy with unfinished legs and label area | Telegraph or Neutral sparring partner | Box head, visible TODO tag, taped-on arms, one honorable stance | Robot complexity, full humanoid rig, lore-heavy AI design |
+| Printer Oracle | Tall jammed-printer silhouette with oracle posture | Manual-page hint giver | Paper crown, accordion jam trail, prophetic output slot | Clean office printer, readable paragraphs on body, too many moving parts |
+
+### Sheet Layout
+
+- Canvas idea: one horizontal contact sheet with five columns.
+- Row 1: pure filled silhouette at gameplay size.
+- Row 2: line-art silhouette with motifs.
+- Row 3: interaction pose or prop extension.
+- Row 4: post-reward memory overlay, such as sticker, stamp, margin note, or
+  extra paper strip.
+- Minimum implementation read: silhouette still communicates identity at about
+  48-64 px tall in the game camera.
+
+## Cicka Mini Kit Spec
+
+Cicka gets the smallest real kit because she is a resident, not a menu icon.
+These can be implemented as separate placeholder textures or simple sprite
+frames. Tail shape carries most emotion.
+
+| Piece | Visual Spec | Implementation Need |
+| --- | --- | --- |
+| Perch | Cicka sits on a box, warm laptop vent, sign, or suspicious paper edge | Static body or sprite anchored to prop; no pathing required |
+| Blink | Eyes vanish for 2-3 stepped frames; body does not move | Idle timer swap; keep subtle |
+| Loaf | Body becomes a compact ink oval with ears and tail tucked | Alternate idle pose for warm/rest places |
+| Stretch | Long low curve, front paws extended, tail counter-curve | One-shot idle flourish; non-blocking |
+| Suspicious turn | Head/tail rotate toward player, body stays planted | Interaction acknowledgement before translator |
+| Tiny hop | Small up/down hop from perch to nearby mark | Optional tween; no navigation promise |
+| Paw-print mark | Three-to-four bean marks plus tiny scratch arrow | Reusable sticker/memory decal near hidden details |
+| Pre-translator meow bubble | Paper-cut bubble with only "meow", punctuation, or spacing | React/Phaser text can use plain "meow"; no translated subtitle until translator beat |
+
+### Cicka Emotion Grammar
+
+- Tail vertical: alert, noticed something.
+- Tail curled around paws: content, safe place.
+- Tail horizontal point: "look there."
+- Tail question mark: suspicious or teasing.
+- Ears forward: curiosity.
+- Ears flat: Potassium is loud or printer is doing theology again.
+
+## Landmark Silhouette Board
+
+Landmarks must work like map anchors from A Short Hike: the player should
+understand the route by looking, not by opening a map. Each board entry needs
+a far silhouette, near/interact composition, and post-reward memory overlay.
+
+| Landmark | Far Silhouette | Near Composition | Memory / Sticker Hook |
+| --- | --- | --- | --- |
+| Relay Spire | Tall thin ink tower with paper antenna forks, visible early above ridge | Base sign half-decoded by manual scrap; cables look hand-taped | Signal stickers climb upward; final "sent" stamp can cap the antenna |
+| Basement hatch | Low rectangular hatch, chunky handle, underground hatching below trail | Familiar current-content bridge, staged as a sketchbook trapdoor | Tape label, glasses mark, small arrow back to known work |
+| Potassium hint | Banana-shaped warning sign or ricochet diagram pinned to rock | Compliance tape, clipboard note, arrow toward arcade secret | Circuit stamp, banana-law seal, rebound arc doodle |
+| Stampede picnic blanket / ink swarm | Blanket diamond with small black swarm cloud rising behind it | Picnic props threatened by overexcited ink ideas; clear Trail Card prop | Glide pip sticker, swarm becomes friendlier background doodles |
+| Telegraph terrace / bag | Cliff ledge with hanging heavy bag and three timing marks | Bag silhouette at readable impact height; TODO: AI may stand nearby | Rhythm ticks, tempo stamp, manual glyph scrap |
+| Domino desk / elevator | Messy desk skyline with domino rectangles and small service elevator | Tape, coffee rings, pushable-looking blocks, elevator gate | Shortcut arrow, elevator permit sticker, deterministic path lines |
+
+### Board Rules
+
+- Far silhouettes should use fewer than three dominant shapes each.
+- Near compositions can add jokes, but the interaction prop must be the darkest
+  readable object in its cluster.
+- Post-reward overlays should be additive. Do not swap the whole landmark if a
+  sticker, scrap, hatching change, or route marker can do the job.
+
+## Sticker / Ink-Memory Vocabulary
+
+Stickers are the visible reward language. They should feel placed by the Ridge,
+not unlocked by a menu.
+
+| Vocabulary Item | Use | Shape Rules |
+| --- | --- | --- |
+| Stamp | Durable hobby clear proof | Thick border, imperfect circle/square, one bold icon |
+| Sticker patch | World changed by reward | Slight paper lift shadow, peeled corner, taped edge |
+| Manual scrap | Knowledge clue or Relay decoding | Torn rectangle, one diagram, one phrase max |
+| Paw mark | Cicka noticed something | Tiny repeated beans, can point with scratch arrow |
+| Ink memory | The world remembers a clear | Faint hatching, ghost doodle, old attempt crossed out |
+| Route arrow | Backtracking or shortcut readability | Hand-drawn arrow, never neon, paired with physical prop |
+| Tape strip | Patch, permit, or construction gag | Two rough strips max per landmark cluster |
+| Impact burst | Parry, stamp, or Stampede hit feedback | Starburst or ink splat; use sparingly so it stays legible |
+| Swarm dot | Stampede enemy/idea language | Small black flecks with varied size; cap density near player |
+| Signal line | Relay/progress motif | Broken upward strokes, can connect stickers toward Spire |
+
+### Memory Layer Priority
+
+1. Gameplay readability: path, interactable, reward state.
+2. Emotional memory: "the Ridge remembers I did this."
+3. Joke layer: margin line, tiny dispute, absurd label.
+
+If a sticker makes interaction less clear, remove or fade the sticker.
+
+## M4 Placeholder Rules
+
+M4 Stampede and Ridge implementation can move with placeholders if they obey
+the read of this pack.
+
+- Use simple black silhouettes on paper: rectangles, ovals, triangles, torn
+  scraps, and hand-drawn arcs are enough.
+- Name placeholders by role, not final-art promise, for example
+  `stampede_picnic_blanket_placeholder`, `cicka_perch_placeholder`, and
+  `relay_spire_silhouette_placeholder`.
+- Build props as separate layers where practical: base landmark, interaction
+  prop, memory sticker. This keeps M5 Ridge Memory cheap.
+- Prefer one static texture plus a wobble/tint/scale pulse over incomplete
+  animation sets.
+- Cicka placeholder minimum: perch silhouette, blink swap, paw-print decal,
+  "meow" bubble.
+- NPC placeholder minimum: filled silhouette, one prop motif, one interaction
+  affordance.
+- Stampede placeholder minimum: picnic blanket, enemy swarm dots, XP ink drops,
+  one auto-attack doodle, result stamp icon.
+- Telegraph and Domino can remain inert landmark silhouettes until their scenes
+  exist. Their Trail Cards should not imply playable behavior before wiring.
+- Do not introduce a shared asset pipeline or generic mini-game art framework
+  for M4. Scene-owned placeholders are fine until repeated pain is proven.
+- Keep placeholder art monochrome and readable at mobile crop. If it only reads
+  on desktop, simplify the silhouette.
+
+## Implementation Handoff Notes
+
+- Ridge scene owns landmark placement, triggers, and placeholder sticker layer.
+- Trail Cards and Manual Pages remain React overlay surfaces; this pack only
+  defines visual language they can echo.
+- Durable reward state should stay small. Stickers can be derived from stamps,
+  manual pages, glide pips, shortcuts, or Potassium Circuit ownership.
+- Audio cues may reinforce timing and reward beats, but visual cues must carry
+  the meaning without sound. Telegraph timing especially needs visual ticks plus
+  any sound cue.
+
+## Open Taste Questions For Danilo
+
+These are taste calls, not implementation blockers.
+
+1. Should Cicka be drawn as a near-solid black cat silhouette, or as a lighter
+   outline-and-hatching cat with black tail/ear accents?
+2. How weird should the Printer Oracle be: "office object being dramatic" or
+   "almost religious sketchbook artifact"?
+3. Should the Relay Spire feel more handmade radio tower, manga antenna shrine,
+   or messy contact-device sculpture?
+4. Are the stickers allowed to look intentionally childish, or should they stay
+   closer to clean monochrome graphic-design marks?
+5. For Stampede, should the ink swarm read more like cute overexcited ideas or
+   like anxious deadline pressure with jokes around the edge?
+
+## Verification
+
+- Changed file path: `docs/game-design/sketchbook-ridge-m3-visual-pack.md`
+- Verification run: `perl -ne 'print if /[^\x00-\x7F]/' docs/game-design/sketchbook-ridge-m3-visual-pack.md`
+  returned no output, confirming ASCII-only content.
+- Verification run: `git diff --check -- docs/game-design/sketchbook-ridge-m3-visual-pack.md`
+  returned no output.

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -19,6 +19,22 @@ The first complete milestone should prove:
 
 Anything beyond that is future scope unless a slice explicitly pulls it in.
 
+## Current Implementation Status
+
+- **M1 Ridge Shell** is complete for the current placeholder slice: Ridge can
+  boot directly with `?startScene=ridge`, uses shared side-view movement, shows
+  the Relay Spire, Cicka's first perch, a static Ridge Guide, and three Trail
+  Card props.
+- **M2 Trail Card and Manual Overlay Surface** has started: the reusable global
+  Trail Card overlay and Ridge trigger contract are in place. Remaining M2 work
+  is the Manual Page overlay decision, mobile/readability pass, and surface
+  polish.
+- **M3 Art and Audio Research Pack** can run in parallel as spec work. It should
+  guide Cicka, Guide, Trail Card, Manual Page, Stampede, Relay Spire, and audio
+  direction without blocking rough engineering prototypes.
+- **M4 Stampede Sketch Prototype** should start after M2 is stable enough to
+  enable a movement-only Stampede scene from the Stampede Trail Card.
+
 ## Production Crew
 
 Role contracts and activation phrases live in

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -33,9 +33,11 @@ Anything beyond that is future scope unless a slice explicitly pulls it in.
   audio direction packs now guide Cicka, Guide, Trail Card, Manual Page,
   Stampede, Relay Spire, and Ridge audio without blocking rough engineering
   prototypes.
-- **M4 Stampede Sketch Prototype** has started with the M4a movement-feel
-  tracer bullet: the Stampede Trail Card can enter a movement-only arena, while
-  rewards, attacks, XP, upgrades, and results remain future M4 slices.
+- **M4 Stampede Sketch Prototype** has started with M4a movement accepted and
+  M4b pressure-loop work in progress: the Stampede Trail Card can enter a
+  scene-local arena with timer, page-noise cadence, soft contact feedback, and
+  return to Ridge, while rewards, attacks, XP, upgrades, and result overlays
+  remain future M4 slices.
 
 ## Production Crew
 
@@ -205,9 +207,10 @@ Owner: Stampede scene.
 Outputs:
 
 - `src/game/scenes/stampedeSketch/**`.
-- 60-90 second move-only survivor prototype. First slice is M4a movement feel:
-  direct entry from the Stampede Trail Card, top-down 8-way movement, pointer
-  drag steering, harmless capped swarm pressure, and return to Ridge.
+- 60-90 second survivor prototype. M4a movement feel covers direct entry from
+  the Stampede Trail Card, top-down 8-way movement, pointer drag steering, and
+  return to Ridge. M4b adds a scene-local page-noise cadence, pressure HUD,
+  capped swarm surges, and soft contact feedback before reward wiring.
 - capped enemies.
 - auto-attacks.
 - XP pickups.

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -119,6 +119,10 @@ Goal: make the main game shape playable with placeholders.
 
 Owner: Ridge scene.
 
+Start Ridge as a separate `ridge` scene first. Keep the current overworld as
+the default route until the Ridge shell feels good. During development, boot
+directly into Ridge with `?startScene=ridge` for fast iteration.
+
 Outputs:
 
 - `src/game/scenes/ridge/**`.

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -25,15 +25,17 @@ Anything beyond that is future scope unless a slice explicitly pulls it in.
   boot directly with `?startScene=ridge`, uses shared side-view movement, shows
   the Relay Spire, Cicka's first perch, a static Ridge Guide, and three Trail
   Card props.
-- **M2 Trail Card and Manual Overlay Surface** has started: the reusable global
-  Trail Card overlay, reusable Manual Page overlay shape, and Ridge trigger
-  contract are in place. Remaining M2 work is the mobile/readability pass and
-  surface polish.
-- **M3 Art and Audio Research Pack** can run in parallel as spec work. It should
-  guide Cicka, Guide, Trail Card, Manual Page, Stampede, Relay Spire, and audio
-  direction without blocking rough engineering prototypes.
-- **M4 Stampede Sketch Prototype** should start after M2 is stable enough to
-  enable a movement-only Stampede scene from the Stampede Trail Card.
+- **M2 Trail Card and Manual Overlay Surface** is complete for the current
+  prototype slice: the reusable global Trail Card overlay, reusable Manual Page
+  overlay shape, Ridge trigger contract, and mobile/readability polish are in
+  place.
+- **M3 Art and Audio Research Pack** is in review: visual, overlay/manual, and
+  audio direction packs now guide Cicka, Guide, Trail Card, Manual Page,
+  Stampede, Relay Spire, and Ridge audio without blocking rough engineering
+  prototypes.
+- **M4 Stampede Sketch Prototype** should start after Danilo reviews the key M3
+  taste calls, with a movement-only Stampede scene enabled from the Stampede
+  Trail Card once the empty scene exists.
 
 ## Production Crew
 
@@ -184,6 +186,12 @@ Outputs:
 - sticker / ink-memory vocabulary.
 - Trail Card and Manual Page visual specs.
 - Ridge audio palette, Cicka SFX language, Potassium acknowledgement micro-pack, Stampede prototype audio notes.
+
+Current review packs:
+
+- [`sketchbook-ridge-m3-visual-pack.md`](./sketchbook-ridge-m3-visual-pack.md)
+- [`sketchbook-ridge-m3-overlay-pack.md`](./sketchbook-ridge-m3-overlay-pack.md)
+- [`sketchbook-ridge-m3-audio-pack.md`](./sketchbook-ridge-m3-audio-pack.md)
 
 These are research/spec deliverables. They should not block engineering beyond
 basic silhouette placeholders.
@@ -352,9 +360,15 @@ What to build:
 - Cicka mini kit spec.
 - landmark silhouette board.
 - sticker/ink-memory vocabulary.
-- one Trail Card and one Manual Page visual mock.
+- Trail Card and Manual Page visual direction.
 
-Human review required because visual taste and Cicka personality matter.
+Current draft:
+[`sketchbook-ridge-m3-visual-pack.md`](./sketchbook-ridge-m3-visual-pack.md)
+and
+[`sketchbook-ridge-m3-overlay-pack.md`](./sketchbook-ridge-m3-overlay-pack.md).
+
+Human review required because visual taste, overlay tone, and Cicka personality
+matter.
 
 ### 8. Produce Ridge Audio Direction Pack
 
@@ -368,6 +382,9 @@ What to build:
 - Potassium acknowledgement micro-pack.
 - Stampede prototype audio notes.
 - Telegraph timing cue notes.
+
+Current draft:
+[`sketchbook-ridge-m3-audio-pack.md`](./sketchbook-ridge-m3-audio-pack.md).
 
 Human review required before committing to music direction.
 

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -26,9 +26,9 @@ Anything beyond that is future scope unless a slice explicitly pulls it in.
   the Relay Spire, Cicka's first perch, a static Ridge Guide, and three Trail
   Card props.
 - **M2 Trail Card and Manual Overlay Surface** has started: the reusable global
-  Trail Card overlay and Ridge trigger contract are in place. Remaining M2 work
-  is the Manual Page overlay decision, mobile/readability pass, and surface
-  polish.
+  Trail Card overlay, reusable Manual Page overlay shape, and Ridge trigger
+  contract are in place. Remaining M2 work is the mobile/readability pass and
+  surface polish.
 - **M3 Art and Audio Research Pack** can run in parallel as spec work. It should
   guide Cicka, Guide, Trail Card, Manual Page, Stampede, Relay Spire, and audio
   direction without blocking rough engineering prototypes.

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -123,6 +123,9 @@ Start Ridge as a separate `ridge` scene first. Keep the current overworld as
 the default route until the Ridge shell feels good. During development, boot
 directly into Ridge with `?startScene=ridge` for fast iteration.
 
+Keep the first movement shell flat and readable. Use visual height changes,
+landmark silhouettes, and prop staging before adding real vertical traversal.
+
 Outputs:
 
 - `src/game/scenes/ridge/**`.

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -33,9 +33,9 @@ Anything beyond that is future scope unless a slice explicitly pulls it in.
   audio direction packs now guide Cicka, Guide, Trail Card, Manual Page,
   Stampede, Relay Spire, and Ridge audio without blocking rough engineering
   prototypes.
-- **M4 Stampede Sketch Prototype** should start after Danilo reviews the key M3
-  taste calls, with a movement-only Stampede scene enabled from the Stampede
-  Trail Card once the empty scene exists.
+- **M4 Stampede Sketch Prototype** has started with the M4a movement-feel
+  tracer bullet: the Stampede Trail Card can enter a movement-only arena, while
+  rewards, attacks, XP, upgrades, and results remain future M4 slices.
 
 ## Production Crew
 
@@ -205,7 +205,9 @@ Owner: Stampede scene.
 Outputs:
 
 - `src/game/scenes/stampedeSketch/**`.
-- 60-90 second move-only survivor prototype.
+- 60-90 second move-only survivor prototype. First slice is M4a movement feel:
+  direct entry from the Stampede Trail Card, top-down 8-way movement, pointer
+  drag steering, harmless capped swarm pressure, and return to Ridge.
 - capped enemies.
 - auto-attacks.
 - XP pickups.

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -33,11 +33,12 @@ Anything beyond that is future scope unless a slice explicitly pulls it in.
   audio direction packs now guide Cicka, Guide, Trail Card, Manual Page,
   Stampede, Relay Spire, and Ridge audio without blocking rough engineering
   prototypes.
-- **M4 Stampede Sketch Prototype** has started with M4a movement accepted and
-  M4b pressure-loop work in progress: the Stampede Trail Card can enter a
-  scene-local arena with timer, page-noise cadence, soft contact feedback, and
-  return to Ridge, while rewards, attacks, XP, upgrades, and result overlays
-  remain future M4 slices.
+- **M4 Stampede Sketch Prototype** is underway with M4a movement accepted and
+  M4b pressure loop accepted as good enough for the current prototype slice:
+  the Stampede Trail Card can enter a scene-local arena with timer,
+  page-noise cadence, pressure HUD, capped swarm surges, pressure-aware swarm
+  motion, soft contact feedback, and return to Ridge. Rewards, attacks, XP,
+  upgrades, and result overlays remain future M4 slices.
 
 ## Production Crew
 
@@ -220,6 +221,34 @@ Outputs:
 
 Depends on M0 and the Ridge trigger contract from M1. Most scene internals can
 be built independently.
+
+Current checkpoint:
+
+- **M4a Movement Feel** accepted: direct entry from the Stampede Trail Card,
+  top-down 8-way movement, pointer drag steering, vertical-board presentation,
+  and return to Ridge are in place.
+- **M4b Pressure Loop** accepted for prototype continuation: session timer,
+  page-noise cadence, pressure HUD, capped swarm surges, contact limit, soft
+  contact feedback, and pressure-aware swarm motion are in place.
+- Scene architecture is intentionally scene-local. `StampedeSketchScene` should
+  remain the Phaser adapter/orchestrator while run decisions live behind
+  `runtime/runFlow.ts` and swarm steering lives behind `runtime/swarmMotion.ts`.
+
+Next implementation slices:
+
+1. **M4c Run Ending Shell**: add a scene-local end surface for `Blanket held`
+   and `Page got crowded`, with Retry and Back to Ridge actions. Keep rewards
+   disabled.
+2. **M4d First Auto-Attack Toy**: add one automatic pencil swipe or ink orbit
+   that can clear pressure marks. Do not add XP or upgrade drafting yet.
+3. **M4e Pickup / Upgrade Draft**: add the first XP pickup loop and a rough
+   three-choice upgrade draft once the attack toy feels readable.
+
+Hold until later:
+
+- Enemy-enemy avoidance beyond pressure-aware steering.
+- Durable reward ids, first-clear stamp, glide pip, and Ridge memory rendering.
+- Player manual updates; Stampede is still dev/prototype behavior.
 
 ### M5: Ridge Memory
 

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -34,7 +34,10 @@ and scales with `Scale.ENVELOP`. React owns the visible shell aspect ratio:
 
 - `portrait-cover` is the default for side-view player scenes on phones. The shell is portrait, overflow is clipped, and the shared side-view camera runtime follows/clamps the player so cover-mode crop does not reveal off-world space.
 - `full-board` is for arcade scenes where the whole landscape board must remain visible.
-- `vertical-board` is for portrait arcade scenes such as Potassium. The shell is tall, Phaser still uses the fixed logical design size with `Scale.ENVELOP`, and direct Phaser pointer input is preserved instead of the React swipe/tap gesture overlay.
+- `vertical-board` is for portrait arcade scenes such as Potassium and the
+  first Stampede movement prototype. The shell is tall, Phaser still uses the
+  fixed logical design size with `Scale.ENVELOP`, and direct Phaser pointer
+  input is preserved instead of the React swipe/tap gesture overlay.
 
 When a scene changes presentation mode, `src/game/shell/Game.tsx` keeps the
 existing Phaser instance mounted and calls `game.scale.refresh()` after the new
@@ -46,8 +49,9 @@ re-apply camera bounds/profile math.
 - Add new Phaser worlds under `src/game/scenes/<scene>/` with a scene context and, when loadable, a scene registry entry.
 - Keep scene triggers in the owning scene. A trigger should call `enterScene(sceneId)` or `openOverlay(overlayId, options)` through the bridge callback it receives at scene start.
 - Use overlay options for scene-owned overlay params and return intent. Ridge
-  Trail Cards use this path to show reusable entry cards while mini-game entry
-  stays disabled until the target scene exists.
+  Trail Cards use this path to show reusable entry cards. Stampede can enter
+  its movement prototype from the Trail Card, while later Ridge props stay
+  disabled until their target scenes exist.
 - Put scene-local overlays under `src/game/scenes/<scene>/overlays` and export overlay definitions from that scene. Put shared/global overlays under `src/game/overlays`.
 - Use `src/game/overlays/OverlayHost.tsx` for overlay rendering. Do not add local React overlay maps to shell or scene code.
 - Use `sceneResumePolicy` for resume persistence and reset rules. The low-level resume store should not be imported directly by scenes or adapters.
@@ -109,7 +113,7 @@ After changes that touch Phaser boot, bridge, scene lifecycle, scenes, or overla
 1. **Overworld** — canvas loads; move left/right, jump, interact near a building.
 2. **Hobbies** — enter hobbies (building or `H` where applicable); walk; interact with an interior target; exit (`H` / `Esc` / close flow) returns to overworld.
 3. **Basement** — enter the Developer Basement; interact with the computer before glasses to see the character thought, then collect glasses and confirm the Developer Console opens and closes back to the basement scene.
-4. **Ridge** — in development, boot `?startScene=ridge`; confirm the separate Ridge shell renders, uses shared side-view movement, and does not replace the default overworld. Walk near a Trail Card prop, interact, confirm the card opens with a disabled primary action, then close back to Ridge.
+4. **Ridge / Stampede** — in development, boot `?startScene=ridge`; confirm the separate Ridge shell renders, uses shared side-view movement, and does not replace the default overworld. Walk near the Stampede Trail Card prop, interact, confirm the card opens and `Enter` starts Stampede Sketch. Move in the Stampede arena, return to Ridge, then confirm Telegraph/Domino Trail Cards remain unavailable.
 5. **React overlays** — open a building overlay from the street; close it; no stuck keyboard focus in the canvas.
 6. **Pause / input** — with a React overlay open, scene pause propagates (no gameplay input leaking); closing overlay resumes the parent scene or overworld input.
 

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -45,6 +45,9 @@ re-apply camera bounds/profile math.
 
 - Add new Phaser worlds under `src/game/scenes/<scene>/` with a scene context and, when loadable, a scene registry entry.
 - Keep scene triggers in the owning scene. A trigger should call `enterScene(sceneId)` or `openOverlay(overlayId, options)` through the bridge callback it receives at scene start.
+- Use overlay options for scene-owned overlay params and return intent. Ridge
+  Trail Cards use this path to show reusable entry cards while mini-game entry
+  stays disabled until the target scene exists.
 - Put scene-local overlays under `src/game/scenes/<scene>/overlays` and export overlay definitions from that scene. Put shared/global overlays under `src/game/overlays`.
 - Use `src/game/overlays/OverlayHost.tsx` for overlay rendering. Do not add local React overlay maps to shell or scene code.
 - Use `sceneResumePolicy` for resume persistence and reset rules. The low-level resume store should not be imported directly by scenes or adapters.
@@ -106,7 +109,7 @@ After changes that touch Phaser boot, bridge, scene lifecycle, scenes, or overla
 1. **Overworld** — canvas loads; move left/right, jump, interact near a building.
 2. **Hobbies** — enter hobbies (building or `H` where applicable); walk; interact with an interior target; exit (`H` / `Esc` / close flow) returns to overworld.
 3. **Basement** — enter the Developer Basement; interact with the computer before glasses to see the character thought, then collect glasses and confirm the Developer Console opens and closes back to the basement scene.
-4. **Ridge** — in development, boot `?startScene=ridge`; confirm the separate Ridge shell renders, uses shared side-view movement, and does not replace the default overworld.
+4. **Ridge** — in development, boot `?startScene=ridge`; confirm the separate Ridge shell renders, uses shared side-view movement, and does not replace the default overworld. Walk near a Trail Card prop, interact, confirm the card opens with a disabled primary action, then close back to Ridge.
 5. **React overlays** — open a building overlay from the street; close it; no stuck keyboard focus in the canvas.
 6. **Pause / input** — with a React overlay open, scene pause propagates (no gameplay input leaking); closing overlay resumes the parent scene or overworld input.
 

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -106,8 +106,9 @@ After changes that touch Phaser boot, bridge, scene lifecycle, scenes, or overla
 1. **Overworld** — canvas loads; move left/right, jump, interact near a building.
 2. **Hobbies** — enter hobbies (building or `H` where applicable); walk; interact with an interior target; exit (`H` / `Esc` / close flow) returns to overworld.
 3. **Basement** — enter the Developer Basement; interact with the computer before glasses to see the character thought, then collect glasses and confirm the Developer Console opens and closes back to the basement scene.
-4. **React overlays** — open a building overlay from the street; close it; no stuck keyboard focus in the canvas.
-5. **Pause / input** — with a React overlay open, scene pause propagates (no gameplay input leaking); closing overlay resumes the parent scene or overworld input.
+4. **Ridge** — in development, boot `?startScene=ridge`; confirm the separate Ridge shell renders, uses shared side-view movement, and does not replace the default overworld.
+5. **React overlays** — open a building overlay from the street; close it; no stuck keyboard focus in the canvas.
+6. **Pause / input** — with a React overlay open, scene pause propagates (no gameplay input leaking); closing overlay resumes the parent scene or overworld input.
 
 Record pass/fail in the PR or release notes when shipping runtime changes.
 

--- a/docs/runtime-modes.md
+++ b/docs/runtime-modes.md
@@ -22,6 +22,8 @@ for fast iteration. Current useful targets include `hobbies`, `basement`,
 
 - `src/game/bridge/store.ts` owns observable cross-boundary state and actions:
   `enterScene`, `returnToOverworld`, `openOverlay`, and `closeOverlay`.
+  `openOverlay(overlayId, options)` can carry overlay params and return-scene
+  intent from Phaser scenes to React overlays.
 - `src/game/sceneLifecycle/SceneLifecycleController.ts` maps bridge scene changes to
   `SceneManager` transitions and maps pause changes to active Phaser scenes.
 - `src/game/overlays/OverlayHost.tsx` renders React overlays from the active
@@ -39,6 +41,9 @@ Use this path when checking pattern refactors:
 4. Open and close a hobby overlay from inside the hobbies scene.
 5. Enter the Developer Basement, open the computer console, and close it back
    to the basement scene.
-6. Boot `?startScene=ridge`; verify the Ridge shell renders and movement works.
+6. Boot `?startScene=ridge`; verify the Ridge shell renders, movement works,
+   and walking near a Stampede/Telegraph/Domino prop shows `[E] INTERACT`.
+   Interact to open the Trail Card, confirm its primary action is disabled while
+   the target scene is unavailable, then close back to Ridge.
 7. Open inventory from the overworld and from a child scene.
 8. Verify mobile touch movement, jump, and interact one-shots.

--- a/docs/runtime-modes.md
+++ b/docs/runtime-modes.md
@@ -12,6 +12,12 @@ code remains the source of truth.
 - `loadingSceneId`: the scene currently being lazy-loaded, or `null`.
 - `isPaused`: derived in the bridge from active overlay or scene loading state.
 
+## Dev Starts
+
+In development, `?startScene=<sceneId>` can boot directly into a Phaser scene
+for fast iteration. Current useful targets include `hobbies`, `basement`,
+`potassium`, and `ridge`.
+
 ## Transition Owners
 
 - `src/game/bridge/store.ts` owns observable cross-boundary state and actions:
@@ -33,5 +39,6 @@ Use this path when checking pattern refactors:
 4. Open and close a hobby overlay from inside the hobbies scene.
 5. Enter the Developer Basement, open the computer console, and close it back
    to the basement scene.
-6. Open inventory from the overworld and from a child scene.
-7. Verify mobile touch movement, jump, and interact one-shots.
+6. Boot `?startScene=ridge`; verify the Ridge shell renders and movement works.
+7. Open inventory from the overworld and from a child scene.
+8. Verify mobile touch movement, jump, and interact one-shots.

--- a/docs/runtime-modes.md
+++ b/docs/runtime-modes.md
@@ -16,7 +16,7 @@ code remains the source of truth.
 
 In development, `?startScene=<sceneId>` can boot directly into a Phaser scene
 for fast iteration. Current useful targets include `hobbies`, `basement`,
-`potassium`, and `ridge`.
+`potassium`, `ridge`, and `stampedeSketch`.
 
 ## Transition Owners
 
@@ -43,7 +43,8 @@ Use this path when checking pattern refactors:
    to the basement scene.
 6. Boot `?startScene=ridge`; verify the Ridge shell renders, movement works,
    and walking near a Stampede/Telegraph/Domino prop shows `[E] INTERACT`.
-   Interact to open the Trail Card, confirm its primary action is disabled while
-   the target scene is unavailable, then close back to Ridge.
+   Interact with the Stampede prop to open its Trail Card, confirm `Enter`
+   starts Stampede Sketch, move in the arena, and return to Ridge. Telegraph and
+   Domino cards should still keep primary entry disabled.
 7. Open inventory from the overworld and from a child scene.
 8. Verify mobile touch movement, jump, and interact one-shots.

--- a/src/game/bridge/store.test.ts
+++ b/src/game/bridge/store.test.ts
@@ -3,8 +3,11 @@ import {
   bridgeActions,
   bridgeStore,
   getTouchState,
+  hasRidgeManualPage,
+  hasRidgeStamp,
   isItemEquipped,
   isItemOwned,
+  isRidgeShortcutUnlocked,
   isSecretDiscovered
 } from './store';
 import { OVERWORLD_SCENE_ID } from '@/game/scenes/sceneIds';
@@ -157,6 +160,14 @@ describe('bridgeStore', () => {
     it('starts without glasses', () => {
       expect(bridgeStore.getState().progress.hasGlasses).toBe(false);
       expect(bridgeStore.getState().progress.discoveredSecretIds).toEqual([]);
+      expect(bridgeStore.getState().progress.ridge).toEqual({
+        stampIds: [],
+        manualPageIds: [],
+        mobility: {
+          glidePips: 0
+        },
+        shortcutIds: []
+      });
       expect(bridgeStore.getState().inventory.ownedItemIds).toEqual([]);
       expect(bridgeStore.getState().equipment.equippedItemIds).toEqual([]);
     });
@@ -175,6 +186,14 @@ describe('bridgeStore', () => {
       bridgeActions.resetProgress();
       expect(bridgeStore.getState().progress.hasGlasses).toBe(false);
       expect(bridgeStore.getState().progress.discoveredSecretIds).toEqual([]);
+      expect(bridgeStore.getState().progress.ridge).toEqual({
+        stampIds: [],
+        manualPageIds: [],
+        mobility: {
+          glidePips: 0
+        },
+        shortcutIds: []
+      });
       expect(bridgeStore.getState().inventory.ownedItemIds).toEqual([]);
       expect(bridgeStore.getState().equipment.equippedItemIds).toEqual([]);
     });
@@ -195,6 +214,44 @@ describe('bridgeStore', () => {
       bridgeActions.resetProgress();
       expect(bridgeStore.getState().progress.discoveredSecretIds).toEqual([]);
       expect(isSecretDiscovered('banana-peel-clue')).toBe(false);
+    });
+
+    it('awards Ridge stamps once by id', () => {
+      bridgeActions.awardRidgeStamp('stampede-sketch');
+      bridgeActions.awardRidgeStamp('stampede-sketch');
+      expect(bridgeStore.getState().progress.ridge.stampIds).toEqual(['stampede-sketch']);
+      expect(hasRidgeStamp('stampede-sketch')).toBe(true);
+    });
+
+    it('awards Ridge manual pages once by id', () => {
+      bridgeActions.awardRidgeManualPage('relay-sign');
+      bridgeActions.awardRidgeManualPage('relay-sign');
+      expect(bridgeStore.getState().progress.ridge.manualPageIds).toEqual(['relay-sign']);
+      expect(hasRidgeManualPage('relay-sign')).toBe(true);
+    });
+
+    it('adds Ridge glide pips from explicit reward actions', () => {
+      bridgeActions.awardRidgeGlidePip();
+      bridgeActions.awardRidgeGlidePip(2);
+      bridgeActions.awardRidgeGlidePip(0);
+      expect(bridgeStore.getState().progress.ridge.mobility.glidePips).toBe(3);
+    });
+
+    it('unlocks Ridge shortcuts once by id', () => {
+      bridgeActions.unlockRidgeShortcut('outskirts-lift');
+      bridgeActions.unlockRidgeShortcut('outskirts-lift');
+      expect(bridgeStore.getState().progress.ridge.shortcutIds).toEqual(['outskirts-lift']);
+      expect(isRidgeShortcutUnlocked('outskirts-lift')).toBe(true);
+    });
+
+    it('keeps Potassium Circuit ownership derived from inventory', () => {
+      bridgeActions.awardRidgeStamp('stampede-sketch');
+      expect(isItemOwned('circuit')).toBe(false);
+      expect(bridgeStore.getState().progress.ridge).not.toHaveProperty('circuitOwned');
+
+      bridgeActions.collectItem('circuit');
+      expect(isItemOwned('circuit')).toBe(true);
+      expect(bridgeStore.getState().progress.ridge).not.toHaveProperty('circuitOwned');
     });
   });
 

--- a/src/game/bridge/store.ts
+++ b/src/game/bridge/store.ts
@@ -25,9 +25,23 @@ export interface BridgeEquipmentState {
   equippedItemIds: InventoryItemId[];
 }
 
+export type RidgeStampId = string;
+export type RidgeManualPageId = string;
+export type RidgeShortcutId = string;
+
+export interface BridgeRidgeProgressState {
+  stampIds: RidgeStampId[];
+  manualPageIds: RidgeManualPageId[];
+  mobility: {
+    glidePips: number;
+  };
+  shortcutIds: RidgeShortcutId[];
+}
+
 export interface BridgeProgressState {
   hasGlasses: boolean;
   discoveredSecretIds: SecretDiscoveryId[];
+  ridge: BridgeRidgeProgressState;
 }
 
 export interface OverlayRequest {
@@ -76,6 +90,17 @@ function arraysEqual<T>(a: readonly T[], b: readonly T[]): boolean {
   return true;
 }
 
+function createInitialRidgeProgress(): BridgeRidgeProgressState {
+  return {
+    stampIds: [],
+    manualPageIds: [],
+    mobility: {
+      glidePips: 0
+    },
+    shortcutIds: []
+  };
+}
+
 function overlayRequestsEqual(
   a: OverlayRequest | null,
   b: OverlayRequest | null
@@ -105,7 +130,8 @@ let state: BridgeState = {
   },
   progress: {
     hasGlasses: false,
-    discoveredSecretIds: []
+    discoveredSecretIds: [],
+    ridge: createInitialRidgeProgress()
   },
   sceneHintText: null,
   touch: {
@@ -142,6 +168,10 @@ function setState(updater: (current: BridgeState) => BridgeState): void {
     arraysEqual(previous.equipment.equippedItemIds, candidate.equipment.equippedItemIds) &&
     previous.progress.hasGlasses === candidate.progress.hasGlasses &&
     arraysEqual(previous.progress.discoveredSecretIds, candidate.progress.discoveredSecretIds) &&
+    arraysEqual(previous.progress.ridge.stampIds, candidate.progress.ridge.stampIds) &&
+    arraysEqual(previous.progress.ridge.manualPageIds, candidate.progress.ridge.manualPageIds) &&
+    previous.progress.ridge.mobility.glidePips === candidate.progress.ridge.mobility.glidePips &&
+    arraysEqual(previous.progress.ridge.shortcutIds, candidate.progress.ridge.shortcutIds) &&
     previous.sceneHintText === candidate.sceneHintText &&
     previous.touch.left === candidate.touch.left &&
     previous.touch.right === candidate.touch.right &&
@@ -273,6 +303,67 @@ export const bridgeActions = {
       };
     });
   },
+  awardRidgeStamp(stampId: RidgeStampId): void {
+    setState((current) => {
+      if (current.progress.ridge.stampIds.includes(stampId)) return current;
+      return {
+        ...current,
+        progress: {
+          ...current.progress,
+          ridge: {
+            ...current.progress.ridge,
+            stampIds: [...current.progress.ridge.stampIds, stampId]
+          }
+        }
+      };
+    });
+  },
+  awardRidgeManualPage(manualPageId: RidgeManualPageId): void {
+    setState((current) => {
+      if (current.progress.ridge.manualPageIds.includes(manualPageId)) return current;
+      return {
+        ...current,
+        progress: {
+          ...current.progress,
+          ridge: {
+            ...current.progress.ridge,
+            manualPageIds: [...current.progress.ridge.manualPageIds, manualPageId]
+          }
+        }
+      };
+    });
+  },
+  awardRidgeGlidePip(count: number = 1): void {
+    const wholeCount = Math.trunc(count);
+    if (!Number.isFinite(wholeCount) || wholeCount <= 0) return;
+    setState((current) => ({
+      ...current,
+      progress: {
+        ...current.progress,
+        ridge: {
+          ...current.progress.ridge,
+          mobility: {
+            glidePips: current.progress.ridge.mobility.glidePips + wholeCount
+          }
+        }
+      }
+    }));
+  },
+  unlockRidgeShortcut(shortcutId: RidgeShortcutId): void {
+    setState((current) => {
+      if (current.progress.ridge.shortcutIds.includes(shortcutId)) return current;
+      return {
+        ...current,
+        progress: {
+          ...current.progress,
+          ridge: {
+            ...current.progress.ridge,
+            shortcutIds: [...current.progress.ridge.shortcutIds, shortcutId]
+          }
+        }
+      };
+    });
+  },
   resetProgress(): void {
     setState((current) => ({
       ...current,
@@ -284,7 +375,8 @@ export const bridgeActions = {
       },
       progress: {
         hasGlasses: false,
-        discoveredSecretIds: []
+        discoveredSecretIds: [],
+        ridge: createInitialRidgeProgress()
       }
     }));
   },
@@ -385,6 +477,18 @@ export function isItemEquipped(itemId: InventoryItemId): boolean {
 
 export function isSecretDiscovered(secretId: SecretDiscoveryId): boolean {
   return bridgeStore.getState().progress.discoveredSecretIds.includes(secretId);
+}
+
+export function hasRidgeStamp(stampId: RidgeStampId): boolean {
+  return bridgeStore.getState().progress.ridge.stampIds.includes(stampId);
+}
+
+export function hasRidgeManualPage(manualPageId: RidgeManualPageId): boolean {
+  return bridgeStore.getState().progress.ridge.manualPageIds.includes(manualPageId);
+}
+
+export function isRidgeShortcutUnlocked(shortcutId: RidgeShortcutId): boolean {
+  return bridgeStore.getState().progress.ridge.shortcutIds.includes(shortcutId);
 }
 
 export function getTouchState(): TouchBridgeState {

--- a/src/game/overlays/globalOverlayDefinitions.ts
+++ b/src/game/overlays/globalOverlayDefinitions.ts
@@ -13,5 +13,9 @@ export const GLOBAL_OVERLAY_DEFINITIONS: readonly OverlayDefinition[] = [
   {
     id: 'trailCard',
     component: lazyOverlay(() => import('./trailCard/TrailCardOverlay'))
+  },
+  {
+    id: 'manualPage',
+    component: lazyOverlay(() => import('./manualPage/ManualPageOverlay'))
   }
 ];

--- a/src/game/overlays/globalOverlayDefinitions.ts
+++ b/src/game/overlays/globalOverlayDefinitions.ts
@@ -9,5 +9,9 @@ export const GLOBAL_OVERLAY_DEFINITIONS: readonly OverlayDefinition[] = [
   {
     id: 'devSwitcher',
     component: lazyOverlay(() => import('./devSwitcher/DevSwitcherOverlay'))
+  },
+  {
+    id: 'trailCard',
+    component: lazyOverlay(() => import('./trailCard/TrailCardOverlay'))
   }
 ];

--- a/src/game/overlays/manualPage/ManualPageOverlay.test.tsx
+++ b/src/game/overlays/manualPage/ManualPageOverlay.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ManualPageOverlay from './ManualPageOverlay';
+import type { ManualPageOverlayParams } from './types';
+
+const params: ManualPageOverlayParams = {
+  title: 'Relay Sign, Smudged',
+  cluePanel: 'Three bright marks can speak louder than one perfect route.',
+  marginNote: 'The spire listens for proof, not perfection.'
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ManualPageOverlay', () => {
+  it('renders the passed title, clue panel, and margin note', () => {
+    render(
+      <ManualPageOverlay
+        params={params}
+        close={vi.fn()}
+        openOverlay={vi.fn()}
+        titleId="manual-title"
+        descriptionId="manual-description"
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Relay Sign, Smudged' })).toBeDefined();
+    expect(screen.getByText('Three bright marks can speak louder than one perfect route.')).toBeDefined();
+    expect(screen.getByText('The spire listens for proof, not perfection.')).toBeDefined();
+  });
+
+  it('closes through the close action', async () => {
+    const close = vi.fn();
+    render(
+      <ManualPageOverlay
+        params={params}
+        close={close}
+        openOverlay={vi.fn()}
+        titleId="manual-title"
+        descriptionId="manual-description"
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Close page' }));
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/game/overlays/manualPage/ManualPageOverlay.tsx
+++ b/src/game/overlays/manualPage/ManualPageOverlay.tsx
@@ -36,7 +36,7 @@ export default function ManualPageOverlay({
       titleId={titleId}
       descriptionId={descriptionId}
     >
-      <div className="grid gap-3 text-[#1a1a1a]">
+      <div className="grid gap-3 text-[#1a1a1a] [overflow-wrap:anywhere]">
         <section
           aria-label={messages.manualPage.clue}
           className="relative min-h-36 overflow-hidden rounded border border-[#1a1a1a]/35 bg-[#fffdf4] px-4 py-5"
@@ -50,11 +50,13 @@ export default function ManualPageOverlay({
           <p className="text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a]/60">
             {messages.manualPage.marginNote}
           </p>
-          <p className="text-xs font-bold uppercase tracking-wide">{manualPage.marginNote}</p>
+          <p className="text-xs font-bold uppercase leading-relaxed tracking-wide">
+            {manualPage.marginNote}
+          </p>
         </aside>
 
-        <div className="flex justify-end">
-          <Button variant="secondary" size="sm" onClick={close}>
+        <div className="grid grid-cols-1 sm:flex sm:justify-end">
+          <Button variant="secondary" size="sm" className="w-full sm:w-auto" onClick={close}>
             {messages.manualPage.close}
           </Button>
         </div>

--- a/src/game/overlays/manualPage/ManualPageOverlay.tsx
+++ b/src/game/overlays/manualPage/ManualPageOverlay.tsx
@@ -1,0 +1,64 @@
+import { Button } from '@/shared/ui';
+import { getMessages } from '@/shared/i18n';
+import { OverlayDialogFrame } from '@/game/overlays/OverlayDialogFrame';
+import type { OverlayControllerProps } from '@/game/overlays/types';
+import type { ManualPageOverlayParams } from './types';
+
+function isManualPageOverlayParams(params: unknown): params is ManualPageOverlayParams {
+  if (!params || typeof params !== 'object') return false;
+  const candidate = params as Partial<Record<keyof ManualPageOverlayParams, unknown>>;
+  return (
+    typeof candidate.title === 'string' &&
+    typeof candidate.cluePanel === 'string' &&
+    typeof candidate.marginNote === 'string'
+  );
+}
+
+export default function ManualPageOverlay({
+  params,
+  close,
+  titleId,
+  descriptionId
+}: OverlayControllerProps) {
+  const messages = getMessages();
+  const manualPage = isManualPageOverlayParams(params)
+    ? params
+    : {
+        title: messages.manualPage.fallbackTitle,
+        cluePanel: messages.manualPage.fallbackClue,
+        marginNote: messages.manualPage.fallbackMarginNote
+      };
+
+  return (
+    <OverlayDialogFrame
+      title={manualPage.title}
+      close={close}
+      titleId={titleId}
+      descriptionId={descriptionId}
+    >
+      <div className="grid gap-3 text-[#1a1a1a]">
+        <section
+          aria-label={messages.manualPage.clue}
+          className="relative min-h-36 overflow-hidden rounded border border-[#1a1a1a]/35 bg-[#fffdf4] px-4 py-5"
+        >
+          <div className="absolute left-4 top-4 h-[calc(100%-2rem)] w-px bg-[#dd6b4d]/45" />
+          <div className="absolute inset-x-4 top-1/2 border-t border-dashed border-[#1a1a1a]/20" />
+          <p className="relative pl-5 text-sm font-bold leading-relaxed">{manualPage.cluePanel}</p>
+        </section>
+
+        <aside className="rounded border border-dashed border-[#1a1a1a]/40 bg-[#f4f1ea]/75 px-3 py-2">
+          <p className="text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a]/60">
+            {messages.manualPage.marginNote}
+          </p>
+          <p className="text-xs font-bold uppercase tracking-wide">{manualPage.marginNote}</p>
+        </aside>
+
+        <div className="flex justify-end">
+          <Button variant="secondary" size="sm" onClick={close}>
+            {messages.manualPage.close}
+          </Button>
+        </div>
+      </div>
+    </OverlayDialogFrame>
+  );
+}

--- a/src/game/overlays/manualPage/types.ts
+++ b/src/game/overlays/manualPage/types.ts
@@ -1,0 +1,5 @@
+export interface ManualPageOverlayParams {
+  title: string;
+  cluePanel: string;
+  marginNote: string;
+}

--- a/src/game/overlays/overlayIds.ts
+++ b/src/game/overlays/overlayIds.ts
@@ -8,7 +8,7 @@ export const PORTFOLIO_OVERLAY_IDS = [
 
 export const HOBBIES_OVERLAY_IDS = ['art', 'music', 'fitness', 'dancing'] as const;
 export const BASEMENT_OVERLAY_IDS = ['games'] as const;
-export const GLOBAL_OVERLAY_IDS = ['inventory', 'devSwitcher'] as const;
+export const GLOBAL_OVERLAY_IDS = ['inventory', 'devSwitcher', 'trailCard'] as const;
 
 export const OVERLAY_IDS = [
   ...PORTFOLIO_OVERLAY_IDS,
@@ -25,6 +25,7 @@ export type OverlayId = (typeof OVERLAY_IDS)[number];
 
 export const INVENTORY_OVERLAY_ID = 'inventory' satisfies OverlayId;
 export const DEV_SWITCHER_OVERLAY_ID = 'devSwitcher' satisfies OverlayId;
+export const TRAIL_CARD_OVERLAY_ID = 'trailCard' satisfies GlobalOverlayId;
 export const BASEMENT_CONSOLE_OVERLAY_ID = 'games' satisfies BasementOverlayId;
 
 export function isOverlayId(id: string | null | undefined): id is OverlayId {

--- a/src/game/overlays/overlayIds.ts
+++ b/src/game/overlays/overlayIds.ts
@@ -8,7 +8,7 @@ export const PORTFOLIO_OVERLAY_IDS = [
 
 export const HOBBIES_OVERLAY_IDS = ['art', 'music', 'fitness', 'dancing'] as const;
 export const BASEMENT_OVERLAY_IDS = ['games'] as const;
-export const GLOBAL_OVERLAY_IDS = ['inventory', 'devSwitcher', 'trailCard'] as const;
+export const GLOBAL_OVERLAY_IDS = ['inventory', 'devSwitcher', 'trailCard', 'manualPage'] as const;
 
 export const OVERLAY_IDS = [
   ...PORTFOLIO_OVERLAY_IDS,
@@ -26,6 +26,7 @@ export type OverlayId = (typeof OVERLAY_IDS)[number];
 export const INVENTORY_OVERLAY_ID = 'inventory' satisfies OverlayId;
 export const DEV_SWITCHER_OVERLAY_ID = 'devSwitcher' satisfies OverlayId;
 export const TRAIL_CARD_OVERLAY_ID = 'trailCard' satisfies GlobalOverlayId;
+export const MANUAL_PAGE_OVERLAY_ID = 'manualPage' satisfies GlobalOverlayId;
 export const BASEMENT_CONSOLE_OVERLAY_ID = 'games' satisfies BasementOverlayId;
 
 export function isOverlayId(id: string | null | undefined): id is OverlayId {

--- a/src/game/overlays/trailCard/TrailCardOverlay.test.tsx
+++ b/src/game/overlays/trailCard/TrailCardOverlay.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TrailCardOverlay from './TrailCardOverlay';
+import type { TrailCardOverlayParams } from './types';
+
+const params: TrailCardOverlayParams = {
+  title: 'Stampede Sketch',
+  mood: 'Low-input ink swarm',
+  timeEstimate: '60-90 seconds',
+  rewardPreview: 'Stamp + glide pip',
+  unavailableReason: 'Prototype scene not wired yet'
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TrailCardOverlay', () => {
+  it('renders Trail Card params with disabled entry', () => {
+    render(
+      <TrailCardOverlay
+        params={params}
+        close={vi.fn()}
+        openOverlay={vi.fn()}
+        titleId="trail-title"
+        descriptionId="trail-description"
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Stampede Sketch' })).toBeDefined();
+    expect(screen.getByText('Low-input ink swarm')).toBeDefined();
+    expect(screen.getByText('60-90 seconds')).toBeDefined();
+    expect(screen.getByText('Stamp + glide pip')).toBeDefined();
+    expect(screen.getByText('Prototype scene not wired yet')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Enter' }).hasAttribute('disabled')).toBe(true);
+  });
+
+  it('closes through the back action', async () => {
+    const close = vi.fn();
+    render(
+      <TrailCardOverlay
+        params={params}
+        close={close}
+        openOverlay={vi.fn()}
+        titleId="trail-title"
+        descriptionId="trail-description"
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Back to Ridge' }));
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/game/overlays/trailCard/TrailCardOverlay.test.tsx
+++ b/src/game/overlays/trailCard/TrailCardOverlay.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TrailCardOverlay from './TrailCardOverlay';
 import type { TrailCardOverlayParams } from './types';
+import { bridgeActions, bridgeStore } from '@/game/bridge/store';
 
 const params: TrailCardOverlayParams = {
   title: 'Stampede Sketch',
@@ -15,6 +16,8 @@ const params: TrailCardOverlayParams = {
 
 afterEach(() => {
   cleanup();
+  bridgeActions.returnToOverworld();
+  bridgeActions.closeOverlay();
 });
 
 describe('TrailCardOverlay', () => {
@@ -35,6 +38,34 @@ describe('TrailCardOverlay', () => {
     expect(screen.getByText('Stamp + glide pip')).toBeDefined();
     expect(screen.getByText('Prototype scene not wired yet')).toBeDefined();
     expect(screen.getByRole('button', { name: 'Enter' }).hasAttribute('disabled')).toBe(true);
+  });
+
+  it('enters the configured scene when the card is available', async () => {
+    const enabledParams: TrailCardOverlayParams = {
+      title: 'Stampede Sketch',
+      mood: 'Kite overexcited ink ideas',
+      timeEstimate: '60-90 seconds',
+      rewardPreview: 'Stamp + glide pip',
+      enterSceneId: 'stampedeSketch'
+    };
+    render(
+      <TrailCardOverlay
+        params={enabledParams}
+        close={vi.fn()}
+        openOverlay={vi.fn()}
+        titleId="trail-title"
+        descriptionId="trail-description"
+      />
+    );
+
+    const enter = screen.getByRole('button', { name: 'Enter' });
+    expect(enter.hasAttribute('disabled')).toBe(false);
+
+    await userEvent.click(enter);
+
+    await waitFor(() => {
+      expect(bridgeStore.getState().activeSceneId).toBe('stampedeSketch');
+    });
   });
 
   it('closes through the back action', async () => {

--- a/src/game/overlays/trailCard/TrailCardOverlay.tsx
+++ b/src/game/overlays/trailCard/TrailCardOverlay.tsx
@@ -1,0 +1,84 @@
+import { Button } from '@/shared/ui';
+import { getMessages } from '@/shared/i18n';
+import { OverlayDialogFrame } from '@/game/overlays/OverlayDialogFrame';
+import type { OverlayControllerProps } from '@/game/overlays/types';
+import type { TrailCardOverlayParams } from './types';
+
+function isTrailCardOverlayParams(params: unknown): params is TrailCardOverlayParams {
+  if (!params || typeof params !== 'object') return false;
+  const candidate = params as Partial<Record<keyof TrailCardOverlayParams, unknown>>;
+  return (
+    typeof candidate.title === 'string' &&
+    typeof candidate.mood === 'string' &&
+    typeof candidate.timeEstimate === 'string' &&
+    typeof candidate.rewardPreview === 'string' &&
+    typeof candidate.unavailableReason === 'string'
+  );
+}
+
+export default function TrailCardOverlay({
+  params,
+  close,
+  titleId,
+  descriptionId
+}: OverlayControllerProps) {
+  const messages = getMessages();
+  const trailCard = isTrailCardOverlayParams(params)
+    ? params
+    : {
+        title: messages.trailCard.fallbackTitle,
+        mood: '',
+        timeEstimate: '',
+        rewardPreview: '',
+        unavailableReason: messages.trailCard.unavailableFallback
+      };
+
+  return (
+    <OverlayDialogFrame
+      title={trailCard.title}
+      close={close}
+      titleId={titleId}
+      descriptionId={descriptionId}
+    >
+      <div className="grid gap-3 text-[#1a1a1a]">
+        <dl className="grid gap-2">
+          <div className="rounded border border-[#1a1a1a]/30 bg-white/45 px-3 py-2">
+            <dt className="text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a]/60">
+              {messages.trailCard.mood}
+            </dt>
+            <dd className="text-sm font-bold">{trailCard.mood}</dd>
+          </div>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <div className="rounded border border-[#1a1a1a]/30 bg-white/45 px-3 py-2">
+              <dt className="text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a]/60">
+                {messages.trailCard.time}
+              </dt>
+              <dd className="text-xs font-bold uppercase tracking-wide">{trailCard.timeEstimate}</dd>
+            </div>
+            <div className="rounded border border-[#1a1a1a]/30 bg-white/45 px-3 py-2">
+              <dt className="text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a]/60">
+                {messages.trailCard.reward}
+              </dt>
+              <dd className="text-xs font-bold uppercase tracking-wide">{trailCard.rewardPreview}</dd>
+            </div>
+          </div>
+          <div className="rounded border border-dashed border-[#1a1a1a]/40 bg-[#f4f1ea]/75 px-3 py-2">
+            <dt className="text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a]/60">
+              {messages.trailCard.unavailable}
+            </dt>
+            <dd className="text-xs font-bold uppercase tracking-wide">{trailCard.unavailableReason}</dd>
+          </div>
+        </dl>
+
+        <div className="flex flex-wrap justify-end gap-2">
+          <Button variant="secondary" size="sm" onClick={close}>
+            {messages.trailCard.back}
+          </Button>
+          <Button variant="primary" size="sm" disabled>
+            {messages.trailCard.enter}
+          </Button>
+        </div>
+      </div>
+    </OverlayDialogFrame>
+  );
+}

--- a/src/game/overlays/trailCard/TrailCardOverlay.tsx
+++ b/src/game/overlays/trailCard/TrailCardOverlay.tsx
@@ -1,5 +1,7 @@
 import { Button } from '@/shared/ui';
 import { getMessages } from '@/shared/i18n';
+import { bridgeActions } from '@/game/bridge/store';
+import { isSceneId } from '@/game/scenes/sceneIds';
 import { OverlayDialogFrame } from '@/game/overlays/OverlayDialogFrame';
 import type { OverlayControllerProps } from '@/game/overlays/types';
 import type { TrailCardOverlayParams } from './types';
@@ -12,7 +14,8 @@ function isTrailCardOverlayParams(params: unknown): params is TrailCardOverlayPa
     typeof candidate.mood === 'string' &&
     typeof candidate.timeEstimate === 'string' &&
     typeof candidate.rewardPreview === 'string' &&
-    typeof candidate.unavailableReason === 'string'
+    (candidate.unavailableReason === undefined || typeof candidate.unavailableReason === 'string') &&
+    (candidate.enterSceneId === undefined || (typeof candidate.enterSceneId === 'string' && isSceneId(candidate.enterSceneId)))
   );
 }
 
@@ -32,6 +35,12 @@ export default function TrailCardOverlay({
         rewardPreview: '',
         unavailableReason: messages.trailCard.unavailableFallback
       };
+  const enterSceneId = trailCard.enterSceneId;
+  const canEnter = !trailCard.unavailableReason && enterSceneId !== undefined;
+  const enterTrail = () => {
+    if (!canEnter || !enterSceneId) return;
+    bridgeActions.enterScene(enterSceneId);
+  };
 
   return (
     <OverlayDialogFrame
@@ -66,21 +75,29 @@ export default function TrailCardOverlay({
               </dd>
             </div>
           </div>
-          <div className="rounded border border-dashed border-[#1a1a1a]/40 bg-[#f4f1ea]/75 px-3 py-2">
-            <dt className="text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a]/60">
-              {messages.trailCard.unavailable}
-            </dt>
-            <dd className="text-xs font-bold uppercase leading-relaxed tracking-wide">
-              {trailCard.unavailableReason}
-            </dd>
-          </div>
+          {trailCard.unavailableReason && (
+            <div className="rounded border border-dashed border-[#1a1a1a]/40 bg-[#f4f1ea]/75 px-3 py-2">
+              <dt className="text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a]/60">
+                {messages.trailCard.unavailable}
+              </dt>
+              <dd className="text-xs font-bold uppercase leading-relaxed tracking-wide">
+                {trailCard.unavailableReason}
+              </dd>
+            </div>
+          )}
         </dl>
 
         <div className="grid grid-cols-1 gap-2 sm:flex sm:flex-wrap sm:justify-end">
           <Button variant="secondary" size="sm" className="w-full sm:w-auto" onClick={close}>
             {messages.trailCard.back}
           </Button>
-          <Button variant="primary" size="sm" className="w-full sm:w-auto" disabled>
+          <Button
+            variant="primary"
+            size="sm"
+            className="w-full sm:w-auto"
+            disabled={!canEnter}
+            onClick={enterTrail}
+          >
             {messages.trailCard.enter}
           </Button>
         </div>

--- a/src/game/overlays/trailCard/TrailCardOverlay.tsx
+++ b/src/game/overlays/trailCard/TrailCardOverlay.tsx
@@ -40,41 +40,47 @@ export default function TrailCardOverlay({
       titleId={titleId}
       descriptionId={descriptionId}
     >
-      <div className="grid gap-3 text-[#1a1a1a]">
+      <div className="grid gap-3 text-[#1a1a1a] [overflow-wrap:anywhere]">
         <dl className="grid gap-2">
           <div className="rounded border border-[#1a1a1a]/30 bg-white/45 px-3 py-2">
             <dt className="text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a]/60">
               {messages.trailCard.mood}
             </dt>
-            <dd className="text-sm font-bold">{trailCard.mood}</dd>
+            <dd className="text-sm font-bold leading-relaxed">{trailCard.mood}</dd>
           </div>
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
             <div className="rounded border border-[#1a1a1a]/30 bg-white/45 px-3 py-2">
               <dt className="text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a]/60">
                 {messages.trailCard.time}
               </dt>
-              <dd className="text-xs font-bold uppercase tracking-wide">{trailCard.timeEstimate}</dd>
+              <dd className="text-xs font-bold uppercase leading-relaxed tracking-wide">
+                {trailCard.timeEstimate}
+              </dd>
             </div>
             <div className="rounded border border-[#1a1a1a]/30 bg-white/45 px-3 py-2">
               <dt className="text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a]/60">
                 {messages.trailCard.reward}
               </dt>
-              <dd className="text-xs font-bold uppercase tracking-wide">{trailCard.rewardPreview}</dd>
+              <dd className="text-xs font-bold uppercase leading-relaxed tracking-wide">
+                {trailCard.rewardPreview}
+              </dd>
             </div>
           </div>
           <div className="rounded border border-dashed border-[#1a1a1a]/40 bg-[#f4f1ea]/75 px-3 py-2">
             <dt className="text-[10px] font-bold uppercase tracking-widest text-[#1a1a1a]/60">
               {messages.trailCard.unavailable}
             </dt>
-            <dd className="text-xs font-bold uppercase tracking-wide">{trailCard.unavailableReason}</dd>
+            <dd className="text-xs font-bold uppercase leading-relaxed tracking-wide">
+              {trailCard.unavailableReason}
+            </dd>
           </div>
         </dl>
 
-        <div className="flex flex-wrap justify-end gap-2">
-          <Button variant="secondary" size="sm" onClick={close}>
+        <div className="grid grid-cols-1 gap-2 sm:flex sm:flex-wrap sm:justify-end">
+          <Button variant="secondary" size="sm" className="w-full sm:w-auto" onClick={close}>
             {messages.trailCard.back}
           </Button>
-          <Button variant="primary" size="sm" disabled>
+          <Button variant="primary" size="sm" className="w-full sm:w-auto" disabled>
             {messages.trailCard.enter}
           </Button>
         </div>

--- a/src/game/overlays/trailCard/types.ts
+++ b/src/game/overlays/trailCard/types.ts
@@ -1,0 +1,7 @@
+export interface TrailCardOverlayParams {
+  title: string;
+  mood: string;
+  timeEstimate: string;
+  rewardPreview: string;
+  unavailableReason: string;
+}

--- a/src/game/overlays/trailCard/types.ts
+++ b/src/game/overlays/trailCard/types.ts
@@ -1,7 +1,10 @@
+import type { SceneId } from '@/game/scenes/sceneIds';
+
 export interface TrailCardOverlayParams {
   title: string;
   mood: string;
   timeEstimate: string;
   rewardPreview: string;
-  unavailableReason: string;
+  unavailableReason?: string;
+  enterSceneId?: SceneId;
 }

--- a/src/game/sceneLifecycle/contexts/createSceneContexts.test.ts
+++ b/src/game/sceneLifecycle/contexts/createSceneContexts.test.ts
@@ -26,7 +26,8 @@ describe('createSceneContexts', () => {
       PHASER_SCENE_KEYS.hobbies,
       PHASER_SCENE_KEYS.basement,
       PHASER_SCENE_KEYS.potassium,
-      PHASER_SCENE_KEYS.ridge
+      PHASER_SCENE_KEYS.ridge,
+      PHASER_SCENE_KEYS.stampedeSketch
     ]);
   });
 
@@ -145,10 +146,22 @@ describe('createSceneContexts', () => {
     await expect(contexts[2].loadScene?.()).resolves.toEqual({ id: 'basement' });
     await expect(contexts[3].loadScene?.()).resolves.toEqual({ id: 'potassium' });
     await expect(contexts[4].loadScene?.()).resolves.toEqual({ id: 'ridge' });
+    await expect(contexts[5].loadScene?.()).resolves.toEqual({ id: 'stampedeSketch' });
     expect(loadPhaserScene).toHaveBeenNthCalledWith(1, 'hobbies');
     expect(loadPhaserScene).toHaveBeenNthCalledWith(2, 'basement');
     expect(loadPhaserScene).toHaveBeenNthCalledWith(3, 'potassium');
     expect(loadPhaserScene).toHaveBeenNthCalledWith(4, 'ridge');
+    expect(loadPhaserScene).toHaveBeenNthCalledWith(5, 'stampedeSketch');
+  });
+
+  it('returns from Stampede Sketch to Ridge', () => {
+    const onEnterScene = vi.fn();
+    const contexts = createSceneContexts(makeDeps({ onEnterScene }));
+    const stampedeStartData = contexts[5].getStartData() as { onClose: () => void };
+
+    stampedeStartData.onClose();
+
+    expect(onEnterScene).toHaveBeenCalledWith('ridge');
   });
 
   it('rejects lazy loading with a descriptive error when a scene binding is missing', async () => {

--- a/src/game/sceneLifecycle/contexts/createSceneContexts.test.ts
+++ b/src/game/sceneLifecycle/contexts/createSceneContexts.test.ts
@@ -25,7 +25,8 @@ describe('createSceneContexts', () => {
       PHASER_SCENE_KEYS.overworld,
       PHASER_SCENE_KEYS.hobbies,
       PHASER_SCENE_KEYS.basement,
-      PHASER_SCENE_KEYS.potassium
+      PHASER_SCENE_KEYS.potassium,
+      PHASER_SCENE_KEYS.ridge
     ]);
   });
 
@@ -117,7 +118,9 @@ describe('createSceneContexts', () => {
       `prepare:${PHASER_SCENE_KEYS.basement}`,
       `get:${PHASER_SCENE_KEYS.basement}`,
       `prepare:${PHASER_SCENE_KEYS.potassium}`,
-      `get:${PHASER_SCENE_KEYS.potassium}`
+      `get:${PHASER_SCENE_KEYS.potassium}`,
+      `prepare:${PHASER_SCENE_KEYS.ridge}`,
+      `get:${PHASER_SCENE_KEYS.ridge}`
     ]);
   });
 
@@ -128,9 +131,11 @@ describe('createSceneContexts', () => {
     await expect(contexts[1].loadScene?.()).resolves.toEqual({ id: 'hobbies' });
     await expect(contexts[2].loadScene?.()).resolves.toEqual({ id: 'basement' });
     await expect(contexts[3].loadScene?.()).resolves.toEqual({ id: 'potassium' });
+    await expect(contexts[4].loadScene?.()).resolves.toEqual({ id: 'ridge' });
     expect(loadPhaserScene).toHaveBeenNthCalledWith(1, 'hobbies');
     expect(loadPhaserScene).toHaveBeenNthCalledWith(2, 'basement');
     expect(loadPhaserScene).toHaveBeenNthCalledWith(3, 'potassium');
+    expect(loadPhaserScene).toHaveBeenNthCalledWith(4, 'ridge');
   });
 
   it('rejects lazy loading with a descriptive error when a scene binding is missing', async () => {

--- a/src/game/sceneLifecycle/contexts/createSceneContexts.test.ts
+++ b/src/game/sceneLifecycle/contexts/createSceneContexts.test.ts
@@ -75,6 +75,19 @@ describe('createSceneContexts', () => {
     expect(getSceneStartResume).toHaveBeenCalledWith(PHASER_SCENE_KEYS.basement);
   });
 
+  it('passes overlay options through scene start callbacks', () => {
+    const onOpenOverlay = vi.fn();
+    const contexts = createSceneContexts(makeDeps({ onOpenOverlay }));
+    const ridgeStartData = contexts[4].getStartData() as {
+      onOpenOverlay: (overlayId: 'trailCard', options?: { params?: unknown }) => void;
+    };
+    const params = { title: 'Stampede Sketch' };
+
+    ridgeStartData.onOpenOverlay('trailCard', { params });
+
+    expect(onOpenOverlay).toHaveBeenCalledWith('trailCard', { params });
+  });
+
   it('prepares potassium start before reading potassium start position', () => {
     const calls: string[] = [];
     const prepareSceneStart = vi.fn((sceneKey: string) => {

--- a/src/game/sceneLifecycle/contexts/createSceneContexts.ts
+++ b/src/game/sceneLifecycle/contexts/createSceneContexts.ts
@@ -7,6 +7,7 @@ import {
   type SceneId
 } from '@/game/scenes/sceneIds';
 import type { OverlayId } from '@/game/overlays/overlayIds';
+import type { OpenOverlayOptions } from '@/game/bridge/store';
 import { createBasementSceneContext } from '@/game/scenes/basement/sceneContext';
 import { createHobbiesSceneContext } from '@/game/scenes/hobbies/sceneContext';
 import { createOverworldSceneContext } from '@/game/scenes/overworld/sceneContext';
@@ -16,7 +17,7 @@ import type { ResumeSnapshot, SceneContextDefinition } from '../types';
 
 export interface SceneContextAssemblyDeps {
   onEnterScene: (sceneId: SceneId) => void;
-  onOpenOverlay: (overlayId: OverlayId) => void;
+  onOpenOverlay: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   onReturnToOverworld: () => void;
   getIsPaused: () => boolean;
   prepareSceneStart: (sceneKey: string) => void;

--- a/src/game/sceneLifecycle/contexts/createSceneContexts.ts
+++ b/src/game/sceneLifecycle/contexts/createSceneContexts.ts
@@ -3,6 +3,7 @@ import {
   HOBBIES_SCENE_ID,
   PHASER_SCENE_KEYS,
   POTASSIUM_SCENE_ID,
+  RIDGE_SCENE_ID,
   type SceneId
 } from '@/game/scenes/sceneIds';
 import type { OverlayId } from '@/game/overlays/overlayIds';
@@ -10,6 +11,7 @@ import { createBasementSceneContext } from '@/game/scenes/basement/sceneContext'
 import { createHobbiesSceneContext } from '@/game/scenes/hobbies/sceneContext';
 import { createOverworldSceneContext } from '@/game/scenes/overworld/sceneContext';
 import { createPotassiumSlipSceneContext } from '@/game/scenes/potassiumSlip/sceneContext';
+import { createRidgeSceneContext } from '@/game/scenes/ridge/sceneContext';
 import type { ResumeSnapshot, SceneContextDefinition } from '../types';
 
 export interface SceneContextAssemblyDeps {
@@ -69,6 +71,12 @@ export function createSceneContexts(
       onClose: deps.onReturnToOverworld,
       getResumePosition: getPreparedResume(PHASER_SCENE_KEYS.potassium),
       loadScene: loadScene(POTASSIUM_SCENE_ID)
+    }),
+    createRidgeSceneContext({
+      onClose: deps.onReturnToOverworld,
+      onOpenOverlay: deps.onOpenOverlay,
+      getResumePosition: getPreparedResume(PHASER_SCENE_KEYS.ridge),
+      loadScene: loadScene(RIDGE_SCENE_ID)
     })
   ];
 }

--- a/src/game/sceneLifecycle/contexts/createSceneContexts.ts
+++ b/src/game/sceneLifecycle/contexts/createSceneContexts.ts
@@ -4,6 +4,7 @@ import {
   PHASER_SCENE_KEYS,
   POTASSIUM_SCENE_ID,
   RIDGE_SCENE_ID,
+  STAMPEDE_SKETCH_SCENE_ID,
   type SceneId
 } from '@/game/scenes/sceneIds';
 import type { OverlayId } from '@/game/overlays/overlayIds';
@@ -13,6 +14,7 @@ import { createHobbiesSceneContext } from '@/game/scenes/hobbies/sceneContext';
 import { createOverworldSceneContext } from '@/game/scenes/overworld/sceneContext';
 import { createPotassiumSlipSceneContext } from '@/game/scenes/potassiumSlip/sceneContext';
 import { createRidgeSceneContext } from '@/game/scenes/ridge/sceneContext';
+import { createStampedeSketchSceneContext } from '@/game/scenes/stampedeSketch/sceneContext';
 import type { ResumeSnapshot, SceneContextDefinition } from '../types';
 
 export interface SceneContextAssemblyDeps {
@@ -78,6 +80,10 @@ export function createSceneContexts(
       onOpenOverlay: deps.onOpenOverlay,
       getResumePosition: getPreparedResume(PHASER_SCENE_KEYS.ridge),
       loadScene: loadScene(RIDGE_SCENE_ID)
+    }),
+    createStampedeSketchSceneContext({
+      onClose: () => deps.onEnterScene(RIDGE_SCENE_ID),
+      loadScene: loadScene(STAMPEDE_SKETCH_SCENE_ID)
     })
   ];
 }

--- a/src/game/scenes/basement/runtime/BasementScene.ts
+++ b/src/game/scenes/basement/runtime/BasementScene.ts
@@ -19,7 +19,7 @@ import {
   OVERWORLD_SPRINT_SPEED,
   OVERWORLD_WALK_SPEED
 } from '@/game/sharedSceneRuntime/config';
-import { bridgeActions, isItemEquipped, isItemOwned } from '@/game/bridge/store';
+import { bridgeActions, isItemEquipped, isItemOwned, type OpenOverlayOptions } from '@/game/bridge/store';
 import { createUiText } from '@/game/sharedSceneRuntime/text/createUiText';
 import { PlayerThoughtText } from '@/game/sharedSceneRuntime/text/PlayerThoughtText';
 import {
@@ -44,7 +44,7 @@ export class BasementScene extends Phaser.Scene {
     BasementInteractionEffect
   >;
   private onClose?: () => void;
-  private onOpenOverlay?: (overlayId: OverlayId) => void;
+  private onOpenOverlay?: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   private isPaused: boolean = false;
   private resumePosition?: { x: number; y: number };
 
@@ -54,7 +54,7 @@ export class BasementScene extends Phaser.Scene {
 
   init(data: {
     onClose: () => void;
-    onOpenOverlay?: (overlayId: OverlayId) => void;
+    onOpenOverlay?: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
     isPaused?: boolean;
     resumePosition?: { x: number; y: number };
   }) {

--- a/src/game/scenes/basement/sceneContext.ts
+++ b/src/game/scenes/basement/sceneContext.ts
@@ -1,10 +1,11 @@
 import { BASEMENT_SCENE_ID, PHASER_SCENE_KEYS } from '@/game/scenes/sceneIds';
 import type { OverlayId } from '@/game/overlays/overlayIds';
+import type { OpenOverlayOptions } from '@/game/bridge/store';
 import type { SceneContextDefinition } from '@/game/sceneLifecycle/types';
 
 interface BasementSceneContextOptions {
   onClose: () => void;
-  onOpenOverlay: (overlayId: OverlayId) => void;
+  onOpenOverlay: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   getResumePosition: () => { x: number; y: number } | undefined;
   loadScene: () => Promise<unknown>;
 }

--- a/src/game/scenes/hobbies/runtime/HobbiesScene.ts
+++ b/src/game/scenes/hobbies/runtime/HobbiesScene.ts
@@ -20,7 +20,7 @@ import {
   OVERWORLD_SPRINT_SPEED,
   OVERWORLD_WALK_SPEED
 } from '@/game/sharedSceneRuntime/config';
-import { isItemEquipped } from '@/game/bridge/store';
+import { isItemEquipped, type OpenOverlayOptions } from '@/game/bridge/store';
 import { buildHobbiesRoom } from './HobbiesRoom';
 import { createUiText } from '@/game/sharedSceneRuntime/text/createUiText';
 import {
@@ -45,7 +45,7 @@ export class HobbiesScene extends Phaser.Scene {
   private playerRuntime?: SideViewPlayerRuntime;
   private interactionRuntime?: InteriorInteractionRuntime<HobbiesInteractionId, HobbiesInteractionEffect>;
   private onClose?: () => void;
-  private onOpenOverlay?: (overlayId: OverlayId) => void;
+  private onOpenOverlay?: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   private isPaused: boolean = false;
   private resumePosition?: { x: number; y: number };
 
@@ -55,7 +55,7 @@ export class HobbiesScene extends Phaser.Scene {
 
   init(data: {
     onClose: () => void;
-    onOpenOverlay: (overlayId: OverlayId) => void;
+    onOpenOverlay: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
     isPaused?: boolean;
     resumePosition?: { x: number; y: number };
   }) {

--- a/src/game/scenes/hobbies/sceneContext.ts
+++ b/src/game/scenes/hobbies/sceneContext.ts
@@ -1,10 +1,11 @@
 import { HOBBIES_SCENE_ID, PHASER_SCENE_KEYS } from '@/game/scenes/sceneIds';
 import type { OverlayId } from '@/game/overlays/overlayIds';
+import type { OpenOverlayOptions } from '@/game/bridge/store';
 import type { SceneContextDefinition } from '@/game/sceneLifecycle/types';
 
 interface HobbiesSceneContextOptions {
   onClose: () => void;
-  onOpenOverlay: (overlayId: OverlayId) => void;
+  onOpenOverlay: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   getResumePosition: () => { x: number; y: number } | undefined;
   loadScene: () => Promise<unknown>;
 }

--- a/src/game/scenes/overworld/runtime/OverworldScene.ts
+++ b/src/game/scenes/overworld/runtime/OverworldScene.ts
@@ -36,6 +36,7 @@ import {
   bridgeActions,
   isItemEquipped,
   isSecretDiscovered,
+  type OpenOverlayOptions,
   type SecretDiscoveryId
 } from '@/game/bridge/store';
 import {
@@ -98,7 +99,7 @@ export class OverworldScene extends Phaser.Scene {
 
   private playerRuntime?: SideViewPlayerRuntime;
   private onEnterScene?: (sceneId: SceneId) => void;
-  private onOpenOverlay?: (overlayId: OverlayId) => void;
+  private onOpenOverlay?: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   private isPaused: boolean = false;
   private resumePosition?: { x: number; y: number };
   private readonly buildingSlots: OverworldBuildingSlot[] = [];
@@ -118,7 +119,7 @@ export class OverworldScene extends Phaser.Scene {
 
   init(data: {
     onEnterScene: (sceneId: SceneId) => void;
-    onOpenOverlay: (overlayId: OverlayId) => void;
+    onOpenOverlay: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
     isPaused: boolean;
     resumePosition?: { x: number; y: number };
   }) {

--- a/src/game/scenes/overworld/sceneContext.ts
+++ b/src/game/scenes/overworld/sceneContext.ts
@@ -1,10 +1,11 @@
 import { OVERWORLD_SCENE_ID, PHASER_SCENE_KEYS, type SceneId } from '@/game/scenes/sceneIds';
 import type { OverlayId } from '@/game/overlays/overlayIds';
+import type { OpenOverlayOptions } from '@/game/bridge/store';
 import type { SceneContextDefinition } from '@/game/sceneLifecycle/types';
 
 interface OverworldSceneContextOptions {
   onEnterScene: (sceneId: SceneId) => void;
-  onOpenOverlay: (overlayId: OverlayId) => void;
+  onOpenOverlay: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   getIsPaused: () => boolean;
   getResumePosition: () => { x: number; y: number } | undefined;
 }

--- a/src/game/scenes/ridge/index.ts
+++ b/src/game/scenes/ridge/index.ts
@@ -1,0 +1,1 @@
+export { createRidgeSceneContext } from './sceneContext';

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -14,22 +14,20 @@ import {
   type SideViewPlayerRuntime
 } from '@/game/sharedSceneRuntime/player/SideViewPlayerRuntime';
 import { TextureGenerator } from '@/game/sharedSceneRuntime/textures/TextureGenerator';
+import {
+  RIDGE_FLOOR_Y,
+  RIDGE_LANDMARKS,
+  RIDGE_PLAYER_RESUME_CLAMP,
+  RIDGE_PLAYER_START,
+  RIDGE_WORLD_WIDTH,
+  type RidgeLandmark
+} from '../worldLayout';
 
 interface RidgeSceneStartData {
   onClose?: () => void;
   isPaused?: boolean;
   resumePosition?: { x: number; y: number };
 }
-
-const RIDGE_WORLD_WIDTH = 1800;
-const RIDGE_FLOOR_Y = 520;
-const RIDGE_PLAYER_START = { x: 120, y: RIDGE_FLOOR_Y - 80 } as const;
-const RIDGE_PLAYER_RESUME_CLAMP = {
-  minX: 48,
-  maxX: RIDGE_WORLD_WIDTH - 48,
-  minY: 120,
-  maxY: RIDGE_FLOOR_Y - 20
-} as const;
 
 export class RidgeScene extends Phaser.Scene {
   player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
@@ -72,8 +70,8 @@ export class RidgeScene extends Phaser.Scene {
 
     const ground = this.createGround();
 
-    this.addRelaySpire();
-    this.addTrailMarkers();
+    this.addBackdrop();
+    this.addLandmarks();
     this.addPlaceholderCopy();
     this.createPlayer(ground);
     this.setPaused(this.isPaused);
@@ -110,6 +108,17 @@ export class RidgeScene extends Phaser.Scene {
     const ground = this.add.zone(RIDGE_WORLD_WIDTH / 2, RIDGE_FLOOR_Y + 24, RIDGE_WORLD_WIDTH, 48);
     this.physics.add.existing(ground, true);
     return ground;
+  }
+
+  private addBackdrop(): void {
+    for (let x = 120; x < RIDGE_WORLD_WIDTH; x += 260) {
+      const y = 420 + Math.sin(x / 160) * 18;
+      this.add.line(x, y, -130, 24, 130, -24, 0x1f1f1d, 0.18).setLineWidth(4);
+      this.add.line(x + 36, y + 34, -80, 14, 80, -14, 0x1f1f1d, 0.12).setLineWidth(3);
+    }
+
+    this.add.rectangle(RIDGE_WORLD_WIDTH / 2, RIDGE_FLOOR_Y - 78, RIDGE_WORLD_WIDTH, 8, 0x1f1f1d, 0.12);
+    this.add.rectangle(RIDGE_WORLD_WIDTH / 2, RIDGE_FLOOR_Y - 6, RIDGE_WORLD_WIDTH, 5, 0x1f1f1d, 0.16);
   }
 
   private createPlayer(ground: Phaser.GameObjects.Zone): void {
@@ -158,29 +167,103 @@ export class RidgeScene extends Phaser.Scene {
     this.physics.add.collider(this.player, ground);
   }
 
-  private addRelaySpire(): void {
-    const x = 1510;
+  private addRelaySpire(x: number): void {
     this.add.triangle(x, 205, 0, 180, 46, 0, 92, 180, 0x1c1a18, 0.82);
     this.add.rectangle(x + 46, 330, 34, 250, 0x1c1a18, 0.82);
     this.add.line(x + 46, 205, -80, 35, 80, 35, 0x1c1a18, 0.5).setLineWidth(3);
+    this.add.circle(x + 46, 166, 12, 0xf0d35f, 0.9);
   }
 
-  private addTrailMarkers(): void {
-    const markers = [
-      { x: 170, label: 'Cicka perch' },
-      { x: 400, label: 'Trail Card' },
-      { x: 760, label: 'NPC placeholder' },
-      { x: 1280, label: 'Relay view' }
-    ];
-
-    markers.forEach((marker) => {
-      this.add.circle(marker.x, GAME_DESIGN_HEIGHT - 132, 18, 0x1f1f1d, 0.92);
-      this.add.text(marker.x - 58, GAME_DESIGN_HEIGHT - 108, marker.label, {
-        fontFamily: 'monospace',
-        fontSize: '16px',
-        color: '#1f1f1d'
-      });
+  private addLandmarks(): void {
+    RIDGE_LANDMARKS.forEach((landmark) => {
+      switch (landmark.kind) {
+        case 'cicka-perch':
+          this.addCickaPerch(landmark);
+          break;
+        case 'stampede-blanket':
+          this.addStampedeBlanket(landmark);
+          break;
+        case 'telegraph-bag':
+          this.addTelegraphBag(landmark);
+          break;
+        case 'ridge-guide':
+          this.addRidgeGuide(landmark);
+          break;
+        case 'relay-spire':
+          this.addRelaySpire(landmark.x);
+          break;
+        case 'domino-desk':
+          this.addDominoDesk(landmark);
+          break;
+      }
+      this.addLandmarkLabel(landmark);
     });
+  }
+
+  private addCickaPerch(landmark: RidgeLandmark): void {
+    const x = landmark.x;
+    const y = RIDGE_FLOOR_Y - 74;
+    this.add.rectangle(x, y + 28, 10, 86, 0x1f1f1d, 0.88);
+    this.add.rectangle(x, y - 12, 86, 10, 0x1f1f1d, 0.88);
+    this.add.ellipse(x + 16, y - 36, 54, 28, 0x1f1f1d, 0.95);
+    this.add.triangle(x - 8, y - 50, 0, 14, 12, 0, 22, 14, 0x1f1f1d, 0.95);
+    this.add.triangle(x + 18, y - 50, 0, 14, 12, 0, 22, 14, 0x1f1f1d, 0.95);
+    this.add.circle(x + 30, y - 38, 3, 0xf7f1df, 1);
+    this.add.line(x - 18, y - 32, -30, 0, -54, -10, 0x1f1f1d, 0.9).setLineWidth(5);
+  }
+
+  private addStampedeBlanket(landmark: RidgeLandmark): void {
+    const x = landmark.x;
+    const y = RIDGE_FLOOR_Y - 46;
+    this.add.rectangle(x, y, 104, 32, 0xb85f5a, 0.9);
+    this.add.rectangle(x - 26, y, 18, 32, 0xf7f1df, 0.7);
+    this.add.rectangle(x + 26, y, 18, 32, 0xf7f1df, 0.7);
+    this.add.circle(x - 22, y - 26, 11, 0x1f1f1d, 0.92);
+    this.add.circle(x + 28, y - 20, 9, 0x1f1f1d, 0.75);
+    this.add.line(x, y - 42, -34, 6, 34, -6, 0x1f1f1d, 0.32).setLineWidth(3);
+  }
+
+  private addTelegraphBag(landmark: RidgeLandmark): void {
+    const x = landmark.x;
+    const y = RIDGE_FLOOR_Y - 58;
+    this.add.rectangle(x, y, 70, 54, 0x596f8f, 0.84);
+    this.add.rectangle(x, y - 34, 48, 16, 0x1f1f1d, 0.88);
+    this.add.arc(x, y - 40, 36, Math.PI, Math.PI * 2, false, 0x1f1f1d, 0.2).setStrokeStyle(4, 0x1f1f1d, 0.7);
+    this.add.line(x + 62, y - 18, -30, -20, 30, 20, 0x1f1f1d, 0.7).setLineWidth(4);
+  }
+
+  private addRidgeGuide(landmark: RidgeLandmark): void {
+    const x = landmark.x;
+    const y = RIDGE_FLOOR_Y - 72;
+    this.add.circle(x, y - 28, 16, 0xf7f1df, 1).setStrokeStyle(3, 0x1f1f1d, 1);
+    this.add.rectangle(x, y + 8, 32, 58, 0xf7f1df, 1).setStrokeStyle(3, 0x1f1f1d, 1);
+    this.add.line(x - 8, y + 2, -30, -16, -52, -28, 0x1f1f1d, 1).setLineWidth(4);
+    this.add.rectangle(x + 42, y - 8, 42, 28, 0xf0d35f, 0.9).setStrokeStyle(3, 0x1f1f1d, 1);
+    this.add.text(x + 29, y - 17, '?', {
+      fontFamily: 'monospace',
+      fontSize: '22px',
+      color: '#1f1f1d'
+    });
+  }
+
+  private addDominoDesk(landmark: RidgeLandmark): void {
+    const x = landmark.x;
+    const y = RIDGE_FLOOR_Y - 62;
+    this.add.rectangle(x, y, 108, 50, 0xd7c78f, 0.96).setStrokeStyle(4, 0x1f1f1d, 1);
+    this.add.rectangle(x + 70, y - 40, 46, 94, 0xf7f1df, 1).setStrokeStyle(4, 0x1f1f1d, 1);
+    this.add.circle(x - 28, y - 16, 7, 0x1f1f1d, 1);
+    this.add.circle(x, y - 16, 7, 0x1f1f1d, 1);
+    this.add.circle(x + 28, y - 16, 7, 0x1f1f1d, 1);
+  }
+
+  private addLandmarkLabel(landmark: RidgeLandmark): void {
+    this.add.text(landmark.x, RIDGE_FLOOR_Y - 14, landmark.label, {
+      fontFamily: 'monospace',
+      fontSize: '13px',
+      color: '#1f1f1d',
+      backgroundColor: '#f7f1dfcc',
+      padding: { x: 3, y: 1 }
+    }).setOrigin(0.5);
   }
 
   private addPlaceholderCopy(): void {

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -1,0 +1,203 @@
+import * as Phaser from 'phaser';
+import { PHASER_SCENE_KEYS } from '@/game/scenes/sceneIds';
+import { isItemEquipped } from '@/game/bridge/store';
+import {
+  GAME_DESIGN_HEIGHT,
+  GAME_DESIGN_WIDTH,
+  OVERWORLD_JUMP_VELOCITY_Y,
+  OVERWORLD_PLAYER_GRAVITY_Y,
+  OVERWORLD_SPRINT_SPEED,
+  OVERWORLD_WALK_SPEED
+} from '@/game/sharedSceneRuntime/config';
+import {
+  createSideViewPlayerRuntime,
+  type SideViewPlayerRuntime
+} from '@/game/sharedSceneRuntime/player/SideViewPlayerRuntime';
+import { TextureGenerator } from '@/game/sharedSceneRuntime/textures/TextureGenerator';
+
+interface RidgeSceneStartData {
+  onClose?: () => void;
+  isPaused?: boolean;
+  resumePosition?: { x: number; y: number };
+}
+
+const RIDGE_WORLD_WIDTH = 1800;
+const RIDGE_FLOOR_Y = 520;
+const RIDGE_PLAYER_START = { x: 120, y: RIDGE_FLOOR_Y - 80 } as const;
+const RIDGE_PLAYER_RESUME_CLAMP = {
+  minX: 48,
+  maxX: RIDGE_WORLD_WIDTH - 48,
+  minY: 120,
+  maxY: RIDGE_FLOOR_Y - 20
+} as const;
+
+export class RidgeScene extends Phaser.Scene {
+  player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
+
+  private playerRuntime?: SideViewPlayerRuntime;
+  private onClose: () => void = () => {};
+  private isPaused = false;
+  private resumePosition?: { x: number; y: number };
+
+  constructor() {
+    super(PHASER_SCENE_KEYS.ridge);
+  }
+
+  init(data: RidgeSceneStartData = {}): void {
+    this.onClose = data.onClose ?? (() => {});
+    this.isPaused = data.isPaused ?? false;
+    this.resumePosition = data.resumePosition;
+  }
+
+  preload(): void {
+    if (!this.textures.exists('player_idle')) {
+      TextureGenerator.generatePlayer(this);
+    }
+  }
+
+  getResumeCapturePosition(): { x: number; y: number } | null {
+    return this.playerRuntime?.captureResume() ?? null;
+  }
+
+  setPaused(paused: boolean): void {
+    this.isPaused = paused;
+    this.playerRuntime?.setPaused(paused);
+  }
+
+  create(data: RidgeSceneStartData = {}): void {
+    this.onClose = data.onClose ?? this.onClose;
+
+    this.cameras.main.setBackgroundColor('#f7f1df');
+    this.physics.world.setBounds(0, 0, RIDGE_WORLD_WIDTH, GAME_DESIGN_HEIGHT);
+
+    const ground = this.createGround();
+
+    this.addRelaySpire();
+    this.addTrailMarkers();
+    this.addPlaceholderCopy();
+    this.createPlayer(ground);
+    this.setPaused(this.isPaused);
+    this.playerRuntime?.syncAppearance();
+  }
+
+  update(): void {
+    const playerUpdate = this.playerRuntime?.update();
+    if (!playerUpdate || playerUpdate.paused) return;
+
+    if (playerUpdate.commands.exitContext) {
+      this.onClose();
+    }
+  }
+
+  private createGround(): Phaser.GameObjects.Zone {
+    this.add.rectangle(
+      RIDGE_WORLD_WIDTH / 2,
+      GAME_DESIGN_HEIGHT - 42,
+      RIDGE_WORLD_WIDTH,
+      84,
+      0x2f4736,
+      1
+    );
+    this.add.rectangle(
+      RIDGE_WORLD_WIDTH / 2,
+      GAME_DESIGN_HEIGHT - 88,
+      RIDGE_WORLD_WIDTH,
+      44,
+      0xd7c78f,
+      1
+    );
+
+    const ground = this.add.zone(RIDGE_WORLD_WIDTH / 2, RIDGE_FLOOR_Y + 24, RIDGE_WORLD_WIDTH, 48);
+    this.physics.add.existing(ground, true);
+    return ground;
+  }
+
+  private createPlayer(ground: Phaser.GameObjects.Zone): void {
+    this.playerRuntime = createSideViewPlayerRuntime({
+      scene: this,
+      start: RIDGE_PLAYER_START,
+      resumePosition: this.resumePosition,
+      resumeClamp: RIDGE_PLAYER_RESUME_CLAMP,
+      sprite: {
+        depth: 30,
+        gravityY: OVERWORLD_PLAYER_GRAVITY_Y
+      },
+      movement: {
+        walkSpeed: OVERWORLD_WALK_SPEED,
+        sprintSpeed: OVERWORLD_SPRINT_SPEED,
+        jumpVelocityY: OVERWORLD_JUMP_VELOCITY_Y
+      },
+      input: {
+        allowJump: true,
+        allowSprint: true,
+        includeEscapeKey: true
+      },
+      appearance: {
+        isGlassesEquipped: () => isItemEquipped('glasses'),
+        idleTextureKey: 'player_idle',
+        glassesTextureKey: 'player_glasses'
+      },
+      camera: {
+        worldBounds: {
+          x: 0,
+          y: 0,
+          width: RIDGE_WORLD_WIDTH,
+          height: GAME_DESIGN_HEIGHT
+        },
+        designSize: {
+          width: GAME_DESIGN_WIDTH,
+          height: GAME_DESIGN_HEIGHT
+        },
+        profile: {
+          zoom: 1,
+          followOffsetY: 0
+        }
+      }
+    });
+    this.player = this.playerRuntime.player;
+    this.physics.add.collider(this.player, ground);
+  }
+
+  private addRelaySpire(): void {
+    const x = 1510;
+    this.add.triangle(x, 205, 0, 180, 46, 0, 92, 180, 0x1c1a18, 0.82);
+    this.add.rectangle(x + 46, 330, 34, 250, 0x1c1a18, 0.82);
+    this.add.line(x + 46, 205, -80, 35, 80, 35, 0x1c1a18, 0.5).setLineWidth(3);
+  }
+
+  private addTrailMarkers(): void {
+    const markers = [
+      { x: 170, label: 'Cicka perch' },
+      { x: 400, label: 'Trail Card' },
+      { x: 760, label: 'NPC placeholder' },
+      { x: 1280, label: 'Relay view' }
+    ];
+
+    markers.forEach((marker) => {
+      this.add.circle(marker.x, GAME_DESIGN_HEIGHT - 132, 18, 0x1f1f1d, 0.92);
+      this.add.text(marker.x - 58, GAME_DESIGN_HEIGHT - 108, marker.label, {
+        fontFamily: 'monospace',
+        fontSize: '16px',
+        color: '#1f1f1d'
+      });
+    });
+  }
+
+  private addPlaceholderCopy(): void {
+    this.add.text(48, 48, 'Sketchbook Ridge', {
+      fontFamily: 'monospace',
+      fontSize: '34px',
+      color: '#1f1f1d'
+    });
+    this.add.text(50, 94, 'M1 shell placeholder. The old overworld stays default for now.', {
+      fontFamily: 'monospace',
+      fontSize: '16px',
+      color: '#4b4337'
+    });
+    this.add.text(50, 122, 'Move with arrows/WASD, sprint with Shift, jump with Up, exit with H or Esc.', {
+      fontFamily: 'monospace',
+      fontSize: '16px',
+      color: '#4b4337'
+    });
+  }
+}

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -1,6 +1,8 @@
 import * as Phaser from 'phaser';
 import { PHASER_SCENE_KEYS } from '@/game/scenes/sceneIds';
-import { isItemEquipped } from '@/game/bridge/store';
+import { isItemEquipped, type OpenOverlayOptions } from '@/game/bridge/store';
+import { TRAIL_CARD_OVERLAY_ID, type OverlayId } from '@/game/overlays/overlayIds';
+import { getMessages } from '@/shared/i18n';
 import {
   GAME_DESIGN_HEIGHT,
   GAME_DESIGN_WIDTH,
@@ -14,26 +16,42 @@ import {
   type SideViewPlayerRuntime
 } from '@/game/sharedSceneRuntime/player/SideViewPlayerRuntime';
 import { TextureGenerator } from '@/game/sharedSceneRuntime/textures/TextureGenerator';
+import { createUiText } from '@/game/sharedSceneRuntime/text/createUiText';
+import {
+  createInteriorInteractionRuntime,
+  type InteriorInteractionRuntime
+} from '@/game/sharedSceneRuntime/interactions/InteriorInteractionRuntime';
 import {
   RIDGE_FLOOR_Y,
   RIDGE_LANDMARKS,
   RIDGE_PLAYER_RESUME_CLAMP,
   RIDGE_PLAYER_START,
+  RIDGE_TRAIL_CARD_TARGETS,
   RIDGE_WORLD_WIDTH,
+  type RidgeTrailCardTargetId,
   type RidgeLandmark
 } from '../worldLayout';
+import type { TrailCardOverlayParams } from '@/game/overlays/trailCard/types';
 
 interface RidgeSceneStartData {
   onClose?: () => void;
+  onOpenOverlay?: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   isPaused?: boolean;
   resumePosition?: { x: number; y: number };
 }
 
+type RidgeInteractionEffect =
+  | { kind: 'close' }
+  | { kind: 'openTrailCard'; params: TrailCardOverlayParams };
+
 export class RidgeScene extends Phaser.Scene {
   player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
+  interactPrompt?: Phaser.GameObjects.Text;
 
   private playerRuntime?: SideViewPlayerRuntime;
+  private interactionRuntime?: InteriorInteractionRuntime<RidgeTrailCardTargetId, RidgeInteractionEffect>;
   private onClose: () => void = () => {};
+  private onOpenOverlay?: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   private isPaused = false;
   private resumePosition?: { x: number; y: number };
 
@@ -43,6 +61,7 @@ export class RidgeScene extends Phaser.Scene {
 
   init(data: RidgeSceneStartData = {}): void {
     this.onClose = data.onClose ?? (() => {});
+    this.onOpenOverlay = data.onOpenOverlay;
     this.isPaused = data.isPaused ?? false;
     this.resumePosition = data.resumePosition;
   }
@@ -64,6 +83,8 @@ export class RidgeScene extends Phaser.Scene {
 
   create(data: RidgeSceneStartData = {}): void {
     this.onClose = data.onClose ?? this.onClose;
+    this.onOpenOverlay = data.onOpenOverlay ?? this.onOpenOverlay;
+    const messages = getMessages();
 
     this.cameras.main.setBackgroundColor('#f7f1df');
     this.physics.world.setBounds(0, 0, RIDGE_WORLD_WIDTH, GAME_DESIGN_HEIGHT);
@@ -74,6 +95,7 @@ export class RidgeScene extends Phaser.Scene {
     this.addLandmarks();
     this.addPlaceholderCopy();
     this.createPlayer(ground);
+    this.createTrailCardInteractions(messages.navigation.interact);
     this.setPaused(this.isPaused);
     this.playerRuntime?.syncAppearance();
   }
@@ -84,6 +106,27 @@ export class RidgeScene extends Phaser.Scene {
 
     if (playerUpdate.commands.exitContext) {
       this.onClose();
+      return;
+    }
+
+    const interaction = this.interactionRuntime?.update({
+      playerX: this.player?.x ?? 0,
+      playerY: this.player?.y ?? 0,
+      interactRequested: playerUpdate.step.interactRequested,
+      exitRequested: playerUpdate.commands.exitContext
+    });
+
+    if (!interaction || !interaction.prompt.visible) {
+      this.interactPrompt?.setVisible(false);
+      return;
+    }
+
+    this.interactPrompt?.setPosition(interaction.prompt.x, interaction.prompt.y).setVisible(true);
+    if (interaction.effect?.kind === 'openTrailCard') {
+      this.onOpenOverlay?.(TRAIL_CARD_OVERLAY_ID, {
+        params: interaction.effect.params,
+        returnToSceneId: PHASER_SCENE_KEYS.ridge
+      });
     }
   }
 
@@ -165,6 +208,34 @@ export class RidgeScene extends Phaser.Scene {
     });
     this.player = this.playerRuntime.player;
     this.physics.add.collider(this.player, ground);
+  }
+
+  private createTrailCardInteractions(promptText: string): void {
+    this.interactPrompt = createUiText(this, 0, 0, promptText, {
+      fontSize: '16px',
+      color: '#1a1a1a',
+      backgroundColor: '#ffffff',
+      padding: { x: 5, y: 2 }
+    }).setOrigin(0.5).setDepth(100).setVisible(false);
+
+    this.interactionRuntime = createInteriorInteractionRuntime<
+      RidgeTrailCardTargetId,
+      RidgeInteractionEffect
+    >({
+      interactRadius: 72,
+      exitEffect: { kind: 'close' },
+      targets: RIDGE_TRAIL_CARD_TARGETS.map((target) => ({
+        id: target.id,
+        kind: 'trail-card',
+        x: target.x,
+        distanceAnchorY: target.distanceAnchorY,
+        prompt: target.prompt,
+        effect: {
+          kind: 'openTrailCard',
+          params: target.card
+        } satisfies RidgeInteractionEffect
+      }))
+    });
   }
 
   private addRelaySpire(x: number): void {

--- a/src/game/scenes/ridge/sceneContext.ts
+++ b/src/game/scenes/ridge/sceneContext.ts
@@ -1,10 +1,11 @@
 import { PHASER_SCENE_KEYS, RIDGE_SCENE_ID } from '@/game/scenes/sceneIds';
 import type { OverlayId } from '@/game/overlays/overlayIds';
+import type { OpenOverlayOptions } from '@/game/bridge/store';
 import type { SceneContextDefinition } from '@/game/sceneLifecycle/types';
 
 interface RidgeSceneContextOptions {
   onClose: () => void;
-  onOpenOverlay: (overlayId: OverlayId) => void;
+  onOpenOverlay: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   getResumePosition: () => { x: number; y: number } | undefined;
   loadScene: () => Promise<unknown>;
 }

--- a/src/game/scenes/ridge/sceneContext.ts
+++ b/src/game/scenes/ridge/sceneContext.ts
@@ -1,0 +1,32 @@
+import { PHASER_SCENE_KEYS, RIDGE_SCENE_ID } from '@/game/scenes/sceneIds';
+import type { OverlayId } from '@/game/overlays/overlayIds';
+import type { SceneContextDefinition } from '@/game/sceneLifecycle/types';
+
+interface RidgeSceneContextOptions {
+  onClose: () => void;
+  onOpenOverlay: (overlayId: OverlayId) => void;
+  getResumePosition: () => { x: number; y: number } | undefined;
+  loadScene: () => Promise<unknown>;
+}
+
+/**
+ * Scene lifecycle contract for the placeholder Sketchbook Ridge scene.
+ *
+ * Ridge starts as a separate loadable scene so it can be tested directly before
+ * replacing or absorbing the current overworld route.
+ */
+export function createRidgeSceneContext(
+  options: RidgeSceneContextOptions
+): SceneContextDefinition {
+  return {
+    id: RIDGE_SCENE_ID,
+    sceneKey: PHASER_SCENE_KEYS.ridge,
+    loadScene: options.loadScene,
+    getStartData: () => ({
+      onClose: options.onClose,
+      onOpenOverlay: options.onOpenOverlay,
+      isPaused: false,
+      resumePosition: options.getResumePosition()
+    })
+  };
+}

--- a/src/game/scenes/ridge/worldLayout.test.ts
+++ b/src/game/scenes/ridge/worldLayout.test.ts
@@ -4,6 +4,7 @@ import {
   RIDGE_LANDMARKS,
   RIDGE_PLAYER_RESUME_CLAMP,
   RIDGE_PLAYER_START,
+  RIDGE_TRAIL_CARD_TARGETS,
   RIDGE_WORLD_WIDTH
 } from './worldLayout';
 
@@ -31,5 +32,19 @@ describe('ridge world layout', () => {
 
     expect(relay?.x).toBeGreaterThan(0);
     expect(relay?.x).toBeLessThan(1100);
+  });
+
+  it('defines exactly three Trail Card targets for the first trigger contract', () => {
+    expect(RIDGE_TRAIL_CARD_TARGETS.map((target) => target.id)).toEqual([
+      'stampede-sketch',
+      'telegraph-terrace',
+      'domino-desk'
+    ]);
+    expect(RIDGE_TRAIL_CARD_TARGETS.map((target) => target.landmarkKind)).toEqual([
+      'stampede-blanket',
+      'telegraph-bag',
+      'domino-desk'
+    ]);
+    expect(RIDGE_TRAIL_CARD_TARGETS.every((target) => target.card.unavailableReason.length > 0)).toBe(true);
   });
 });

--- a/src/game/scenes/ridge/worldLayout.test.ts
+++ b/src/game/scenes/ridge/worldLayout.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RIDGE_FLOOR_Y,
+  RIDGE_LANDMARKS,
+  RIDGE_PLAYER_RESUME_CLAMP,
+  RIDGE_PLAYER_START,
+  RIDGE_WORLD_WIDTH
+} from './worldLayout';
+
+describe('ridge world layout', () => {
+  it('keeps the first movement shell flat and inside world bounds', () => {
+    expect(RIDGE_PLAYER_START.y).toBeLessThan(RIDGE_FLOOR_Y);
+    expect(RIDGE_PLAYER_RESUME_CLAMP.minX).toBeGreaterThan(0);
+    expect(RIDGE_PLAYER_RESUME_CLAMP.maxX).toBeLessThan(RIDGE_WORLD_WIDTH);
+    expect(RIDGE_PLAYER_RESUME_CLAMP.maxY).toBeLessThan(RIDGE_FLOOR_Y);
+  });
+
+  it('stages the first Ridge shell landmarks in dependency order', () => {
+    expect(RIDGE_LANDMARKS.map((landmark) => landmark.kind)).toEqual([
+      'cicka-perch',
+      'stampede-blanket',
+      'telegraph-bag',
+      'ridge-guide',
+      'relay-spire',
+      'domino-desk'
+    ]);
+  });
+
+  it('keeps Relay Spire visible early in the first route', () => {
+    const relay = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'relay-spire');
+
+    expect(relay?.x).toBeGreaterThan(0);
+    expect(relay?.x).toBeLessThan(1100);
+  });
+});

--- a/src/game/scenes/ridge/worldLayout.test.ts
+++ b/src/game/scenes/ridge/worldLayout.test.ts
@@ -7,6 +7,7 @@ import {
   RIDGE_TRAIL_CARD_TARGETS,
   RIDGE_WORLD_WIDTH
 } from './worldLayout';
+import { STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
 
 describe('ridge world layout', () => {
   it('keeps the first movement shell flat and inside world bounds', () => {
@@ -45,6 +46,14 @@ describe('ridge world layout', () => {
       'telegraph-bag',
       'domino-desk'
     ]);
-    expect(RIDGE_TRAIL_CARD_TARGETS.every((target) => target.card.unavailableReason.length > 0)).toBe(true);
+  });
+
+  it('enables only the Stampede Trail Card for the movement-only prototype', () => {
+    const stampede = RIDGE_TRAIL_CARD_TARGETS.find((target) => target.id === 'stampede-sketch');
+    const unavailable = RIDGE_TRAIL_CARD_TARGETS.filter((target) => target.id !== 'stampede-sketch');
+
+    expect(stampede?.card.enterSceneId).toBe(STAMPEDE_SKETCH_SCENE_ID);
+    expect(stampede?.card.unavailableReason).toBeUndefined();
+    expect(unavailable.every((target) => target.card.unavailableReason && !target.card.enterSceneId)).toBe(true);
   });
 });

--- a/src/game/scenes/ridge/worldLayout.ts
+++ b/src/game/scenes/ridge/worldLayout.ts
@@ -1,4 +1,5 @@
 import type { TrailCardOverlayParams } from '@/game/overlays/trailCard/types';
+import { STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
 
 export const RIDGE_WORLD_WIDTH = 1800;
 export const RIDGE_FLOOR_Y = 520;
@@ -93,10 +94,10 @@ export const RIDGE_TRAIL_CARD_TARGETS: readonly RidgeTrailCardTarget[] = [
     },
     card: {
       title: 'Stampede Sketch',
-      mood: 'Move-only ink swarm around a picnic blanket.',
+      mood: 'Kite overexcited ink ideas around a picnic blanket.',
       timeEstimate: '60-90 seconds',
       rewardPreview: 'Stamp + glide pip',
-      unavailableReason: 'Stampede is not wired yet.'
+      enterSceneId: STAMPEDE_SKETCH_SCENE_ID
     }
   },
   {

--- a/src/game/scenes/ridge/worldLayout.ts
+++ b/src/game/scenes/ridge/worldLayout.ts
@@ -1,0 +1,63 @@
+export const RIDGE_WORLD_WIDTH = 1800;
+export const RIDGE_FLOOR_Y = 520;
+export const RIDGE_PLAYER_START = { x: 120, y: RIDGE_FLOOR_Y - 80 } as const;
+export const RIDGE_PLAYER_RESUME_CLAMP = {
+  minX: 48,
+  maxX: RIDGE_WORLD_WIDTH - 48,
+  minY: 120,
+  maxY: RIDGE_FLOOR_Y - 20
+} as const;
+
+export type RidgeLandmarkKind =
+  | 'cicka-perch'
+  | 'stampede-blanket'
+  | 'telegraph-bag'
+  | 'ridge-guide'
+  | 'domino-desk'
+  | 'relay-spire';
+
+export interface RidgeLandmark {
+  id: string;
+  kind: RidgeLandmarkKind;
+  x: number;
+  label: string;
+}
+
+export const RIDGE_LANDMARKS: readonly RidgeLandmark[] = [
+  {
+    id: 'cicka-first-perch',
+    kind: 'cicka-perch',
+    x: 220,
+    label: 'Cicka perch'
+  },
+  {
+    id: 'stampede-sketch-blanket',
+    kind: 'stampede-blanket',
+    x: 430,
+    label: 'Stampede'
+  },
+  {
+    id: 'telegraph-terrace-bag',
+    kind: 'telegraph-bag',
+    x: 650,
+    label: 'Telegraph'
+  },
+  {
+    id: 'ridge-guide',
+    kind: 'ridge-guide',
+    x: 790,
+    label: 'Guide'
+  },
+  {
+    id: 'relay-spire',
+    kind: 'relay-spire',
+    x: 890,
+    label: 'Relay Spire'
+  },
+  {
+    id: 'domino-desk-elevator',
+    kind: 'domino-desk',
+    x: 1240,
+    label: 'Domino Desk'
+  }
+];

--- a/src/game/scenes/ridge/worldLayout.ts
+++ b/src/game/scenes/ridge/worldLayout.ts
@@ -1,3 +1,5 @@
+import type { TrailCardOverlayParams } from '@/game/overlays/trailCard/types';
+
 export const RIDGE_WORLD_WIDTH = 1800;
 export const RIDGE_FLOOR_Y = 520;
 export const RIDGE_PLAYER_START = { x: 120, y: RIDGE_FLOOR_Y - 80 } as const;
@@ -21,6 +23,23 @@ export interface RidgeLandmark {
   kind: RidgeLandmarkKind;
   x: number;
   label: string;
+}
+
+export type RidgeTrailCardTargetId =
+  | 'stampede-sketch'
+  | 'telegraph-terrace'
+  | 'domino-desk';
+
+export interface RidgeTrailCardTarget {
+  id: RidgeTrailCardTargetId;
+  landmarkKind: Extract<RidgeLandmarkKind, 'stampede-blanket' | 'telegraph-bag' | 'domino-desk'>;
+  x: number;
+  distanceAnchorY: number;
+  prompt: {
+    x: number;
+    y: number;
+  };
+  card: TrailCardOverlayParams;
 }
 
 export const RIDGE_LANDMARKS: readonly RidgeLandmark[] = [
@@ -59,5 +78,59 @@ export const RIDGE_LANDMARKS: readonly RidgeLandmark[] = [
     kind: 'domino-desk',
     x: 1240,
     label: 'Domino Desk'
+  }
+];
+
+export const RIDGE_TRAIL_CARD_TARGETS: readonly RidgeTrailCardTarget[] = [
+  {
+    id: 'stampede-sketch',
+    landmarkKind: 'stampede-blanket',
+    x: 430,
+    distanceAnchorY: RIDGE_FLOOR_Y - 56,
+    prompt: {
+      x: 430,
+      y: RIDGE_FLOOR_Y - 118
+    },
+    card: {
+      title: 'Stampede Sketch',
+      mood: 'Move-only ink swarm around a picnic blanket.',
+      timeEstimate: '60-90 seconds',
+      rewardPreview: 'Stamp + glide pip',
+      unavailableReason: 'Stampede is not wired yet.'
+    }
+  },
+  {
+    id: 'telegraph-terrace',
+    landmarkKind: 'telegraph-bag',
+    x: 650,
+    distanceAnchorY: RIDGE_FLOOR_Y - 58,
+    prompt: {
+      x: 650,
+      y: RIDGE_FLOOR_Y - 130
+    },
+    card: {
+      title: 'Telegraph Terrace',
+      mood: 'One-button timing practice with clean parry reads.',
+      timeEstimate: 'Prototype TBD',
+      rewardPreview: 'Manual page',
+      unavailableReason: 'Telegraph Terrace is a later prototype.'
+    }
+  },
+  {
+    id: 'domino-desk',
+    landmarkKind: 'domino-desk',
+    x: 1240,
+    distanceAnchorY: RIDGE_FLOOR_Y - 62,
+    prompt: {
+      x: 1240,
+      y: RIDGE_FLOOR_Y - 132
+    },
+    card: {
+      title: 'Domino Desk',
+      mood: 'A careful little deterministic puzzle desk.',
+      timeEstimate: 'Future slice',
+      rewardPreview: 'Shortcut sticker',
+      unavailableReason: 'Domino Desk is future scope.'
+    }
   }
 ];

--- a/src/game/scenes/sceneIds.ts
+++ b/src/game/scenes/sceneIds.ts
@@ -1,4 +1,11 @@
-export const SCENE_IDS = ['overworld', 'hobbies', 'basement', 'potassium', 'ridge'] as const;
+export const SCENE_IDS = [
+  'overworld',
+  'hobbies',
+  'basement',
+  'potassium',
+  'ridge',
+  'stampedeSketch'
+] as const;
 
 export type SceneId = (typeof SCENE_IDS)[number];
 
@@ -7,13 +14,15 @@ export const HOBBIES_SCENE_ID = 'hobbies' satisfies SceneId;
 export const BASEMENT_SCENE_ID = 'basement' satisfies SceneId;
 export const POTASSIUM_SCENE_ID = 'potassium' satisfies SceneId;
 export const RIDGE_SCENE_ID = 'ridge' satisfies SceneId;
+export const STAMPEDE_SKETCH_SCENE_ID = 'stampedeSketch' satisfies SceneId;
 
 export const PHASER_SCENE_KEYS = {
   overworld: 'MainScene',
   hobbies: HOBBIES_SCENE_ID,
   basement: BASEMENT_SCENE_ID,
   potassium: POTASSIUM_SCENE_ID,
-  ridge: RIDGE_SCENE_ID
+  ridge: RIDGE_SCENE_ID,
+  stampedeSketch: STAMPEDE_SKETCH_SCENE_ID
 } as const;
 
 export function isSceneId(id: string | null | undefined): id is SceneId {

--- a/src/game/scenes/sceneIds.ts
+++ b/src/game/scenes/sceneIds.ts
@@ -1,4 +1,4 @@
-export const SCENE_IDS = ['overworld', 'hobbies', 'basement', 'potassium'] as const;
+export const SCENE_IDS = ['overworld', 'hobbies', 'basement', 'potassium', 'ridge'] as const;
 
 export type SceneId = (typeof SCENE_IDS)[number];
 
@@ -6,12 +6,14 @@ export const OVERWORLD_SCENE_ID = 'overworld' satisfies SceneId;
 export const HOBBIES_SCENE_ID = 'hobbies' satisfies SceneId;
 export const BASEMENT_SCENE_ID = 'basement' satisfies SceneId;
 export const POTASSIUM_SCENE_ID = 'potassium' satisfies SceneId;
+export const RIDGE_SCENE_ID = 'ridge' satisfies SceneId;
 
 export const PHASER_SCENE_KEYS = {
   overworld: 'MainScene',
   hobbies: HOBBIES_SCENE_ID,
   basement: BASEMENT_SCENE_ID,
-  potassium: POTASSIUM_SCENE_ID
+  potassium: POTASSIUM_SCENE_ID,
+  ridge: RIDGE_SCENE_ID
 } as const;
 
 export function isSceneId(id: string | null | undefined): id is SceneId {

--- a/src/game/scenes/sceneRegistry.test.ts
+++ b/src/game/scenes/sceneRegistry.test.ts
@@ -20,6 +20,7 @@ describe('sceneRegistry', () => {
     expect(getLoadableScene('basement')?.loadScene).toBeDefined();
     expect(getLoadableScene('potassium')?.loadScene).toBeDefined();
     expect(getLoadableScene('ridge')?.loadScene).toBeDefined();
+    expect(getLoadableScene('stampedeSketch')?.loadScene).toBeDefined();
   });
 
   it('exposes scene targets for the dev switcher', () => {

--- a/src/game/scenes/sceneRegistry.test.ts
+++ b/src/game/scenes/sceneRegistry.test.ts
@@ -19,6 +19,7 @@ describe('sceneRegistry', () => {
     expect(getLoadableScene('hobbies')?.loadScene).toBeDefined();
     expect(getLoadableScene('basement')?.loadScene).toBeDefined();
     expect(getLoadableScene('potassium')?.loadScene).toBeDefined();
+    expect(getLoadableScene('ridge')?.loadScene).toBeDefined();
   });
 
   it('exposes scene targets for the dev switcher', () => {

--- a/src/game/scenes/sceneRegistry.ts
+++ b/src/game/scenes/sceneRegistry.ts
@@ -7,6 +7,7 @@ import {
   PHASER_SCENE_KEYS,
   POTASSIUM_SCENE_ID,
   RIDGE_SCENE_ID,
+  STAMPEDE_SKETCH_SCENE_ID,
   type SceneId
 } from './sceneIds';
 
@@ -60,6 +61,14 @@ export const SCENE_DEFINITIONS: readonly SceneDefinition[] = [
     description: messages.catalog.ridge.ridge.description,
     includeInDevSwitcher: true,
     loadScene: () => import('./ridge/runtime/RidgeScene').then((m) => m.RidgeScene)
+  },
+  {
+    id: STAMPEDE_SKETCH_SCENE_ID,
+    sceneKey: PHASER_SCENE_KEYS.stampedeSketch,
+    title: messages.catalog.stampedeSketch.stampedeSketch.name,
+    description: messages.catalog.stampedeSketch.stampedeSketch.description,
+    includeInDevSwitcher: true,
+    loadScene: () => import('./stampedeSketch/runtime/StampedeSketchScene').then((m) => m.StampedeSketchScene)
   }
 ];
 

--- a/src/game/scenes/sceneRegistry.ts
+++ b/src/game/scenes/sceneRegistry.ts
@@ -6,6 +6,7 @@ import {
   OVERWORLD_SCENE_ID,
   PHASER_SCENE_KEYS,
   POTASSIUM_SCENE_ID,
+  RIDGE_SCENE_ID,
   type SceneId
 } from './sceneIds';
 
@@ -51,6 +52,14 @@ export const SCENE_DEFINITIONS: readonly SceneDefinition[] = [
     description: messages.catalog.potassiumSlip.potassium.description,
     includeInDevSwitcher: true,
     loadScene: () => import('./potassiumSlip/runtime/PotassiumSlipScene').then((m) => m.PotassiumSlipScene)
+  },
+  {
+    id: RIDGE_SCENE_ID,
+    sceneKey: PHASER_SCENE_KEYS.ridge,
+    title: messages.catalog.ridge.ridge.name,
+    description: messages.catalog.ridge.ridge.description,
+    includeInDevSwitcher: true,
+    loadScene: () => import('./ridge/runtime/RidgeScene').then((m) => m.RidgeScene)
   }
 ];
 

--- a/src/game/scenes/stampedeSketch/index.ts
+++ b/src/game/scenes/stampedeSketch/index.ts
@@ -1,0 +1,1 @@
+export { createStampedeSketchSceneContext } from './sceneContext';

--- a/src/game/scenes/stampedeSketch/runtime/StampedeSketchScene.ts
+++ b/src/game/scenes/stampedeSketch/runtime/StampedeSketchScene.ts
@@ -11,6 +11,15 @@ import {
   drawStampedeArena
 } from './arenaPresentation';
 import {
+  createStampedeFeedbackRuntime,
+  type StampedeFeedbackRuntime
+} from './feedbackPresentation';
+import {
+  createStampedeHudRuntime,
+  createStampedeHudSnapshot,
+  type StampedeHudRuntime
+} from './hudPresentation';
+import {
   createStampedeInputRuntime,
   type StampedeInputRuntime
 } from './input';
@@ -18,6 +27,17 @@ import {
   clampStampedePosition,
   type StampedeVelocity
 } from './movement';
+import {
+  resolveStampedePressure,
+  type StampedePressureSnapshot
+} from './pressure';
+import {
+  advanceStampedeSession,
+  createStampedeSession,
+  readStampedeSessionSnapshot,
+  resolveStampedeContact,
+  type StampedeSession
+} from './session';
 import {
   createStampedeSwarmRuntime,
   type StampedeSwarmRuntime
@@ -32,6 +52,9 @@ export class StampedeSketchScene extends Phaser.Scene {
   private player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
   private inputRuntime?: StampedeInputRuntime;
   private swarmRuntime?: StampedeSwarmRuntime;
+  private hudRuntime?: StampedeHudRuntime;
+  private feedbackRuntime?: StampedeFeedbackRuntime;
+  private session: StampedeSession = createStampedeSession();
   private isPaused = false;
   private onClose: () => void = () => {};
 
@@ -65,6 +88,10 @@ export class StampedeSketchScene extends Phaser.Scene {
       backBounds: STAMPEDE_BACK_BOUNDS
     });
     this.swarmRuntime = createStampedeSwarmRuntime({ scene: this });
+    this.hudRuntime = createStampedeHudRuntime({ scene: this });
+    this.feedbackRuntime = createStampedeFeedbackRuntime({ scene: this });
+    this.session = createStampedeSession();
+    this.updateHud();
     this.setPaused(this.isPaused);
   }
 
@@ -82,7 +109,7 @@ export class StampedeSketchScene extends Phaser.Scene {
   }
 
   update(time: number, delta: number): void {
-    if (!this.player || !this.inputRuntime) return;
+    if (!this.player || !this.inputRuntime || !this.swarmRuntime) return;
     if (this.isPaused) {
       this.player.setVelocity(0, 0);
       return;
@@ -93,11 +120,36 @@ export class StampedeSketchScene extends Phaser.Scene {
       return;
     }
 
+    this.session = advanceStampedeSession(this.session, delta);
+    if (this.session.phase !== 'playing') {
+      this.player.setVelocity(0, 0);
+      this.swarmRuntime.update(this.player, delta, {
+        mode: 'recover',
+        pressure: this.session.phase === 'failed' ? 1 : 0.08
+      });
+      this.inputRuntime.updateStickVisuals();
+      this.updateHud();
+      this.announceTerminalPhase();
+      return;
+    }
+
     const velocity = this.inputRuntime.readVelocity();
     this.player.setVelocity(velocity.x, velocity.y);
     this.clampPlayer();
     this.updatePlayerInkTilt(time, velocity);
-    this.swarmRuntime?.update(this.player, delta);
+
+    const pressure = this.resolvePressureSnapshot();
+    if (pressure.canContact) {
+      this.session = resolveStampedeContact(this.session, this.session.elapsedMs);
+      this.feedbackRuntime?.showContact(this.player, pressure.nearestContactCandidate);
+    }
+
+    this.swarmRuntime.update(this.player, delta, {
+      mode: pressure.band,
+      pressure: pressure.pressure
+    });
+    this.updateHud(pressure);
+    this.announceTerminalPhase();
     this.inputRuntime.updateStickVisuals();
   }
 
@@ -115,6 +167,42 @@ export class StampedeSketchScene extends Phaser.Scene {
   private closeToRidge(): void {
     this.player?.setVelocity(0, 0);
     this.onClose();
+  }
+
+  private resolvePressureSnapshot(): StampedePressureSnapshot {
+    const player = this.player;
+    const swarm = this.swarmRuntime;
+    if (!player || !swarm) {
+      return resolveStampedePressure({
+        elapsedMs: this.session.elapsedMs,
+        durationMs: this.session.durationMs,
+        player: { x: 0, y: 0 },
+        candidates: [],
+        lastContactAtMs: this.session.lastContactAtMs
+      });
+    }
+
+    return resolveStampedePressure({
+      elapsedMs: this.session.elapsedMs,
+      durationMs: this.session.durationMs,
+      player: {
+        x: player.x,
+        y: player.y,
+        radius: 24
+      },
+      candidates: swarm.getContactCandidates(),
+      lastContactAtMs: this.session.lastContactAtMs
+    });
+  }
+
+  private updateHud(pressure?: StampedePressureSnapshot): void {
+    this.hudRuntime?.update(
+      createStampedeHudSnapshot(readStampedeSessionSnapshot(this.session), pressure)
+    );
+  }
+
+  private announceTerminalPhase(): void {
+    this.feedbackRuntime?.announceTerminal(this.session.phase, this.player);
   }
 
   private clampPlayer(): void {

--- a/src/game/scenes/stampedeSketch/runtime/StampedeSketchScene.ts
+++ b/src/game/scenes/stampedeSketch/runtime/StampedeSketchScene.ts
@@ -27,15 +27,14 @@ import {
   clampStampedePosition,
   type StampedeVelocity
 } from './movement';
+import type { StampedePressureSnapshot } from './pressure';
 import {
-  resolveStampedePressure,
-  type StampedePressureSnapshot
-} from './pressure';
+  resolveStampedeRunFrame,
+  STAMPEDE_PLAYER_CONTACT_RADIUS
+} from './runFlow';
 import {
-  advanceStampedeSession,
   createStampedeSession,
   readStampedeSessionSnapshot,
-  resolveStampedeContact,
   type StampedeSession
 } from './session';
 import {
@@ -115,42 +114,44 @@ export class StampedeSketchScene extends Phaser.Scene {
       return;
     }
 
-    if (this.inputRuntime.closeRequested()) {
-      this.closeToRidge();
-      return;
-    }
-
-    this.session = advanceStampedeSession(this.session, delta);
-    if (this.session.phase !== 'playing') {
-      this.player.setVelocity(0, 0);
-      this.swarmRuntime.update(this.player, delta, {
-        mode: 'recover',
-        pressure: this.session.phase === 'failed' ? 1 : 0.08
-      });
-      this.inputRuntime.updateStickVisuals();
-      this.updateHud();
-      this.announceTerminalPhase();
-      return;
-    }
-
-    const velocity = this.inputRuntime.readVelocity();
-    this.player.setVelocity(velocity.x, velocity.y);
-    this.clampPlayer();
-    this.updatePlayerInkTilt(time, velocity);
-
-    const pressure = this.resolvePressureSnapshot();
-    if (pressure.canContact) {
-      this.session = resolveStampedeContact(this.session, this.session.elapsedMs);
-      this.feedbackRuntime?.showContact(this.player, pressure.nearestContactCandidate);
-    }
-
-    this.swarmRuntime.update(this.player, delta, {
-      mode: pressure.band,
-      pressure: pressure.pressure
+    const frame = resolveStampedeRunFrame({
+      session: this.session,
+      deltaMs: delta,
+      closeRequested: this.inputRuntime.closeRequested(),
+      velocity: this.inputRuntime.readVelocity(),
+      player: {
+        x: this.player.x,
+        y: this.player.y,
+        radius: STAMPEDE_PLAYER_CONTACT_RADIUS
+      },
+      contactCandidates: this.swarmRuntime.getContactCandidates()
     });
-    this.updateHud(pressure);
-    this.announceTerminalPhase();
-    this.inputRuntime.updateStickVisuals();
+
+    this.session = frame.session;
+    switch (frame.kind) {
+      case 'close':
+        this.closeToRidge();
+        return;
+      case 'terminal':
+        this.player.setVelocity(0, 0);
+        this.swarmRuntime.update(this.player, delta, frame.swarm);
+        this.inputRuntime.updateStickVisuals();
+        this.updateHud();
+        this.announceTerminalPhase();
+        return;
+      case 'playing':
+        this.player.setVelocity(frame.velocity.x, frame.velocity.y);
+        this.player.setPosition(frame.player.x, frame.player.y);
+        this.updatePlayerInkTilt(time, frame.velocity);
+        if (frame.contactCandidate) {
+          this.feedbackRuntime?.showContact(this.player, frame.contactCandidate);
+        }
+        this.swarmRuntime.update(this.player, delta, frame.swarm);
+        this.updateHud(frame.pressure);
+        this.announceTerminalPhase();
+        this.inputRuntime.updateStickVisuals();
+        return;
+    }
   }
 
   private createPlayer(): void {
@@ -169,32 +170,6 @@ export class StampedeSketchScene extends Phaser.Scene {
     this.onClose();
   }
 
-  private resolvePressureSnapshot(): StampedePressureSnapshot {
-    const player = this.player;
-    const swarm = this.swarmRuntime;
-    if (!player || !swarm) {
-      return resolveStampedePressure({
-        elapsedMs: this.session.elapsedMs,
-        durationMs: this.session.durationMs,
-        player: { x: 0, y: 0 },
-        candidates: [],
-        lastContactAtMs: this.session.lastContactAtMs
-      });
-    }
-
-    return resolveStampedePressure({
-      elapsedMs: this.session.elapsedMs,
-      durationMs: this.session.durationMs,
-      player: {
-        x: player.x,
-        y: player.y,
-        radius: 24
-      },
-      candidates: swarm.getContactCandidates(),
-      lastContactAtMs: this.session.lastContactAtMs
-    });
-  }
-
   private updateHud(pressure?: StampedePressureSnapshot): void {
     this.hudRuntime?.update(
       createStampedeHudSnapshot(readStampedeSessionSnapshot(this.session), pressure)
@@ -203,12 +178,6 @@ export class StampedeSketchScene extends Phaser.Scene {
 
   private announceTerminalPhase(): void {
     this.feedbackRuntime?.announceTerminal(this.session.phase, this.player);
-  }
-
-  private clampPlayer(): void {
-    if (!this.player) return;
-    const clamped = clampStampedePosition({ x: this.player.x, y: this.player.y });
-    this.player.setPosition(clamped.x, clamped.y);
   }
 
   private updatePlayerInkTilt(time: number, velocity: StampedeVelocity): void {

--- a/src/game/scenes/stampedeSketch/runtime/StampedeSketchScene.ts
+++ b/src/game/scenes/stampedeSketch/runtime/StampedeSketchScene.ts
@@ -1,0 +1,134 @@
+import * as Phaser from 'phaser';
+import { PHASER_SCENE_KEYS } from '@/game/scenes/sceneIds';
+import {
+  GAME_DESIGN_HEIGHT,
+  GAME_DESIGN_WIDTH
+} from '@/game/sharedSceneRuntime/config';
+import { setSceneKeyboardPaused } from '@/game/sharedSceneRuntime/sceneKeyboardPause';
+import { TextureGenerator } from '@/game/sharedSceneRuntime/textures/TextureGenerator';
+import {
+  STAMPEDE_BACK_BOUNDS,
+  drawStampedeArena
+} from './arenaPresentation';
+import {
+  createStampedeInputRuntime,
+  type StampedeInputRuntime
+} from './input';
+import {
+  clampStampedePosition,
+  type StampedeVelocity
+} from './movement';
+import {
+  createStampedeSwarmRuntime,
+  type StampedeSwarmRuntime
+} from './swarmPresentation';
+
+interface StampedeSketchSceneStartData {
+  onClose?: () => void;
+  isPaused?: boolean;
+}
+
+export class StampedeSketchScene extends Phaser.Scene {
+  private player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
+  private inputRuntime?: StampedeInputRuntime;
+  private swarmRuntime?: StampedeSwarmRuntime;
+  private isPaused = false;
+  private onClose: () => void = () => {};
+
+  constructor() {
+    super(PHASER_SCENE_KEYS.stampedeSketch);
+  }
+
+  init(data: StampedeSketchSceneStartData = {}): void {
+    this.onClose = data.onClose ?? (() => {});
+    this.isPaused = data.isPaused ?? false;
+  }
+
+  preload(): void {
+    if (!this.textures.exists('player_idle')) {
+      TextureGenerator.generatePlayer(this);
+    }
+  }
+
+  create(data: StampedeSketchSceneStartData = {}): void {
+    this.onClose = data.onClose ?? this.onClose;
+    this.isPaused = data.isPaused ?? this.isPaused;
+
+    this.cameras.main.setBackgroundColor('#fbfbf9');
+    this.physics.world.setBounds(0, 0, GAME_DESIGN_WIDTH, GAME_DESIGN_HEIGHT);
+    this.physics.world.gravity.set(0, 0);
+
+    drawStampedeArena(this, () => this.closeToRidge());
+    this.createPlayer();
+    this.inputRuntime = createStampedeInputRuntime({
+      scene: this,
+      backBounds: STAMPEDE_BACK_BOUNDS
+    });
+    this.swarmRuntime = createStampedeSwarmRuntime({ scene: this });
+    this.setPaused(this.isPaused);
+  }
+
+  setPaused(paused: boolean): void {
+    this.isPaused = paused;
+    if (paused) {
+      this.player?.setVelocity(0, 0);
+      this.inputRuntime?.clearPointerControl();
+      this.inputRuntime?.updateStickVisuals();
+    }
+    setSceneKeyboardPaused(this, paused, {
+      pausePhysicsWorld: true,
+      zeroHorizontalVelocity: () => this.player?.setVelocity(0, 0)
+    });
+  }
+
+  update(time: number, delta: number): void {
+    if (!this.player || !this.inputRuntime) return;
+    if (this.isPaused) {
+      this.player.setVelocity(0, 0);
+      return;
+    }
+
+    if (this.inputRuntime.closeRequested()) {
+      this.closeToRidge();
+      return;
+    }
+
+    const velocity = this.inputRuntime.readVelocity();
+    this.player.setVelocity(velocity.x, velocity.y);
+    this.clampPlayer();
+    this.updatePlayerInkTilt(time, velocity);
+    this.swarmRuntime?.update(this.player, delta);
+    this.inputRuntime.updateStickVisuals();
+  }
+
+  private createPlayer(): void {
+    const start = clampStampedePosition({ x: GAME_DESIGN_WIDTH / 2, y: GAME_DESIGN_HEIGHT / 2 + 36 });
+    this.player = this.physics.add.sprite(start.x, start.y, 'player_idle');
+    this.player.setDepth(30);
+    this.player.setScale(0.82);
+    this.player.setDrag(1400, 1400);
+    this.player.body.setAllowGravity(false);
+    this.player.setCollideWorldBounds(false);
+    this.player.body.setCircle(24, 8, 8);
+  }
+
+  private closeToRidge(): void {
+    this.player?.setVelocity(0, 0);
+    this.onClose();
+  }
+
+  private clampPlayer(): void {
+    if (!this.player) return;
+    const clamped = clampStampedePosition({ x: this.player.x, y: this.player.y });
+    this.player.setPosition(clamped.x, clamped.y);
+  }
+
+  private updatePlayerInkTilt(time: number, velocity: StampedeVelocity): void {
+    if (!this.player) return;
+    const speed = Math.hypot(velocity.x, velocity.y);
+    this.player.setAngle(speed > 0 ? Math.sin(time / 95) * 6 : 0);
+    if (velocity.x !== 0) {
+      this.player.setFlipX(velocity.x < 0);
+    }
+  }
+}

--- a/src/game/scenes/stampedeSketch/runtime/arenaPresentation.ts
+++ b/src/game/scenes/stampedeSketch/runtime/arenaPresentation.ts
@@ -1,0 +1,92 @@
+import * as Phaser from 'phaser';
+import { STAMPEDE_ARENA } from './movement';
+
+export const STAMPEDE_BACK_BOUNDS = new Phaser.Geom.Rectangle(
+  STAMPEDE_ARENA.safeLeft + 8,
+  STAMPEDE_ARENA.safeTop - 48,
+  96,
+  44
+);
+
+export function drawStampedeArena(scene: Phaser.Scene, onBack: () => void): void {
+  const centerX = (STAMPEDE_ARENA.left + STAMPEDE_ARENA.right) / 2;
+  const centerY = (STAMPEDE_ARENA.top + STAMPEDE_ARENA.bottom) / 2;
+  const width = STAMPEDE_ARENA.right - STAMPEDE_ARENA.left;
+  const height = STAMPEDE_ARENA.bottom - STAMPEDE_ARENA.top;
+
+  scene.add.rectangle(centerX, centerY, width, height, 0xf4f1ea, 1)
+    .setStrokeStyle(5, 0x1a1a1a, 0.9);
+  scene.add.ellipse(centerX, centerY + 48, width - 78, height - 270, 0xfbfbf9, 1)
+    .setStrokeStyle(4, 0x1a1a1a, 0.8);
+
+  for (let x = STAMPEDE_ARENA.left + 22; x < STAMPEDE_ARENA.right; x += 34) {
+    scene.add.line(x, 50, -18, 18, 18, -18, 0x1a1a1a, 0.14).setLineWidth(2);
+    scene.add.line(x, 550, -18, 18, 18, -18, 0x1a1a1a, 0.14).setLineWidth(2);
+  }
+
+  scene.add.text(centerX, 90, 'Stampede Sketch', {
+    fontFamily: 'monospace',
+    fontSize: '26px',
+    color: '#1a1a1a'
+  }).setOrigin(0.5);
+  scene.add.text(centerX, 120, 'M4a movement feel: kite the ink, no rewards yet.', {
+    fontFamily: 'monospace',
+    fontSize: '14px',
+    color: '#4b4337'
+  }).setOrigin(0.5);
+  scene.add.text(centerX, 542, 'Drag or WASD. E / H / Esc returns to Ridge.', {
+    fontFamily: 'monospace',
+    fontSize: '14px',
+    color: '#4b4337'
+  }).setOrigin(0.5);
+
+  drawPicnicBlanket(scene, centerX, centerY + 36);
+  drawBackTarget(scene, onBack);
+}
+
+function drawPicnicBlanket(scene: Phaser.Scene, x: number, y: number): void {
+  const blanket = scene.add.polygon(
+    x,
+    y,
+    [
+      0, -44,
+      84, 0,
+      0, 44,
+      -84, 0
+    ],
+    0xfbfbf9,
+    1
+  );
+  blanket.setStrokeStyle(5, 0x1a1a1a, 0.9);
+
+  scene.add.line(x, y, -54, -16, 54, 16, 0x1a1a1a, 0.4).setLineWidth(3);
+  scene.add.line(x, y, -54, 16, 54, -16, 0x1a1a1a, 0.4).setLineWidth(3);
+  scene.add.circle(x - 42, y - 58, 9, 0x1a1a1a, 0.85);
+  scene.add.circle(x + 52, y - 48, 7, 0x1a1a1a, 0.7);
+  scene.add.circle(x + 34, y + 58, 6, 0x1a1a1a, 0.62);
+}
+
+function drawBackTarget(scene: Phaser.Scene, onBack: () => void): void {
+  scene.add.rectangle(
+    STAMPEDE_BACK_BOUNDS.centerX,
+    STAMPEDE_BACK_BOUNDS.centerY,
+    STAMPEDE_BACK_BOUNDS.width,
+    STAMPEDE_BACK_BOUNDS.height,
+    0xfbfbf9,
+    1
+  ).setStrokeStyle(4, 0x1a1a1a, 1);
+  scene.add.text(STAMPEDE_BACK_BOUNDS.centerX, STAMPEDE_BACK_BOUNDS.centerY, 'BACK', {
+    fontFamily: 'monospace',
+    fontSize: '15px',
+    color: '#1a1a1a'
+  }).setOrigin(0.5);
+
+  scene.add.zone(
+    STAMPEDE_BACK_BOUNDS.centerX,
+    STAMPEDE_BACK_BOUNDS.centerY,
+    STAMPEDE_BACK_BOUNDS.width,
+    STAMPEDE_BACK_BOUNDS.height
+  )
+    .setInteractive({ useHandCursor: true })
+    .on('pointerup', onBack);
+}

--- a/src/game/scenes/stampedeSketch/runtime/arenaPresentation.ts
+++ b/src/game/scenes/stampedeSketch/runtime/arenaPresentation.ts
@@ -29,7 +29,7 @@ export function drawStampedeArena(scene: Phaser.Scene, onBack: () => void): void
     fontSize: '26px',
     color: '#1a1a1a'
   }).setOrigin(0.5);
-  scene.add.text(centerX, 120, 'M4b pressure loop: kite the ideas, no rewards yet.', {
+  scene.add.text(centerX, 120, 'M4b: kite ideas, no rewards yet.', {
     fontFamily: 'monospace',
     fontSize: '14px',
     color: '#4b4337'

--- a/src/game/scenes/stampedeSketch/runtime/arenaPresentation.ts
+++ b/src/game/scenes/stampedeSketch/runtime/arenaPresentation.ts
@@ -29,7 +29,7 @@ export function drawStampedeArena(scene: Phaser.Scene, onBack: () => void): void
     fontSize: '26px',
     color: '#1a1a1a'
   }).setOrigin(0.5);
-  scene.add.text(centerX, 120, 'M4a movement feel: kite the ink, no rewards yet.', {
+  scene.add.text(centerX, 120, 'M4b pressure loop: kite the ideas, no rewards yet.', {
     fontFamily: 'monospace',
     fontSize: '14px',
     color: '#4b4337'

--- a/src/game/scenes/stampedeSketch/runtime/feedbackPresentation.ts
+++ b/src/game/scenes/stampedeSketch/runtime/feedbackPresentation.ts
@@ -1,0 +1,82 @@
+import * as Phaser from 'phaser';
+import { clampStampedePosition } from './movement';
+import type { StampedeSessionPhase } from './session';
+
+interface StampedeFeedbackRuntimeOptions {
+  scene: Phaser.Scene;
+}
+
+export interface StampedeFeedbackRuntime {
+  showContact(
+    player: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody,
+    candidate: { x: number; y: number } | null
+  ): void;
+  announceTerminal(
+    phase: StampedeSessionPhase,
+    player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody
+  ): void;
+}
+
+export function createStampedeFeedbackRuntime(
+  options: StampedeFeedbackRuntimeOptions
+): StampedeFeedbackRuntime {
+  return new PhaserStampedeFeedbackRuntime(options.scene);
+}
+
+class PhaserStampedeFeedbackRuntime implements StampedeFeedbackRuntime {
+  private readonly scene: Phaser.Scene;
+  private lastAnnouncedPhase?: StampedeSessionPhase;
+
+  constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+  }
+
+  showContact(
+    player: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody,
+    candidate: { x: number; y: number } | null
+  ): void {
+    if (candidate) {
+      const dx = player.x - candidate.x;
+      const dy = player.y - candidate.y;
+      const distance = Math.max(1, Math.hypot(dx, dy));
+      const clamped = clampStampedePosition({
+        x: player.x + (dx / distance) * 14,
+        y: player.y + (dy / distance) * 14
+      });
+      player.setPosition(clamped.x, clamped.y);
+    }
+
+    this.scene.cameras.main.shake(90, 0.0025);
+    this.scene.tweens.killTweensOf(player);
+    player.setAlpha(0.52);
+    this.scene.tweens.add({
+      targets: player,
+      alpha: 1,
+      duration: 220,
+      ease: 'Sine.easeOut'
+    });
+  }
+
+  announceTerminal(
+    phase: StampedeSessionPhase,
+    player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody
+  ): void {
+    if (phase === 'playing') return;
+    if (this.lastAnnouncedPhase === phase) return;
+
+    this.lastAnnouncedPhase = phase;
+    if (phase === 'failed') {
+      this.scene.cameras.main.shake(140, 0.003);
+      return;
+    }
+
+    if (!player) return;
+    this.scene.tweens.add({
+      targets: player,
+      scale: 0.9,
+      yoyo: true,
+      duration: 120,
+      ease: 'Sine.easeOut'
+    });
+  }
+}

--- a/src/game/scenes/stampedeSketch/runtime/hudPresentation.ts
+++ b/src/game/scenes/stampedeSketch/runtime/hudPresentation.ts
@@ -1,0 +1,170 @@
+import * as Phaser from 'phaser';
+import type { StampedePressureSnapshot } from './pressure';
+import type { StampedeSessionSnapshot } from './session';
+
+export type StampedeHudFeedback = 'smudged' | 'blanketHeld' | 'crowded' | string;
+
+export interface StampedeHudSnapshot {
+  timeRemainingSeconds?: number;
+  timerSeconds?: number;
+  pageNoise?: number;
+  phaseLabel?: string;
+  feedback?: StampedeHudFeedback;
+}
+
+interface StampedeHudRuntimeOptions {
+  scene: Phaser.Scene;
+}
+
+export interface StampedeHudRuntime {
+  update(snapshot: StampedeHudSnapshot): void;
+  destroy(): void;
+}
+
+export function createStampedeHudSnapshot(
+  session: StampedeSessionSnapshot,
+  pressure?: StampedePressureSnapshot
+): StampedeHudSnapshot {
+  const remainingMs = Math.max(0, session.durationMs - session.elapsedMs);
+
+  return {
+    timeRemainingSeconds: remainingMs / 1000,
+    pageNoise: resolveHudNoise(session, pressure),
+    phaseLabel: resolvePhaseLabel(session, pressure),
+    feedback: resolveHudFeedback(session)
+  };
+}
+
+export function createStampedeHudRuntime(
+  options: StampedeHudRuntimeOptions
+): StampedeHudRuntime {
+  return new PhaserStampedeHudRuntime(options.scene);
+}
+
+class PhaserStampedeHudRuntime implements StampedeHudRuntime {
+  private readonly root: Phaser.GameObjects.Container;
+  private readonly timerText: Phaser.GameObjects.Text;
+  private readonly phaseText: Phaser.GameObjects.Text;
+  private readonly noiseText: Phaser.GameObjects.Text;
+  private readonly feedbackText: Phaser.GameObjects.Text;
+  private readonly noiseFill: Phaser.GameObjects.Rectangle;
+
+  constructor(scene: Phaser.Scene) {
+    const x = 624;
+    const y = 70;
+    const panel = scene.add.rectangle(0, 0, 190, 94, 0xfbfbf9, 0.88)
+      .setOrigin(0, 0)
+      .setStrokeStyle(3, 0x1a1a1a, 0.86);
+
+    this.timerText = createHudText(scene, 12, 10, '0:00', 17, '#1a1a1a');
+    this.phaseText = createHudText(scene, 12, 32, 'Calm', 13, '#4b4337');
+    this.noiseText = createHudText(scene, 12, 54, 'Page noise', 12, '#4b4337');
+
+    const noiseTrack = scene.add.rectangle(92, 61, 82, 8, 0xf4f1ea, 1)
+      .setOrigin(0, 0.5)
+      .setStrokeStyle(2, 0x1a1a1a, 0.62);
+    this.noiseFill = scene.add.rectangle(94, 61, 0, 4, 0x1a1a1a, 0.78)
+      .setOrigin(0, 0.5);
+
+    this.feedbackText = createHudText(scene, 12, 73, '', 13, '#1a1a1a');
+    this.root = scene.add.container(x, y, [
+      panel,
+      this.timerText,
+      this.phaseText,
+      this.noiseText,
+      noiseTrack,
+      this.noiseFill,
+      this.feedbackText
+    ]).setDepth(80);
+  }
+
+  update(snapshot: StampedeHudSnapshot): void {
+    const seconds = snapshot.timeRemainingSeconds ?? snapshot.timerSeconds ?? 0;
+    const noise = Phaser.Math.Clamp(snapshot.pageNoise ?? 0, 0, 1);
+
+    this.timerText.setText(formatTimer(seconds));
+    this.phaseText.setText(snapshot.phaseLabel ?? 'Calm');
+    this.noiseFill.width = Math.round(78 * noise);
+    this.feedbackText.setText(formatFeedback(snapshot.feedback));
+  }
+
+  destroy(): void {
+    this.root.destroy(true);
+  }
+}
+
+function createHudText(
+  scene: Phaser.Scene,
+  x: number,
+  y: number,
+  text: string,
+  fontSize: number,
+  color: string
+): Phaser.GameObjects.Text {
+  return scene.add.text(x, y, text, {
+    fontFamily: 'monospace',
+    fontSize: `${fontSize}px`,
+    color
+  });
+}
+
+function formatTimer(seconds: number): string {
+  const wholeSeconds = Math.max(0, Math.ceil(seconds));
+  const minutes = Math.floor(wholeSeconds / 60);
+  const paddedSeconds = `${wholeSeconds % 60}`.padStart(2, '0');
+
+  return `${minutes}:${paddedSeconds}`;
+}
+
+function formatFeedback(feedback: StampedeHudFeedback | undefined): string {
+  if (!feedback) return '';
+
+  switch (feedback) {
+    case 'smudged':
+      return 'Smudged!';
+    case 'blanketHeld':
+      return 'Blanket held';
+    case 'crowded':
+      return 'Page got crowded';
+    default:
+      return feedback;
+  }
+}
+
+function resolveHudNoise(
+  session: StampedeSessionSnapshot,
+  pressure?: StampedePressureSnapshot
+): number {
+  if (session.phase === 'failed') return 1;
+  if (session.phase === 'cleared') return 0.08;
+  return pressure?.pressure ?? 0.12;
+}
+
+function resolvePhaseLabel(
+  session: StampedeSessionSnapshot,
+  pressure?: StampedePressureSnapshot
+): string {
+  if (session.phase === 'failed') return 'Page crowded';
+  if (session.phase === 'cleared') return 'Blanket held';
+
+  switch (pressure?.band) {
+    case 'build':
+      return 'Page noise rising';
+    case 'surge':
+      return 'Idea surge';
+    case 'recover':
+      return 'Catch breath';
+    case 'calm':
+    default:
+      return 'Kite the ideas';
+  }
+}
+
+function resolveHudFeedback(
+  session: StampedeSessionSnapshot
+): StampedeHudFeedback | undefined {
+  if (session.phase === 'failed') return 'crowded';
+  if (session.phase === 'cleared') return 'blanketHeld';
+  if (session.recentContact) return 'smudged';
+  return undefined;
+}

--- a/src/game/scenes/stampedeSketch/runtime/hudPresentation.ts
+++ b/src/game/scenes/stampedeSketch/runtime/hudPresentation.ts
@@ -1,4 +1,5 @@
 import * as Phaser from 'phaser';
+import { STAMPEDE_ARENA } from './movement';
 import type { StampedePressureSnapshot } from './pressure';
 import type { StampedeSessionSnapshot } from './session';
 
@@ -50,23 +51,24 @@ class PhaserStampedeHudRuntime implements StampedeHudRuntime {
   private readonly noiseFill: Phaser.GameObjects.Rectangle;
 
   constructor(scene: Phaser.Scene) {
-    const x = 624;
-    const y = 70;
-    const panel = scene.add.rectangle(0, 0, 190, 94, 0xfbfbf9, 0.88)
+    const width = 340;
+    const x = STAMPEDE_ARENA.safeLeft + 16;
+    const y = 140;
+    const panel = scene.add.rectangle(0, 0, width, 38, 0xfbfbf9, 0.88)
       .setOrigin(0, 0)
       .setStrokeStyle(3, 0x1a1a1a, 0.86);
 
     this.timerText = createHudText(scene, 12, 10, '0:00', 17, '#1a1a1a');
-    this.phaseText = createHudText(scene, 12, 32, 'Calm', 13, '#4b4337');
-    this.noiseText = createHudText(scene, 12, 54, 'Page noise', 12, '#4b4337');
+    this.phaseText = createHudText(scene, 74, 12, 'Kite ideas', 12, '#4b4337');
+    this.noiseText = createHudText(scene, 198, 12, 'Noise', 12, '#4b4337');
 
-    const noiseTrack = scene.add.rectangle(92, 61, 82, 8, 0xf4f1ea, 1)
+    const noiseTrack = scene.add.rectangle(248, 19, 74, 8, 0xf4f1ea, 1)
       .setOrigin(0, 0.5)
       .setStrokeStyle(2, 0x1a1a1a, 0.62);
-    this.noiseFill = scene.add.rectangle(94, 61, 0, 4, 0x1a1a1a, 0.78)
+    this.noiseFill = scene.add.rectangle(250, 19, 0, 4, 0x1a1a1a, 0.78)
       .setOrigin(0, 0.5);
 
-    this.feedbackText = createHudText(scene, 12, 73, '', 13, '#1a1a1a');
+    this.feedbackText = createHudText(scene, 74, 25, '', 10, '#1a1a1a');
     this.root = scene.add.container(x, y, [
       panel,
       this.timerText,
@@ -84,7 +86,7 @@ class PhaserStampedeHudRuntime implements StampedeHudRuntime {
 
     this.timerText.setText(formatTimer(seconds));
     this.phaseText.setText(snapshot.phaseLabel ?? 'Calm');
-    this.noiseFill.width = Math.round(78 * noise);
+    this.noiseFill.width = Math.round(70 * noise);
     this.feedbackText.setText(formatFeedback(snapshot.feedback));
   }
 
@@ -149,14 +151,14 @@ function resolvePhaseLabel(
 
   switch (pressure?.band) {
     case 'build':
-      return 'Page noise rising';
+      return 'Noise rising';
     case 'surge':
-      return 'Idea surge';
+      return 'Surge';
     case 'recover':
-      return 'Catch breath';
+      return 'Breather';
     case 'calm':
     default:
-      return 'Kite the ideas';
+      return 'Kite ideas';
   }
 }
 

--- a/src/game/scenes/stampedeSketch/runtime/index.ts
+++ b/src/game/scenes/stampedeSketch/runtime/index.ts
@@ -1,0 +1,1 @@
+export { StampedeSketchScene } from './StampedeSketchScene';

--- a/src/game/scenes/stampedeSketch/runtime/input.ts
+++ b/src/game/scenes/stampedeSketch/runtime/input.ts
@@ -1,0 +1,187 @@
+import * as Phaser from 'phaser';
+import {
+  resolveStampedeVelocity,
+  type StampedeVelocity
+} from './movement';
+
+interface StampedePointerControl {
+  active: boolean;
+  pointerId: number | null;
+  anchorX: number;
+  anchorY: number;
+}
+
+interface StampedeInputRuntimeOptions {
+  scene: Phaser.Scene;
+  backBounds: Phaser.Geom.Rectangle;
+}
+
+export interface StampedeInputRuntime {
+  readVelocity(): StampedeVelocity;
+  closeRequested(): boolean;
+  clearPointerControl(): void;
+  updateStickVisuals(): void;
+}
+
+export function createStampedeInputRuntime(
+  options: StampedeInputRuntimeOptions
+): StampedeInputRuntime {
+  return new PhaserStampedeInputRuntime(options);
+}
+
+class PhaserStampedeInputRuntime implements StampedeInputRuntime {
+  private readonly scene: Phaser.Scene;
+  private readonly backBounds: Phaser.Geom.Rectangle;
+  private readonly cursors?: Phaser.Types.Input.Keyboard.CursorKeys;
+  private readonly keyW?: Phaser.Input.Keyboard.Key;
+  private readonly keyA?: Phaser.Input.Keyboard.Key;
+  private readonly keyS?: Phaser.Input.Keyboard.Key;
+  private readonly keyD?: Phaser.Input.Keyboard.Key;
+  private readonly keyE?: Phaser.Input.Keyboard.Key;
+  private readonly keyH?: Phaser.Input.Keyboard.Key;
+  private readonly keyEsc?: Phaser.Input.Keyboard.Key;
+  private readonly stickBase: Phaser.GameObjects.Arc;
+  private readonly stickKnob: Phaser.GameObjects.Arc;
+  private readonly stickLine: Phaser.GameObjects.Line;
+
+  private pointerControl: StampedePointerControl = {
+    active: false,
+    pointerId: null,
+    anchorX: 0,
+    anchorY: 0
+  };
+
+  constructor({ scene, backBounds }: StampedeInputRuntimeOptions) {
+    this.scene = scene;
+    this.backBounds = backBounds;
+
+    const keyboard = scene.input.keyboard;
+    this.cursors = keyboard?.createCursorKeys();
+    this.keyW = keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.W);
+    this.keyA = keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.A);
+    this.keyS = keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.S);
+    this.keyD = keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.D);
+    this.keyE = keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.E);
+    this.keyH = keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.H);
+    this.keyEsc = keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
+
+    this.stickBase = scene.add.circle(0, 0, 34, 0xfbfbf9, 0.72)
+      .setStrokeStyle(3, 0x1a1a1a, 0.75)
+      .setDepth(90)
+      .setVisible(false);
+    this.stickLine = scene.add.line(0, 0, 0, 0, 0, 0, 0x1a1a1a, 0.5)
+      .setLineWidth(4)
+      .setDepth(91)
+      .setVisible(false);
+    this.stickKnob = scene.add.circle(0, 0, 12, 0x1a1a1a, 0.72)
+      .setDepth(92)
+      .setVisible(false);
+
+    this.registerPointerControls();
+  }
+
+  readVelocity(): StampedeVelocity {
+    return resolveStampedeVelocity({
+      keyboard: this.readKeyboardAxis(),
+      pointer: this.readPointerInput()
+    });
+  }
+
+  closeRequested(): boolean {
+    const justDown = Phaser.Input.Keyboard.JustDown;
+    return Boolean(
+      (this.keyE && justDown(this.keyE)) ||
+        (this.keyH && justDown(this.keyH)) ||
+        (this.keyEsc && justDown(this.keyEsc))
+    );
+  }
+
+  clearPointerControl(): void {
+    this.pointerControl = {
+      active: false,
+      pointerId: null,
+      anchorX: 0,
+      anchorY: 0
+    };
+  }
+
+  updateStickVisuals(): void {
+    const pointer = this.scene.input.activePointer;
+    const active =
+      this.pointerControl.active &&
+      this.pointerControl.pointerId === pointer.id &&
+      pointer.isDown;
+
+    this.stickBase.setVisible(active);
+    this.stickLine.setVisible(active);
+    this.stickKnob.setVisible(active);
+    if (!active) return;
+
+    const dx = pointer.worldX - this.pointerControl.anchorX;
+    const dy = pointer.worldY - this.pointerControl.anchorY;
+    const distance = Math.hypot(dx, dy);
+    const maxDistance = 44;
+    const scale = distance > maxDistance ? maxDistance / distance : 1;
+    const knobX = this.pointerControl.anchorX + dx * scale;
+    const knobY = this.pointerControl.anchorY + dy * scale;
+
+    this.stickBase.setPosition(this.pointerControl.anchorX, this.pointerControl.anchorY);
+    this.stickKnob.setPosition(knobX, knobY);
+    this.stickLine.setPosition(this.pointerControl.anchorX, this.pointerControl.anchorY);
+    this.stickLine.setTo(0, 0, knobX - this.pointerControl.anchorX, knobY - this.pointerControl.anchorY);
+  }
+
+  private registerPointerControls(): void {
+    this.scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      if (this.isPointerInBackTarget(pointer)) return;
+      this.pointerControl = {
+        active: true,
+        pointerId: pointer.id,
+        anchorX: pointer.worldX,
+        anchorY: pointer.worldY
+      };
+      this.updateStickVisuals();
+    });
+
+    this.scene.input.on('pointerup', (pointer: Phaser.Input.Pointer) => {
+      if (this.pointerControl.pointerId !== pointer.id) return;
+      this.clearPointerControl();
+      this.updateStickVisuals();
+    });
+  }
+
+  private readKeyboardAxis(): { x: number; y: number } {
+    const left = Boolean(this.cursors?.left.isDown || this.keyA?.isDown);
+    const right = Boolean(this.cursors?.right.isDown || this.keyD?.isDown);
+    const up = Boolean(this.cursors?.up.isDown || this.keyW?.isDown);
+    const down = Boolean(this.cursors?.down.isDown || this.keyS?.isDown);
+
+    return {
+      x: (right ? 1 : 0) - (left ? 1 : 0),
+      y: (down ? 1 : 0) - (up ? 1 : 0)
+    };
+  }
+
+  private readPointerInput(): { active: boolean; deltaX: number; deltaY: number } {
+    const pointer = this.scene.input.activePointer;
+    const active =
+      this.pointerControl.active &&
+      this.pointerControl.pointerId === pointer.id &&
+      pointer.isDown;
+
+    if (!active) {
+      if (this.pointerControl.active) this.clearPointerControl();
+      return { active: false, deltaX: 0, deltaY: 0 };
+    }
+
+    return {
+      active: true,
+      deltaX: pointer.worldX - this.pointerControl.anchorX,
+      deltaY: pointer.worldY - this.pointerControl.anchorY
+    };
+  }
+
+  private isPointerInBackTarget(pointer: Phaser.Input.Pointer): boolean {
+    return Phaser.Geom.Rectangle.Contains(this.backBounds, pointer.worldX, pointer.worldY);
+  }
+}

--- a/src/game/scenes/stampedeSketch/runtime/movement.test.ts
+++ b/src/game/scenes/stampedeSketch/runtime/movement.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  STAMPEDE_ARENA,
+  STAMPEDE_PLAYER_SPEED,
+  clampStampedePosition,
+  resolveStampedeVelocity
+} from './movement';
+
+describe('stampede movement', () => {
+  it('normalizes diagonal keyboard movement', () => {
+    const velocity = resolveStampedeVelocity({
+      keyboard: { x: 1, y: 1 },
+      pointer: { active: false, deltaX: 0, deltaY: 0 }
+    });
+
+    expect(Math.hypot(velocity.x, velocity.y)).toBeCloseTo(STAMPEDE_PLAYER_SPEED, 5);
+  });
+
+  it('uses pointer movement intensity after the dead zone', () => {
+    const idle = resolveStampedeVelocity({
+      keyboard: { x: 0, y: 0 },
+      pointer: { active: true, deltaX: 4, deltaY: 0 }
+    });
+    const moving = resolveStampedeVelocity({
+      keyboard: { x: 0, y: 0 },
+      pointer: { active: true, deltaX: 60, deltaY: 0 }
+    });
+
+    expect(idle).toEqual({ x: 0, y: 0 });
+    expect(moving.x).toBeCloseTo(STAMPEDE_PLAYER_SPEED, 5);
+    expect(moving.y).toBe(0);
+  });
+
+  it('clamps the player inside the safe arena', () => {
+    expect(clampStampedePosition({ x: 100, y: 900 })).toEqual({
+      x: STAMPEDE_ARENA.safeLeft,
+      y: STAMPEDE_ARENA.safeBottom
+    });
+  });
+});

--- a/src/game/scenes/stampedeSketch/runtime/movement.ts
+++ b/src/game/scenes/stampedeSketch/runtime/movement.ts
@@ -1,0 +1,99 @@
+export const STAMPEDE_ARENA = {
+  left: 275,
+  right: 725,
+  top: 0,
+  bottom: 600,
+  safeLeft: 315,
+  safeRight: 685,
+  safeTop: 74,
+  safeBottom: 526
+} as const;
+
+export const STAMPEDE_PLAYER_SPEED = 210;
+export const STAMPEDE_STICK_DEAD_ZONE = 10;
+export const STAMPEDE_STICK_FULL_DISTANCE = 60;
+
+export interface StampedeAxisInput {
+  x: number;
+  y: number;
+}
+
+export interface StampedePointerInput {
+  active: boolean;
+  deltaX: number;
+  deltaY: number;
+}
+
+export interface StampedeVelocityInput {
+  keyboard: StampedeAxisInput;
+  pointer: StampedePointerInput;
+  speed?: number;
+}
+
+export interface StampedeVelocity {
+  x: number;
+  y: number;
+}
+
+export interface StampedeBounds {
+  safeLeft: number;
+  safeRight: number;
+  safeTop: number;
+  safeBottom: number;
+}
+
+export function resolveStampedeVelocity({
+  keyboard,
+  pointer,
+  speed = STAMPEDE_PLAYER_SPEED
+}: StampedeVelocityInput): StampedeVelocity {
+  const vector = pointer.active
+    ? resolvePointerAxis(pointer)
+    : normalizeAxis(keyboard.x, keyboard.y);
+
+  return {
+    x: vector.x * speed,
+    y: vector.y * speed
+  };
+}
+
+export function clampStampedePosition(
+  position: { x: number; y: number },
+  bounds: StampedeBounds = STAMPEDE_ARENA
+): { x: number; y: number } {
+  return {
+    x: clamp(position.x, bounds.safeLeft, bounds.safeRight),
+    y: clamp(position.y, bounds.safeTop, bounds.safeBottom)
+  };
+}
+
+function resolvePointerAxis(pointer: StampedePointerInput): StampedeAxisInput {
+  const distance = Math.hypot(pointer.deltaX, pointer.deltaY);
+  if (distance < STAMPEDE_STICK_DEAD_ZONE) return { x: 0, y: 0 };
+
+  const normalized = normalizeAxis(pointer.deltaX, pointer.deltaY);
+  const intensity = clamp(
+    (distance - STAMPEDE_STICK_DEAD_ZONE) /
+      (STAMPEDE_STICK_FULL_DISTANCE - STAMPEDE_STICK_DEAD_ZONE),
+    0,
+    1
+  );
+
+  return {
+    x: normalized.x * intensity,
+    y: normalized.y * intensity
+  };
+}
+
+function normalizeAxis(x: number, y: number): StampedeAxisInput {
+  const length = Math.hypot(x, y);
+  if (length === 0) return { x: 0, y: 0 };
+  return {
+    x: x / length,
+    y: y / length
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/src/game/scenes/stampedeSketch/runtime/pressure.test.ts
+++ b/src/game/scenes/stampedeSketch/runtime/pressure.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+  STAMPEDE_BUILD_MS,
+  STAMPEDE_CONTACT_COOLDOWN_MS,
+  STAMPEDE_CONTACT_RADIUS_PADDING,
+  STAMPEDE_OPENING_CALM_MS,
+  STAMPEDE_RECOVER_MS,
+  STAMPEDE_SURGE_MS,
+  canApplyStampedeContact,
+  resolveStampedePressure
+} from './pressure';
+
+describe('stampede pressure', () => {
+  it('moves through repeating cadence bands over the run', () => {
+    const base = {
+      durationMs: 75_000,
+      player: { x: 0, y: 0 },
+      candidates: []
+    };
+
+    expect(resolveStampedePressure({ ...base, elapsedMs: 0 }).band).toBe('calm');
+    expect(resolveStampedePressure({ ...base, elapsedMs: STAMPEDE_OPENING_CALM_MS }).band).toBe('build');
+    expect(resolveStampedePressure({
+      ...base,
+      elapsedMs: STAMPEDE_OPENING_CALM_MS + STAMPEDE_BUILD_MS
+    }).band).toBe('surge');
+    expect(resolveStampedePressure({
+      ...base,
+      elapsedMs: STAMPEDE_OPENING_CALM_MS + STAMPEDE_BUILD_MS + STAMPEDE_SURGE_MS
+    }).band).toBe('recover');
+    expect(resolveStampedePressure({
+      ...base,
+      elapsedMs:
+        STAMPEDE_OPENING_CALM_MS +
+        STAMPEDE_BUILD_MS +
+        STAMPEDE_SURGE_MS +
+        STAMPEDE_RECOVER_MS
+    }).band).toBe('build');
+    expect(
+      resolveStampedePressure({
+        ...base,
+        elapsedMs: STAMPEDE_OPENING_CALM_MS + STAMPEDE_BUILD_MS,
+        lastContactAtMs: STAMPEDE_OPENING_CALM_MS + STAMPEDE_BUILD_MS - 500
+      }).band
+    ).toBe('recover');
+  });
+
+  it('keeps cadence fastest during surge and slowest while calm', () => {
+    const base = {
+      durationMs: 75_000,
+      player: { x: 0, y: 0 },
+      candidates: []
+    };
+    const calm = resolveStampedePressure({ ...base, elapsedMs: 0 });
+    const surge = resolveStampedePressure({ ...base, elapsedMs: 70_000 });
+
+    expect(surge.cadenceMs).toBeLessThan(calm.cadenceMs);
+  });
+
+  it('clamps pressure between zero and one', () => {
+    const early = resolveStampedePressure({
+      elapsedMs: -1_000,
+      durationMs: 75_000,
+      player: { x: 0, y: 0 },
+      candidates: []
+    });
+    const late = resolveStampedePressure({
+      elapsedMs: 100_000,
+      durationMs: 75_000,
+      player: { x: 0, y: 0 },
+      candidates: [{ x: 0, y: 0, radius: 40 }]
+    });
+
+    expect(early.pressure).toBeGreaterThanOrEqual(0);
+    expect(early.pressure).toBeLessThanOrEqual(1);
+    expect(late.pressure).toBeGreaterThanOrEqual(0);
+    expect(late.pressure).toBeLessThanOrEqual(1);
+  });
+
+  it('reports the nearest contact distance from candidates', () => {
+    const far = { x: 80, y: 0, radius: 8 };
+    const near = { x: 30, y: 0, radius: 8 };
+
+    const pressure = resolveStampedePressure({
+      elapsedMs: 0,
+      durationMs: 75_000,
+      player: { x: 0, y: 0, radius: 10 },
+      candidates: [far, near],
+      contactRadiusPadding: 0
+    });
+
+    expect(pressure.nearestContactCandidate).toBe(near);
+    expect(pressure.nearestContactDistance).toBe(12);
+  });
+
+  it('treats exact contact radius as contact', () => {
+    const pressure = resolveStampedePressure({
+      elapsedMs: 1_000,
+      durationMs: 75_000,
+      player: { x: 0, y: 0, radius: 10 },
+      candidates: [{ x: 26, y: 0, radius: 10 }]
+    });
+
+    expect(pressure.nearestContactDistance).toBe(0);
+    expect(pressure.withinContactRadius).toBe(true);
+    expect(pressure.canContact).toBe(true);
+  });
+
+  it('gates contacts until the cooldown boundary', () => {
+    expect(
+      canApplyStampedeContact(
+        STAMPEDE_CONTACT_COOLDOWN_MS - 1,
+        0,
+        STAMPEDE_CONTACT_COOLDOWN_MS
+      )
+    ).toBe(false);
+    expect(
+      canApplyStampedeContact(
+        STAMPEDE_CONTACT_COOLDOWN_MS,
+        0,
+        STAMPEDE_CONTACT_COOLDOWN_MS
+      )
+    ).toBe(true);
+  });
+
+  it('uses the exact cooldown boundary in pressure snapshots', () => {
+    const candidate = {
+      x: 20 + STAMPEDE_CONTACT_RADIUS_PADDING,
+      y: 0,
+      radius: 10
+    };
+    const base = {
+      durationMs: 75_000,
+      player: { x: 0, y: 0, radius: 10 },
+      candidates: [candidate],
+      lastContactAtMs: 0
+    };
+
+    expect(
+      resolveStampedePressure({
+        ...base,
+        elapsedMs: STAMPEDE_CONTACT_COOLDOWN_MS - 1
+      }).canContact
+    ).toBe(false);
+    expect(
+      resolveStampedePressure({
+        ...base,
+        elapsedMs: STAMPEDE_CONTACT_COOLDOWN_MS
+      }).canContact
+    ).toBe(true);
+  });
+});

--- a/src/game/scenes/stampedeSketch/runtime/pressure.ts
+++ b/src/game/scenes/stampedeSketch/runtime/pressure.ts
@@ -1,0 +1,177 @@
+export const STAMPEDE_CONTACT_COOLDOWN_MS = 900;
+export const STAMPEDE_CONTACT_RADIUS_PADDING = 6;
+export const STAMPEDE_OPENING_CALM_MS = 10_000;
+export const STAMPEDE_BUILD_MS = 12_000;
+export const STAMPEDE_SURGE_MS = 3_500;
+export const STAMPEDE_RECOVER_MS = 6_000;
+
+export type StampedePressureBand = 'calm' | 'build' | 'surge' | 'recover';
+
+export interface StampedePressurePoint {
+  x: number;
+  y: number;
+  radius?: number;
+}
+
+export interface StampedeContactCandidate {
+  x: number;
+  y: number;
+  radius: number;
+}
+
+export interface StampedePressureInput {
+  elapsedMs: number;
+  durationMs: number;
+  player: StampedePressurePoint;
+  candidates: readonly StampedeContactCandidate[];
+  lastContactAtMs?: number | null;
+  contactCooldownMs?: number;
+  contactRadiusPadding?: number;
+}
+
+export interface StampedePressureSnapshot {
+  band: StampedePressureBand;
+  cadenceMs: number;
+  pressure: number;
+  nearestContactDistance: number | null;
+  nearestContactCandidate: StampedeContactCandidate | null;
+  withinContactRadius: boolean;
+  canContact: boolean;
+}
+
+export function resolveStampedePressure({
+  elapsedMs,
+  durationMs,
+  player,
+  candidates,
+  lastContactAtMs = null,
+  contactCooldownMs = STAMPEDE_CONTACT_COOLDOWN_MS,
+  contactRadiusPadding = STAMPEDE_CONTACT_RADIUS_PADDING
+}: StampedePressureInput): StampedePressureSnapshot {
+  const clampedElapsedMs = Math.max(0, elapsedMs);
+  const progress = durationMs <= 0 ? 1 : clamp(clampedElapsedMs / durationMs, 0, 1);
+  const nearest = resolveNearestContactDistance(
+    player,
+    candidates,
+    contactRadiusPadding
+  );
+  const withinContactRadius =
+    nearest.nearestContactDistance !== null && nearest.nearestContactDistance <= 0;
+  const canContact =
+    withinContactRadius &&
+    canApplyStampedeContact(clampedElapsedMs, lastContactAtMs, contactCooldownMs);
+  const band = resolvePressureBand(clampedElapsedMs, lastContactAtMs, contactCooldownMs);
+  const proximityPressure =
+    nearest.nearestContactDistance === null
+      ? 0
+      : 1 - clamp(nearest.nearestContactDistance / 160, 0, 1);
+
+  return {
+    band,
+    cadenceMs: resolvePressureCadenceMs(band),
+    pressure: clamp(
+      resolveBandPressureFloor(band) + progress * 0.2 + proximityPressure * 0.32,
+      0,
+      1
+    ),
+    nearestContactDistance: nearest.nearestContactDistance,
+    nearestContactCandidate: nearest.nearestContactCandidate,
+    withinContactRadius,
+    canContact
+  };
+}
+
+export function canApplyStampedeContact(
+  nowMs: number,
+  lastContactAtMs: number | null | undefined,
+  contactCooldownMs: number = STAMPEDE_CONTACT_COOLDOWN_MS
+): boolean {
+  return (
+    lastContactAtMs === null ||
+    lastContactAtMs === undefined ||
+    nowMs - lastContactAtMs >= contactCooldownMs
+  );
+}
+
+function resolveNearestContactDistance(
+  player: StampedePressurePoint,
+  candidates: readonly StampedeContactCandidate[],
+  contactRadiusPadding: number
+): Pick<
+  StampedePressureSnapshot,
+  'nearestContactDistance' | 'nearestContactCandidate'
+> {
+  let nearestContactDistance: number | null = null;
+  let nearestContactCandidate: StampedeContactCandidate | null = null;
+
+  candidates.forEach((candidate) => {
+    const distance =
+      Math.hypot(player.x - candidate.x, player.y - candidate.y) -
+      (player.radius ?? 0) -
+      candidate.radius -
+      contactRadiusPadding;
+
+    if (
+      nearestContactDistance === null ||
+      distance < nearestContactDistance
+    ) {
+      nearestContactDistance = distance;
+      nearestContactCandidate = candidate;
+    }
+  });
+
+  return {
+    nearestContactDistance,
+    nearestContactCandidate
+  };
+}
+
+function resolvePressureBand(
+  elapsedMs: number,
+  lastContactAtMs: number | null,
+  contactCooldownMs: number
+): StampedePressureBand {
+  if (!canApplyStampedeContact(elapsedMs, lastContactAtMs, contactCooldownMs)) {
+    return 'recover';
+  }
+  if (elapsedMs < STAMPEDE_OPENING_CALM_MS) return 'calm';
+
+  const cycleMs = STAMPEDE_BUILD_MS + STAMPEDE_SURGE_MS + STAMPEDE_RECOVER_MS;
+  const cycleElapsedMs = (elapsedMs - STAMPEDE_OPENING_CALM_MS) % cycleMs;
+
+  if (cycleElapsedMs < STAMPEDE_BUILD_MS) return 'build';
+  if (cycleElapsedMs < STAMPEDE_BUILD_MS + STAMPEDE_SURGE_MS) return 'surge';
+  return 'recover';
+}
+
+function resolveBandPressureFloor(band: StampedePressureBand): number {
+  switch (band) {
+    case 'build':
+      return 0.38;
+    case 'surge':
+      return 0.72;
+    case 'recover':
+      return 0.24;
+    case 'calm':
+    default:
+      return 0.12;
+  }
+}
+
+function resolvePressureCadenceMs(band: StampedePressureBand): number {
+  switch (band) {
+    case 'build':
+      return 1_100;
+    case 'surge':
+      return 700;
+    case 'recover':
+      return 1_350;
+    case 'calm':
+    default:
+      return 1_600;
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/src/game/scenes/stampedeSketch/runtime/runFlow.test.ts
+++ b/src/game/scenes/stampedeSketch/runtime/runFlow.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  STAMPEDE_PLAYER_CONTACT_RADIUS,
+  resolveStampedeRunFrame
+} from './runFlow';
+import {
+  STAMPEDE_CONTACT_LIMIT,
+  createStampedeSession,
+  resolveStampedeContact
+} from './session';
+
+describe('stampede run flow', () => {
+  const baseVelocity = { x: 10, y: -20 };
+  const basePlayer = { x: 500, y: 300 };
+
+  it('returns close without advancing the run session', () => {
+    const session = createStampedeSession({ durationMs: 1_000 });
+    const frame = resolveStampedeRunFrame({
+      session,
+      deltaMs: 900,
+      closeRequested: true,
+      velocity: baseVelocity,
+      player: basePlayer,
+      contactCandidates: []
+    });
+
+    expect(frame).toEqual({
+      kind: 'close',
+      session
+    });
+  });
+
+  it('returns a terminal clear frame once the timer completes', () => {
+    const frame = resolveStampedeRunFrame({
+      session: createStampedeSession({ durationMs: 1_000 }),
+      deltaMs: 1_000,
+      closeRequested: false,
+      velocity: baseVelocity,
+      player: basePlayer,
+      contactCandidates: []
+    });
+
+    expect(frame.kind).toBe('terminal');
+    if (frame.kind !== 'terminal') return;
+    expect(frame.phase).toBe('cleared');
+    expect(frame.session.phase).toBe('cleared');
+    expect(frame.swarm).toEqual({
+      mode: 'recover',
+      pressure: 0.08
+    });
+  });
+
+  it('clamps player facts and applies one contact when a candidate reaches the player', () => {
+    const candidate = {
+      x: 315,
+      y: 526,
+      radius: 10
+    };
+    const frame = resolveStampedeRunFrame({
+      session: createStampedeSession(),
+      deltaMs: 500,
+      closeRequested: false,
+      velocity: baseVelocity,
+      player: { x: 100, y: 900 },
+      contactCandidates: [candidate]
+    });
+
+    expect(frame.kind).toBe('playing');
+    if (frame.kind !== 'playing') return;
+    expect(frame.player).toEqual({
+      x: 315,
+      y: 526,
+      radius: STAMPEDE_PLAYER_CONTACT_RADIUS
+    });
+    expect(frame.contactCandidate).toBe(candidate);
+    expect(frame.session.contacts).toBe(1);
+    expect(frame.pressure.canContact).toBe(true);
+  });
+
+  it('keeps terminal failure behind the run frame seam after the contact limit', () => {
+    let session = createStampedeSession();
+    for (let index = 0; index < STAMPEDE_CONTACT_LIMIT - 1; index += 1) {
+      session = resolveStampedeContact(session, index * 1_000);
+    }
+
+    const frame = resolveStampedeRunFrame({
+      session,
+      deltaMs: 2_500,
+      closeRequested: false,
+      velocity: baseVelocity,
+      player: basePlayer,
+      contactCandidates: [{ ...basePlayer, radius: 10 }]
+    });
+
+    expect(frame.kind).toBe('playing');
+    if (frame.kind !== 'playing') return;
+    expect(frame.session.phase).toBe('failed');
+    expect(frame.session.contacts).toBe(STAMPEDE_CONTACT_LIMIT);
+    expect(frame.contactCandidate).toEqual({ ...basePlayer, radius: 10 });
+  });
+});

--- a/src/game/scenes/stampedeSketch/runtime/runFlow.ts
+++ b/src/game/scenes/stampedeSketch/runtime/runFlow.ts
@@ -1,0 +1,111 @@
+import {
+  clampStampedePosition,
+  type StampedeVelocity
+} from './movement';
+import {
+  resolveStampedePressure,
+  type StampedeContactCandidate,
+  type StampedePressurePoint,
+  type StampedePressureSnapshot
+} from './pressure';
+import {
+  advanceStampedeSession,
+  resolveStampedeContact,
+  type StampedeSession,
+  type StampedeSessionPhase
+} from './session';
+import type { StampedeSwarmMode } from './swarmPresentation';
+
+export const STAMPEDE_PLAYER_CONTACT_RADIUS = 24;
+
+export interface StampedeRunFrameInput {
+  session: StampedeSession;
+  deltaMs: number;
+  closeRequested: boolean;
+  velocity: StampedeVelocity;
+  player: StampedePressurePoint;
+  contactCandidates: readonly StampedeContactCandidate[];
+}
+
+export interface StampedeRunSwarmFrame {
+  mode: StampedeSwarmMode;
+  pressure: number;
+}
+
+export type StampedeRunFrame =
+  | {
+    kind: 'close';
+    session: StampedeSession;
+  }
+  | {
+    kind: 'terminal';
+    session: StampedeSession;
+    phase: Exclude<StampedeSessionPhase, 'playing'>;
+    swarm: StampedeRunSwarmFrame;
+  }
+  | {
+    kind: 'playing';
+    session: StampedeSession;
+    velocity: StampedeVelocity;
+    player: StampedePressurePoint;
+    pressure: StampedePressureSnapshot;
+    contactCandidate: StampedeContactCandidate | null;
+    swarm: StampedeRunSwarmFrame;
+  };
+
+export function resolveStampedeRunFrame({
+  session,
+  deltaMs,
+  closeRequested,
+  velocity,
+  player,
+  contactCandidates
+}: StampedeRunFrameInput): StampedeRunFrame {
+  if (closeRequested) {
+    return {
+      kind: 'close',
+      session
+    };
+  }
+
+  const advancedSession = advanceStampedeSession(session, deltaMs);
+  if (advancedSession.phase !== 'playing') {
+    return {
+      kind: 'terminal',
+      session: advancedSession,
+      phase: advancedSession.phase,
+      swarm: {
+        mode: 'recover',
+        pressure: advancedSession.phase === 'failed' ? 1 : 0.08
+      }
+    };
+  }
+
+  const clampedPlayer = {
+    ...clampStampedePosition(player),
+    radius: player.radius ?? STAMPEDE_PLAYER_CONTACT_RADIUS
+  };
+  const pressure = resolveStampedePressure({
+    elapsedMs: advancedSession.elapsedMs,
+    durationMs: advancedSession.durationMs,
+    player: clampedPlayer,
+    candidates: contactCandidates,
+    lastContactAtMs: advancedSession.lastContactAtMs
+  });
+  const nextSession = pressure.canContact
+    ? resolveStampedeContact(advancedSession, advancedSession.elapsedMs)
+    : advancedSession;
+
+  return {
+    kind: 'playing',
+    session: nextSession,
+    velocity,
+    player: clampedPlayer,
+    pressure,
+    contactCandidate: pressure.canContact ? pressure.nearestContactCandidate : null,
+    swarm: {
+      mode: pressure.band,
+      pressure: pressure.pressure
+    }
+  };
+}

--- a/src/game/scenes/stampedeSketch/runtime/session.test.ts
+++ b/src/game/scenes/stampedeSketch/runtime/session.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  STAMPEDE_CONTACT_LIMIT,
+  STAMPEDE_SESSION_DURATION_MS,
+  advanceStampedeSession,
+  createStampedeSession,
+  readStampedeSessionSnapshot,
+  resolveStampedeContact
+} from './session';
+
+describe('stampede session', () => {
+  it('clears when the run timer reaches the duration', () => {
+    const session = advanceStampedeSession(
+      createStampedeSession(),
+      STAMPEDE_SESSION_DURATION_MS
+    );
+
+    expect(session.phase).toBe('cleared');
+    expect(session.elapsedMs).toBe(STAMPEDE_SESSION_DURATION_MS);
+  });
+
+  it('clamps timer advance at the duration', () => {
+    const session = advanceStampedeSession(
+      createStampedeSession({ durationMs: 1_000 }),
+      1_500
+    );
+
+    expect(session).toMatchObject({
+      phase: 'cleared',
+      elapsedMs: 1_000
+    });
+  });
+
+  it('fails at the contact limit', () => {
+    let session = createStampedeSession();
+
+    for (let index = 0; index < STAMPEDE_CONTACT_LIMIT; index += 1) {
+      session = resolveStampedeContact(session, index * 100);
+    }
+
+    expect(session.phase).toBe('failed');
+    expect(session.contacts).toBe(STAMPEDE_CONTACT_LIMIT);
+  });
+
+  it('ignores contacts and timer advance after a terminal state', () => {
+    const cleared = advanceStampedeSession(
+      createStampedeSession({ durationMs: 100 }),
+      100
+    );
+    const contacted = resolveStampedeContact(cleared, 100);
+    const advanced = advanceStampedeSession(contacted, 500);
+
+    expect(advanced).toEqual(cleared);
+  });
+
+  it('tracks recent contact as a short-lived marker', () => {
+    const contacted = resolveStampedeContact(createStampedeSession(), 250);
+    const recent = advanceStampedeSession(contacted, 600);
+    const stale = advanceStampedeSession(contacted, 601);
+
+    expect(recent.recentContact).toBe(true);
+    expect(stale.recentContact).toBe(false);
+  });
+
+  it('returns a defensive read snapshot', () => {
+    const session = createStampedeSession();
+
+    expect(readStampedeSessionSnapshot(session)).toEqual(session);
+    expect(readStampedeSessionSnapshot(session)).not.toBe(session);
+  });
+});

--- a/src/game/scenes/stampedeSketch/runtime/session.ts
+++ b/src/game/scenes/stampedeSketch/runtime/session.ts
@@ -1,0 +1,95 @@
+export const STAMPEDE_SESSION_DURATION_MS = 75_000;
+export const STAMPEDE_CONTACT_LIMIT = 3;
+
+const STAMPEDE_RECENT_CONTACT_MS = 600;
+
+export type StampedeSessionPhase = 'playing' | 'cleared' | 'failed';
+
+export interface StampedeSession {
+  phase: StampedeSessionPhase;
+  elapsedMs: number;
+  durationMs: number;
+  contacts: number;
+  lastContactAtMs: number | null;
+  recentContact: boolean;
+}
+
+export interface StampedeSessionOptions {
+  durationMs?: number;
+  contactLimit?: number;
+}
+
+export type StampedeSessionSnapshot = Readonly<StampedeSession>;
+
+export function createStampedeSession(
+  options: StampedeSessionOptions = {}
+): StampedeSession {
+  return {
+    phase: 'playing',
+    elapsedMs: 0,
+    durationMs: Math.max(0, options.durationMs ?? STAMPEDE_SESSION_DURATION_MS),
+    contacts: 0,
+    lastContactAtMs: null,
+    recentContact: false
+  };
+}
+
+export function advanceStampedeSession(
+  session: StampedeSession,
+  deltaMs: number
+): StampedeSession {
+  if (session.phase !== 'playing') return session;
+
+  const elapsedMs = clamp(
+    session.elapsedMs + Math.max(0, deltaMs),
+    0,
+    session.durationMs
+  );
+  const phase: StampedeSessionPhase =
+    elapsedMs >= session.durationMs ? 'cleared' : 'playing';
+
+  return {
+    ...session,
+    phase,
+    elapsedMs,
+    recentContact: isRecentContact(session.lastContactAtMs, elapsedMs)
+  };
+}
+
+export function resolveStampedeContact(
+  session: StampedeSession,
+  atMs: number = session.elapsedMs,
+  options: StampedeSessionOptions = {}
+): StampedeSession {
+  if (session.phase !== 'playing') return session;
+
+  const contactLimit = options.contactLimit ?? STAMPEDE_CONTACT_LIMIT;
+  const elapsedMs = clamp(atMs, 0, session.durationMs);
+  const contacts = session.contacts + 1;
+
+  return {
+    ...session,
+    phase: contacts >= contactLimit ? 'failed' : 'playing',
+    elapsedMs,
+    contacts,
+    lastContactAtMs: elapsedMs,
+    recentContact: true
+  };
+}
+
+export function readStampedeSessionSnapshot(
+  session: StampedeSession
+): StampedeSessionSnapshot {
+  return { ...session };
+}
+
+function isRecentContact(lastContactAtMs: number | null, elapsedMs: number): boolean {
+  return (
+    lastContactAtMs !== null &&
+    elapsedMs - lastContactAtMs <= STAMPEDE_RECENT_CONTACT_MS
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/src/game/scenes/stampedeSketch/runtime/swarmMotion.test.ts
+++ b/src/game/scenes/stampedeSketch/runtime/swarmMotion.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getStampedeSwarmMotion,
+  resolveStampedeSwarmTarget
+} from './swarmMotion';
+
+describe('stampede swarm motion', () => {
+  it('keeps swarm targets distributed around the player instead of all at center', () => {
+    const target = { x: 500, y: 300 };
+    const first = resolveStampedeSwarmTarget({
+      target,
+      phase: 0,
+      mode: 'build',
+      pressure: 0.5,
+      nowMs: 10_000
+    });
+    const second = resolveStampedeSwarmTarget({
+      target,
+      phase: 2.1,
+      mode: 'build',
+      pressure: 0.5,
+      nowMs: 10_000
+    });
+
+    expect(first).not.toEqual(target);
+    expect(second).not.toEqual(target);
+    expect(Math.hypot(first.x - second.x, first.y - second.y)).toBeGreaterThan(40);
+  });
+
+  it('tightens the orbit during surge without collapsing to zero radius', () => {
+    const calm = getStampedeSwarmMotion('calm', 0);
+    const surge = getStampedeSwarmMotion('surge', 1);
+
+    expect(surge.orbitRadius).toBeLessThan(calm.orbitRadius);
+    expect(surge.orbitRadius).toBeGreaterThan(18);
+    expect(surge.centerBias).toBeGreaterThan(0.7);
+  });
+
+  it('cuts inside the broad spacing radius once pressure surges', () => {
+    const build = getStampedeSwarmMotion('build', 0.5);
+    const surge = getStampedeSwarmMotion('surge', 1);
+
+    expect(build.orbitRadius).toBeGreaterThan(30);
+    expect(surge.orbitRadius).toBeLessThan(30);
+  });
+
+  it('blends surge targets close to the player center while keeping build distributed', () => {
+    const target = { x: 500, y: 300 };
+    const build = resolveStampedeSwarmTarget({
+      target,
+      phase: 0,
+      mode: 'build',
+      pressure: 0.5,
+      nowMs: 0
+    });
+    const surge = resolveStampedeSwarmTarget({
+      target,
+      phase: 0,
+      mode: 'surge',
+      pressure: 1,
+      nowMs: 0
+    });
+
+    const buildDistance = Math.hypot(build.x - target.x, build.y - target.y);
+    const surgeDistance = Math.hypot(surge.x - target.x, surge.y - target.y);
+
+    expect(buildDistance).toBeGreaterThan(30);
+    expect(surgeDistance).toBeLessThan(8);
+    expect(surge).not.toEqual(target);
+  });
+});

--- a/src/game/scenes/stampedeSketch/runtime/swarmMotion.ts
+++ b/src/game/scenes/stampedeSketch/runtime/swarmMotion.ts
@@ -1,0 +1,89 @@
+import type { StampedeSwarmMode } from './swarmPresentation';
+
+export interface StampedeSwarmMotion {
+  speedMultiplier: number;
+  wobbleMultiplier: number;
+  alphaMultiplier: number;
+  scaleMultiplier: number;
+  orbitRadius: number;
+  centerBias: number;
+}
+
+interface StampedeSwarmPoint {
+  x: number;
+  y: number;
+}
+
+interface ResolveStampedeSwarmTargetInput {
+  target: StampedeSwarmPoint;
+  phase: number;
+  mode: StampedeSwarmMode;
+  pressure: number;
+  nowMs: number;
+}
+
+export function getStampedeSwarmMotion(
+  mode: StampedeSwarmMode,
+  pressure: number
+): StampedeSwarmMotion {
+  switch (mode) {
+    case 'build':
+      return {
+        speedMultiplier: 1.28 + pressure * 0.48,
+        wobbleMultiplier: 1.1 + pressure * 0.35,
+        alphaMultiplier: 1.05 + pressure * 0.18,
+        scaleMultiplier: 1 + pressure * 0.08,
+        orbitRadius: 42 - pressure * 12,
+        centerBias: pressure * 0.25
+      };
+    case 'surge':
+      return {
+        speedMultiplier: 1.85 + pressure * 0.65,
+        wobbleMultiplier: 1.45 + pressure * 0.4,
+        alphaMultiplier: 1.2 + pressure * 0.24,
+        scaleMultiplier: 1.08 + pressure * 0.16,
+        orbitRadius: 28 - pressure * 6,
+        centerBias: 0.62 + pressure * 0.18
+      };
+    case 'recover':
+      return {
+        speedMultiplier: 0.82 + pressure * 0.12,
+        wobbleMultiplier: 0.86,
+        alphaMultiplier: 0.92,
+        scaleMultiplier: 0.96,
+        orbitRadius: 62,
+        centerBias: 0
+      };
+    case 'calm':
+    default:
+      return {
+        speedMultiplier: 1,
+        wobbleMultiplier: 1,
+        alphaMultiplier: 1,
+        scaleMultiplier: 1,
+        orbitRadius: 54,
+        centerBias: 0
+      };
+  }
+}
+
+export function resolveStampedeSwarmTarget({
+  target,
+  phase,
+  mode,
+  pressure,
+  nowMs
+}: ResolveStampedeSwarmTargetInput): StampedeSwarmPoint {
+  const motion = getStampedeSwarmMotion(mode, pressure);
+  const angle = phase + nowMs / 1450;
+  const offsetScale = 1 - clamp(motion.centerBias, 0, 0.92);
+
+  return {
+    x: target.x + Math.cos(angle) * motion.orbitRadius * offsetScale,
+    y: target.y + Math.sin(angle) * motion.orbitRadius * 0.72 * offsetScale
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/src/game/scenes/stampedeSketch/runtime/swarmPresentation.ts
+++ b/src/game/scenes/stampedeSketch/runtime/swarmPresentation.ts
@@ -99,8 +99,9 @@ class PhaserStampedeSwarmRuntime implements StampedeSwarmRuntime {
 
       const clamped = clampStampedePosition({ x: dot.shape.x, y: dot.shape.y });
       dot.shape.setPosition(clamped.x, clamped.y);
-      dot.shape.setScale((distance < 38 ? 1.35 : 1) * motion.scaleMultiplier);
-      dot.shape.setAlpha(Math.min(distance < 38 ? 0.96 : 0.82, (distance < 38 ? 0.9 : 0.62) * motion.alphaMultiplier));
+      const isNear = distance < 38;
+      dot.shape.setScale((isNear ? 1.35 : 1) * motion.scaleMultiplier);
+      dot.shape.setAlpha(Math.min(isNear ? 0.96 : 0.82, (isNear ? 0.9 : 0.62) * motion.alphaMultiplier));
     });
   }
 

--- a/src/game/scenes/stampedeSketch/runtime/swarmPresentation.ts
+++ b/src/game/scenes/stampedeSketch/runtime/swarmPresentation.ts
@@ -1,5 +1,9 @@
 import * as Phaser from 'phaser';
 import { clampStampedePosition } from './movement';
+import {
+  getStampedeSwarmMotion,
+  resolveStampedeSwarmTarget
+} from './swarmMotion';
 
 interface StampedeSwarmDot {
   shape: Phaser.GameObjects.Arc;
@@ -74,11 +78,19 @@ class PhaserStampedeSwarmRuntime implements StampedeSwarmRuntime {
   update(target: { x: number; y: number }, delta: number, options: StampedeSwarmUpdateOptions = {}): void {
     const deltaSeconds = delta / 1000;
     const pressure = Phaser.Math.Clamp(options.pressure ?? 0, 0, 1);
-    const motion = getSwarmMotion(options.mode ?? 'calm', pressure);
+    const mode = options.mode ?? 'calm';
+    const motion = getStampedeSwarmMotion(mode, pressure);
 
     this.dots.forEach((dot) => {
-      const dx = target.x - dot.shape.x;
-      const dy = target.y - dot.shape.y;
+      const chaseTarget = resolveStampedeSwarmTarget({
+        target,
+        phase: dot.phase,
+        mode,
+        pressure,
+        nowMs: this.scene.time.now
+      });
+      const dx = chaseTarget.x - dot.shape.x;
+      const dy = chaseTarget.y - dot.shape.y;
       const distance = Math.max(1, Math.hypot(dx, dy));
       const wobbleX = Math.sin(this.scene.time.now / 380 + dot.phase) * 8 * motion.wobbleMultiplier;
       const wobbleY = Math.cos(this.scene.time.now / 420 + dot.phase) * 6 * motion.wobbleMultiplier;
@@ -98,42 +110,5 @@ class PhaserStampedeSwarmRuntime implements StampedeSwarmRuntime {
       y: dot.shape.y,
       radius: dot.shape.radius * dot.shape.scaleX
     }));
-  }
-}
-
-function getSwarmMotion(
-  mode: StampedeSwarmMode,
-  pressure: number
-): { speedMultiplier: number; wobbleMultiplier: number; alphaMultiplier: number; scaleMultiplier: number } {
-  switch (mode) {
-    case 'build':
-      return {
-        speedMultiplier: 1.15 + pressure * 0.35,
-        wobbleMultiplier: 1.1 + pressure * 0.35,
-        alphaMultiplier: 1.05 + pressure * 0.18,
-        scaleMultiplier: 1 + pressure * 0.08
-      };
-    case 'surge':
-      return {
-        speedMultiplier: 1.55 + pressure * 0.45,
-        wobbleMultiplier: 1.45 + pressure * 0.4,
-        alphaMultiplier: 1.2 + pressure * 0.24,
-        scaleMultiplier: 1.08 + pressure * 0.16
-      };
-    case 'recover':
-      return {
-        speedMultiplier: 0.82 + pressure * 0.12,
-        wobbleMultiplier: 0.86,
-        alphaMultiplier: 0.92,
-        scaleMultiplier: 0.96
-      };
-    case 'calm':
-    default:
-      return {
-        speedMultiplier: 1,
-        wobbleMultiplier: 1,
-        alphaMultiplier: 1,
-        scaleMultiplier: 1
-      };
   }
 }

--- a/src/game/scenes/stampedeSketch/runtime/swarmPresentation.ts
+++ b/src/game/scenes/stampedeSketch/runtime/swarmPresentation.ts
@@ -1,0 +1,77 @@
+import * as Phaser from 'phaser';
+import { clampStampedePosition } from './movement';
+
+interface StampedeSwarmDot {
+  shape: Phaser.GameObjects.Arc;
+  speed: number;
+  phase: number;
+}
+
+interface StampedeSwarmRuntimeOptions {
+  scene: Phaser.Scene;
+}
+
+export interface StampedeSwarmRuntime {
+  update(target: { x: number; y: number }, delta: number): void;
+}
+
+export function createStampedeSwarmRuntime(
+  options: StampedeSwarmRuntimeOptions
+): StampedeSwarmRuntime {
+  const spawnPoints = [
+    { x: 330, y: 202 },
+    { x: 392, y: 158 },
+    { x: 608, y: 164 },
+    { x: 668, y: 214 },
+    { x: 684, y: 438 },
+    { x: 612, y: 506 },
+    { x: 388, y: 510 },
+    { x: 318, y: 426 },
+    { x: 330, y: 292 },
+    { x: 672, y: 302 }
+  ];
+  const dots = spawnPoints.map((point, index) => ({
+    shape: options.scene.add.circle(
+      point.x,
+      point.y,
+      index % 3 === 0 ? 7 : 5,
+      0x1a1a1a,
+      0.68
+    ).setDepth(20),
+    speed: 18 + index * 2,
+    phase: index * 0.7
+  }));
+
+  return new PhaserStampedeSwarmRuntime(options.scene, dots);
+}
+
+class PhaserStampedeSwarmRuntime implements StampedeSwarmRuntime {
+  private readonly scene: Phaser.Scene;
+  private readonly dots: StampedeSwarmDot[];
+
+  constructor(
+    scene: Phaser.Scene,
+    dots: StampedeSwarmDot[]
+  ) {
+    this.scene = scene;
+    this.dots = dots;
+  }
+
+  update(target: { x: number; y: number }, delta: number): void {
+    const deltaSeconds = delta / 1000;
+    this.dots.forEach((dot) => {
+      const dx = target.x - dot.shape.x;
+      const dy = target.y - dot.shape.y;
+      const distance = Math.max(1, Math.hypot(dx, dy));
+      const wobbleX = Math.sin(this.scene.time.now / 380 + dot.phase) * 8;
+      const wobbleY = Math.cos(this.scene.time.now / 420 + dot.phase) * 6;
+      dot.shape.x += (dx / distance) * dot.speed * deltaSeconds + wobbleX * deltaSeconds;
+      dot.shape.y += (dy / distance) * dot.speed * deltaSeconds + wobbleY * deltaSeconds;
+
+      const clamped = clampStampedePosition({ x: dot.shape.x, y: dot.shape.y });
+      dot.shape.setPosition(clamped.x, clamped.y);
+      dot.shape.setScale(distance < 38 ? 1.35 : 1);
+      dot.shape.setAlpha(distance < 38 ? 0.9 : 0.62);
+    });
+  }
+}

--- a/src/game/scenes/stampedeSketch/runtime/swarmPresentation.ts
+++ b/src/game/scenes/stampedeSketch/runtime/swarmPresentation.ts
@@ -7,12 +7,26 @@ interface StampedeSwarmDot {
   phase: number;
 }
 
+export type StampedeSwarmMode = 'calm' | 'build' | 'surge' | 'recover';
+
+export interface StampedeSwarmUpdateOptions {
+  mode?: StampedeSwarmMode;
+  pressure?: number;
+}
+
+export interface StampedeSwarmContactCandidate {
+  x: number;
+  y: number;
+  radius: number;
+}
+
 interface StampedeSwarmRuntimeOptions {
   scene: Phaser.Scene;
 }
 
 export interface StampedeSwarmRuntime {
-  update(target: { x: number; y: number }, delta: number): void;
+  update(target: { x: number; y: number }, delta: number, options?: StampedeSwarmUpdateOptions): void;
+  getContactCandidates(): readonly StampedeSwarmContactCandidate[];
 }
 
 export function createStampedeSwarmRuntime(
@@ -57,21 +71,69 @@ class PhaserStampedeSwarmRuntime implements StampedeSwarmRuntime {
     this.dots = dots;
   }
 
-  update(target: { x: number; y: number }, delta: number): void {
+  update(target: { x: number; y: number }, delta: number, options: StampedeSwarmUpdateOptions = {}): void {
     const deltaSeconds = delta / 1000;
+    const pressure = Phaser.Math.Clamp(options.pressure ?? 0, 0, 1);
+    const motion = getSwarmMotion(options.mode ?? 'calm', pressure);
+
     this.dots.forEach((dot) => {
       const dx = target.x - dot.shape.x;
       const dy = target.y - dot.shape.y;
       const distance = Math.max(1, Math.hypot(dx, dy));
-      const wobbleX = Math.sin(this.scene.time.now / 380 + dot.phase) * 8;
-      const wobbleY = Math.cos(this.scene.time.now / 420 + dot.phase) * 6;
-      dot.shape.x += (dx / distance) * dot.speed * deltaSeconds + wobbleX * deltaSeconds;
-      dot.shape.y += (dy / distance) * dot.speed * deltaSeconds + wobbleY * deltaSeconds;
+      const wobbleX = Math.sin(this.scene.time.now / 380 + dot.phase) * 8 * motion.wobbleMultiplier;
+      const wobbleY = Math.cos(this.scene.time.now / 420 + dot.phase) * 6 * motion.wobbleMultiplier;
+      dot.shape.x += (dx / distance) * dot.speed * motion.speedMultiplier * deltaSeconds + wobbleX * deltaSeconds;
+      dot.shape.y += (dy / distance) * dot.speed * motion.speedMultiplier * deltaSeconds + wobbleY * deltaSeconds;
 
       const clamped = clampStampedePosition({ x: dot.shape.x, y: dot.shape.y });
       dot.shape.setPosition(clamped.x, clamped.y);
-      dot.shape.setScale(distance < 38 ? 1.35 : 1);
-      dot.shape.setAlpha(distance < 38 ? 0.9 : 0.62);
+      dot.shape.setScale((distance < 38 ? 1.35 : 1) * motion.scaleMultiplier);
+      dot.shape.setAlpha(Math.min(distance < 38 ? 0.96 : 0.82, (distance < 38 ? 0.9 : 0.62) * motion.alphaMultiplier));
     });
+  }
+
+  getContactCandidates(): readonly StampedeSwarmContactCandidate[] {
+    return this.dots.map((dot) => ({
+      x: dot.shape.x,
+      y: dot.shape.y,
+      radius: dot.shape.radius * dot.shape.scaleX
+    }));
+  }
+}
+
+function getSwarmMotion(
+  mode: StampedeSwarmMode,
+  pressure: number
+): { speedMultiplier: number; wobbleMultiplier: number; alphaMultiplier: number; scaleMultiplier: number } {
+  switch (mode) {
+    case 'build':
+      return {
+        speedMultiplier: 1.15 + pressure * 0.35,
+        wobbleMultiplier: 1.1 + pressure * 0.35,
+        alphaMultiplier: 1.05 + pressure * 0.18,
+        scaleMultiplier: 1 + pressure * 0.08
+      };
+    case 'surge':
+      return {
+        speedMultiplier: 1.55 + pressure * 0.45,
+        wobbleMultiplier: 1.45 + pressure * 0.4,
+        alphaMultiplier: 1.2 + pressure * 0.24,
+        scaleMultiplier: 1.08 + pressure * 0.16
+      };
+    case 'recover':
+      return {
+        speedMultiplier: 0.82 + pressure * 0.12,
+        wobbleMultiplier: 0.86,
+        alphaMultiplier: 0.92,
+        scaleMultiplier: 0.96
+      };
+    case 'calm':
+    default:
+      return {
+        speedMultiplier: 1,
+        wobbleMultiplier: 1,
+        alphaMultiplier: 1,
+        scaleMultiplier: 1
+      };
   }
 }

--- a/src/game/scenes/stampedeSketch/sceneContext.ts
+++ b/src/game/scenes/stampedeSketch/sceneContext.ts
@@ -1,0 +1,27 @@
+import { PHASER_SCENE_KEYS, STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
+import type { SceneContextDefinition } from '@/game/sceneLifecycle/types';
+
+interface StampedeSketchSceneContextOptions {
+  onClose: () => void;
+  loadScene: () => Promise<unknown>;
+}
+
+/**
+ * Scene lifecycle contract for the movement-only Stampede Sketch prototype.
+ *
+ * Stampede is entered from Ridge Trail Cards, so closing returns to Ridge
+ * instead of the legacy overworld route used by older interior scenes.
+ */
+export function createStampedeSketchSceneContext(
+  options: StampedeSketchSceneContextOptions
+): SceneContextDefinition {
+  return {
+    id: STAMPEDE_SKETCH_SCENE_ID,
+    sceneKey: PHASER_SCENE_KEYS.stampedeSketch,
+    loadScene: options.loadScene,
+    getStartData: () => ({
+      onClose: options.onClose,
+      isPaused: false
+    })
+  };
+}

--- a/src/game/sharedSceneRuntime/config.ts
+++ b/src/game/sharedSceneRuntime/config.ts
@@ -55,10 +55,10 @@ export const OVERWORLD_PARTICLE_MAX_Y = GAME_DESIGN_HEIGHT;
 
 /**
  * Keycodes passed to Phaser `addCapture` when gameplay resumes after a React overlay.
- * Shift, Space, Arrows, A, D, E, H.
+ * Shift, Space, Arrows, W, A, S, D, E, H.
  */
 export const GAMEPLAY_KEYBOARD_CAPTURES = [
-  16, 32, 37, 38, 39, 40, 65, 68, 69, 72
+  16, 32, 37, 38, 39, 40, 65, 68, 69, 72, 83, 87
 ] as const;
 
 export const getGameConfig = (container: HTMLElement): Phaser.Types.Core.GameConfig => ({

--- a/src/game/sharedSceneRuntime/input/readSceneInputCommands.test.ts
+++ b/src/game/sharedSceneRuntime/input/readSceneInputCommands.test.ts
@@ -94,7 +94,7 @@ describe('readSceneInputCommands', () => {
     expect(frame.exitContext).toBe(true);
   });
 
-  it('maps held H or Escape to exit context', () => {
+  it('does not map held H or Escape to exit context', () => {
     const frame = readSceneInputCommands({
       frame: createInputCommandFrame(),
       cursors: cursors(),
@@ -108,6 +108,6 @@ describe('readSceneInputCommands', () => {
       allowSprint: false
     });
 
-    expect(frame.exitContext).toBe(true);
+    expect(frame.exitContext).toBe(false);
   });
 });

--- a/src/game/sharedSceneRuntime/input/readSceneInputCommands.test.ts
+++ b/src/game/sharedSceneRuntime/input/readSceneInputCommands.test.ts
@@ -93,4 +93,21 @@ describe('readSceneInputCommands', () => {
 
     expect(frame.exitContext).toBe(true);
   });
+
+  it('maps held H or Escape to exit context', () => {
+    const frame = readSceneInputCommands({
+      frame: createInputCommandFrame(),
+      cursors: cursors(),
+      wasd: { a: key(), d: key() },
+      interactKey: key(),
+      hKey: key(true),
+      escapeKey: key(),
+      touch: neutralTouch,
+      oneShots: { jumpQueued: false, interactTap: false },
+      allowJump: false,
+      allowSprint: false
+    });
+
+    expect(frame.exitContext).toBe(true);
+  });
 });

--- a/src/game/sharedSceneRuntime/input/readSceneInputCommands.ts
+++ b/src/game/sharedSceneRuntime/input/readSceneInputCommands.ts
@@ -31,8 +31,8 @@ export function readSceneInputCommands(options: ReadSceneInputOptions): InputCom
   frame.jump = options.allowJump && (cursors.up.isDown || oneShots.jumpQueued);
   frame.interact = Phaser.Input.Keyboard.JustDown(interactKey) || oneShots.interactTap;
   frame.exitContext =
-    (hKey ? hKey.isDown || Phaser.Input.Keyboard.JustDown(hKey) : false) ||
-    (escapeKey ? escapeKey.isDown || Phaser.Input.Keyboard.JustDown(escapeKey) : false);
+    (hKey ? Phaser.Input.Keyboard.JustDown(hKey) : false) ||
+    (escapeKey ? Phaser.Input.Keyboard.JustDown(escapeKey) : false);
 
   return frame;
 }

--- a/src/game/sharedSceneRuntime/input/readSceneInputCommands.ts
+++ b/src/game/sharedSceneRuntime/input/readSceneInputCommands.ts
@@ -31,8 +31,8 @@ export function readSceneInputCommands(options: ReadSceneInputOptions): InputCom
   frame.jump = options.allowJump && (cursors.up.isDown || oneShots.jumpQueued);
   frame.interact = Phaser.Input.Keyboard.JustDown(interactKey) || oneShots.interactTap;
   frame.exitContext =
-    (hKey ? Phaser.Input.Keyboard.JustDown(hKey) : false) ||
-    (escapeKey ? Phaser.Input.Keyboard.JustDown(escapeKey) : false);
+    (hKey ? hKey.isDown || Phaser.Input.Keyboard.JustDown(hKey) : false) ||
+    (escapeKey ? escapeKey.isDown || Phaser.Input.Keyboard.JustDown(escapeKey) : false);
 
   return frame;
 }

--- a/src/game/sharedSceneRuntime/phaserScenePresentation.test.ts
+++ b/src/game/sharedSceneRuntime/phaserScenePresentation.test.ts
@@ -5,20 +5,24 @@ import {
 } from './phaserScenePresentation';
 
 describe('isFullBoardPhaserScene', () => {
-  it('marks Potassium as a full-board scene', () => {
+  it('marks board-owned scenes as full-board scenes', () => {
     expect(isFullBoardPhaserScene('potassium')).toBe(true);
+    expect(isFullBoardPhaserScene('stampedeSketch')).toBe(true);
   });
 
   it('keeps side-view scenes in the portrait shell', () => {
     expect(isFullBoardPhaserScene('hobbies')).toBe(false);
     expect(isFullBoardPhaserScene('basement')).toBe(false);
+    expect(isFullBoardPhaserScene('ridge')).toBe(false);
     expect(isFullBoardPhaserScene(null)).toBe(false);
   });
 
   it('returns the presentation mode for Phaser scene ids', () => {
     expect(getPhaserScenePresentationMode('potassium')).toBe('vertical-board');
+    expect(getPhaserScenePresentationMode('stampedeSketch')).toBe('vertical-board');
     expect(getPhaserScenePresentationMode('hobbies')).toBe('portrait-cover');
     expect(getPhaserScenePresentationMode('basement')).toBe('portrait-cover');
+    expect(getPhaserScenePresentationMode('ridge')).toBe('portrait-cover');
     expect(getPhaserScenePresentationMode(null)).toBe('portrait-cover');
   });
 });

--- a/src/game/sharedSceneRuntime/phaserScenePresentation.ts
+++ b/src/game/sharedSceneRuntime/phaserScenePresentation.ts
@@ -1,11 +1,18 @@
-import { POTASSIUM_SCENE_ID, type SceneId } from '@/game/scenes/sceneIds';
+import {
+  POTASSIUM_SCENE_ID,
+  STAMPEDE_SKETCH_SCENE_ID,
+  type SceneId
+} from '@/game/scenes/sceneIds';
 
-const FULL_BOARD_PHASER_SCENE_IDS = new Set<SceneId>([POTASSIUM_SCENE_ID]);
+const VERTICAL_BOARD_PHASER_SCENE_IDS = new Set<SceneId>([
+  POTASSIUM_SCENE_ID,
+  STAMPEDE_SKETCH_SCENE_ID
+]);
 
 export type PhaserScenePresentationMode = 'portrait-cover' | 'full-board' | 'vertical-board';
 
 export function isFullBoardPhaserScene(id: string | null | undefined): id is SceneId {
-  return id !== null && id !== undefined && FULL_BOARD_PHASER_SCENE_IDS.has(id as SceneId);
+  return id !== null && id !== undefined && VERTICAL_BOARD_PHASER_SCENE_IDS.has(id as SceneId);
 }
 
 export function getPhaserScenePresentationMode(

--- a/src/game/shell/Game.tsx
+++ b/src/game/shell/Game.tsx
@@ -7,10 +7,11 @@ import { usePhaserScaleRefresh } from './usePhaserScaleRefresh';
 import type { PhaserScenePresentationMode } from '@/game/sharedSceneRuntime/phaserScenePresentation';
 import type { SceneId } from '@/game/scenes/sceneIds';
 import type { OverlayId } from '@/game/overlays/overlayIds';
+import type { OpenOverlayOptions } from '@/game/bridge/store';
 
 interface GameProps {
   onEnterScene: (sceneId: SceneId) => void;
-  onOpenOverlay: (overlayId: OverlayId) => void;
+  onOpenOverlay: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   isPaused: boolean;
   activeSceneId: SceneId;
   presentationMode: PhaserScenePresentationMode;

--- a/src/game/shell/InteractiveApp.tsx
+++ b/src/game/shell/InteractiveApp.tsx
@@ -1,6 +1,6 @@
 import { BookOpen, Backpack, Bug } from 'lucide-react';
 import Game from './Game';
-import { bridgeActions, useBridgeState } from '@/game/bridge/store';
+import { bridgeActions, useBridgeState, type OpenOverlayOptions } from '@/game/bridge/store';
 import {
   getPhaserScenePresentationMode,
   type PhaserScenePresentationMode
@@ -39,7 +39,7 @@ export default function InteractiveApp({ onSwitchToStatic }: InteractiveAppProps
   const shouldShowFooterHint = shouldReserveSceneHint || shouldShowNavigationHint;
 
   const enterScene = (sceneId: SceneId) => bridgeActions.enterScene(sceneId);
-  const openOverlay = (overlayId: OverlayId) => bridgeActions.openOverlay(overlayId);
+  const openOverlay = (overlayId: OverlayId, options?: OpenOverlayOptions) => bridgeActions.openOverlay(overlayId, options);
   const returnToOverworld = () => bridgeActions.returnToOverworld();
 
   return (

--- a/src/game/shell/useGameBridgeCallbacks.ts
+++ b/src/game/shell/useGameBridgeCallbacks.ts
@@ -1,10 +1,11 @@
 import { useCallback, useLayoutEffect, useRef } from 'react';
 import type { OverlayId } from '@/game/overlays/overlayIds';
 import type { SceneId } from '@/game/scenes/sceneIds';
+import type { OpenOverlayOptions } from '@/game/bridge/store';
 
 interface GameBridgeCallbacks {
   onEnterScene: (sceneId: SceneId) => void;
-  onOpenOverlay: (overlayId: OverlayId) => void;
+  onOpenOverlay: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   onReturnToOverworld: () => void;
   isPaused: boolean;
 }
@@ -25,8 +26,8 @@ export function useGameBridgeCallbacks({
     bridgeRef.current.onEnterScene(sceneId);
   }, []);
 
-  const stableOnOpenOverlay = useCallback((overlayId: OverlayId) => {
-    bridgeRef.current.onOpenOverlay(overlayId);
+  const stableOnOpenOverlay = useCallback((overlayId: OverlayId, options?: OpenOverlayOptions) => {
+    bridgeRef.current.onOpenOverlay(overlayId, options);
   }, []);
 
   const stableOnReturnToOverworld = useCallback(() => {

--- a/src/game/shell/usePhaserGameBoot.ts
+++ b/src/game/shell/usePhaserGameBoot.ts
@@ -1,6 +1,6 @@
 import { useEffect, type RefObject } from 'react';
 import * as Phaser from 'phaser';
-import { bridgeActions } from '@/game/bridge/store';
+import { bridgeActions, type OpenOverlayOptions } from '@/game/bridge/store';
 import { createSceneContexts } from '@/game/sceneLifecycle/contexts/createSceneContexts';
 import { OverworldScene } from '@/game/scenes/overworld/runtime';
 import { PHASER_SCENE_KEYS, isSceneId, type SceneId } from '@/game/scenes/sceneIds';
@@ -16,13 +16,13 @@ interface UsePhaserGameBootOptions {
   bridgeRef: RefObject<{
     isPaused: boolean;
     onEnterScene: (sceneId: SceneId) => void;
-    onOpenOverlay: (overlayId: OverlayId) => void;
+    onOpenOverlay: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
     onReturnToOverworld: () => void;
   }>;
   containerRef: RefObject<HTMLDivElement | null>;
   gameRef: RefObject<Phaser.Game | null>;
   stableOnEnterScene: (sceneId: SceneId) => void;
-  stableOnOpenOverlay: (overlayId: OverlayId) => void;
+  stableOnOpenOverlay: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   stableOnReturnToOverworld: () => void;
 }
 

--- a/src/shared/i18n/messages/en/catalog.ts
+++ b/src/shared/i18n/messages/en/catalog.ts
@@ -59,4 +59,10 @@ export const catalogMessages = {
       description: "Slip the incoming stakeholders and dodge the deadlines in this slippery challenge.",
     },
   },
+  ridge: {
+    ridge: {
+      name: "Sketchbook Ridge",
+      description: "A compact ridge route toward the Relay Spire.",
+    },
+  },
 } as const;

--- a/src/shared/i18n/messages/en/catalog.ts
+++ b/src/shared/i18n/messages/en/catalog.ts
@@ -65,4 +65,10 @@ export const catalogMessages = {
       description: "A compact ridge route toward the Relay Spire.",
     },
   },
+  stampedeSketch: {
+    stampedeSketch: {
+      name: "Stampede Sketch",
+      description: "A movement-only ink swarm prototype around a picnic blanket.",
+    },
+  },
 } as const;

--- a/src/shared/i18n/messages/en/index.ts
+++ b/src/shared/i18n/messages/en/index.ts
@@ -2,6 +2,7 @@ import { catalogMessages } from './catalog';
 import { commonMessages } from './common';
 import { gameShellMessages } from './gameShell';
 import { inventoryMessages } from './inventory';
+import { manualPageMessages } from './manualPage';
 import { miniGameMessages } from './miniGames';
 import { modePickerMessages } from './modePicker';
 import { navigationMessages } from './navigation';
@@ -18,6 +19,7 @@ export const enMessages = {
   staticPortfolio: staticPortfolioMessages,
   gameShell: gameShellMessages,
   inventory: inventoryMessages,
+  manualPage: manualPageMessages,
   portfolio: portfolioMessages,
   catalog: catalogMessages,
   scenes: sceneMessages,

--- a/src/shared/i18n/messages/en/index.ts
+++ b/src/shared/i18n/messages/en/index.ts
@@ -9,6 +9,7 @@ import { portfolioMessages } from './portfolio';
 import { potassiumSlipMessages } from './potassiumSlip';
 import { sceneMessages } from './scenes';
 import { staticPortfolioMessages } from './staticPortfolio';
+import { trailCardMessages } from './trailCard';
 
 export const enMessages = {
   common: commonMessages,
@@ -22,4 +23,5 @@ export const enMessages = {
   scenes: sceneMessages,
   miniGames: miniGameMessages,
   potassiumSlip: potassiumSlipMessages,
+  trailCard: trailCardMessages,
 } as const;

--- a/src/shared/i18n/messages/en/manualPage.ts
+++ b/src/shared/i18n/messages/en/manualPage.ts
@@ -1,0 +1,8 @@
+export const manualPageMessages = {
+  fallbackTitle: "Manual Page",
+  clue: "Clue",
+  marginNote: "Margin note",
+  fallbackClue: "The page is still too smudged to read.",
+  fallbackMarginNote: "Come back when the ink settles.",
+  close: "Close page",
+} as const;

--- a/src/shared/i18n/messages/en/trailCard.ts
+++ b/src/shared/i18n/messages/en/trailCard.ts
@@ -1,0 +1,10 @@
+export const trailCardMessages = {
+  fallbackTitle: "Trail Card",
+  mood: "Mood",
+  time: "Time",
+  reward: "Reward",
+  unavailable: "Unavailable",
+  unavailableFallback: "This trail is not ready yet.",
+  enter: "Enter",
+  back: "Back to Ridge",
+} as const;

--- a/src/shared/ui/DialogCard/DialogCard.tsx
+++ b/src/shared/ui/DialogCard/DialogCard.tsx
@@ -38,12 +38,12 @@ export function DialogCard({
 
       <h2
         id={titleId}
-        className="mb-3 mt-1 border-b-4 border-[#1a1a1a] pb-2 pr-14 text-2xl font-bold uppercase tracking-wider sm:mb-4 sm:mt-0 sm:pr-16 sm:text-4xl"
+        className="mb-3 mt-1 break-words border-b-4 border-[#1a1a1a] pb-2 pr-14 text-2xl font-bold uppercase leading-tight tracking-wider [overflow-wrap:anywhere] sm:mb-4 sm:mt-0 sm:pr-16 sm:text-4xl"
       >
         {title}
       </h2>
 
-      <div className="mt-4 text-base leading-relaxed sm:mt-6 sm:text-xl">
+      <div className="mt-4 text-base leading-relaxed [overflow-wrap:anywhere] sm:mt-6 sm:text-xl">
         {description ? (
           <p id={descriptionId} className="mb-6 font-medium italic opacity-80 sm:mb-8">{description}</p>
         ) : descriptionId ? (


### PR DESCRIPTION
## Summary
- Add the Ridge trigger contract with reusable Trail Card and Manual Page overlays.
- Wire Ridge, Stampede Sketch, and scene lifecycle callbacks through the shared bridge path.
- Build the Stampede Sketch prototype with movement, pressure loop, HUD, soft contact feedback, and scene-local run/swarm modules.
- Update docs and milestone notes so the next M4 slice can resume cleanly.

## Testing
- Added and updated unit tests for overlay resolution, Ridge layout, scene context wiring, and Stampede runtime modules.
- Local validation passed with lint, typecheck/build, and the full test suite.