### PR TITLE
Wire Stampede first-clear rewards into Ridge memory

### DIFF
--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -267,16 +267,19 @@ Current checkpoint:
   HUD/scene, raised prototype survivability, and telegraphed mark respawns.
   The respawn warning is now part of the prototype loop because it creates
   fairer avoidance and direction-planning decisions.
-  This remains prototype behavior and does not award durable Ridge progress.
+- **M4f Durable Rewards Draft** accepted for continuation: first Stampede clear
+  now awards the `stampede-sketch` Ridge stamp and one glide pip through bridge
+  progress, repeat clears do not duplicate the reward, the result panel reports
+  earned/already-owned reward state, and Ridge renders one small Stampede blanket
+  memory mark derived from the stamp.
 - Scene architecture is intentionally scene-local. `StampedeSketchScene` should
   remain the Phaser adapter/orchestrator while run decisions live behind
   `runtime/runFlow.ts` and swarm steering lives behind `runtime/swarmMotion.ts`.
 
 Next implementation slices:
 
-1. **M4f Stampede Durable Rewards Draft**: wire first-clear Stampede reward ids,
-   one stamp, one glide pip, and the smallest Ridge memory response now that the
-   scene-local loop feels fair enough to reward.
+1. **M5 Ridge Memory**: broaden reward memory from the one Stampede first-clear
+   response into the planned Ridge sticker/world-change layer.
 
 Hold until later:
 

--- a/src/game/bridge/ridgeProgressIds.ts
+++ b/src/game/bridge/ridgeProgressIds.ts
@@ -1,0 +1,1 @@
+export const STAMPEDE_SKETCH_RIDGE_STAMP_ID = 'stampede-sketch' as const;

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -97,7 +97,7 @@ export class RidgeScene extends Phaser.Scene {
     const ground = this.createGround();
 
     this.addBackdrop();
-    this.addLandmarks();
+    this.addLandmarks(messages.scenes.ridge.memory.stampedeFirstClearLabel);
     this.addPlaceholderCopy();
     this.createPlayer(ground);
     this.createTrailCardInteractions(messages.navigation.interact);
@@ -250,14 +250,14 @@ export class RidgeScene extends Phaser.Scene {
     this.add.circle(x + 46, 166, 12, 0xf0d35f, 0.9);
   }
 
-  private addLandmarks(): void {
+  private addLandmarks(stampedeFirstClearLabel: string): void {
     RIDGE_LANDMARKS.forEach((landmark) => {
       switch (landmark.kind) {
         case 'cicka-perch':
           this.addCickaPerch(landmark);
           break;
         case 'stampede-blanket':
-          this.addStampedeBlanket(landmark);
+          this.addStampedeBlanket(landmark, stampedeFirstClearLabel);
           break;
         case 'telegraph-bag':
           this.addTelegraphBag(landmark);
@@ -288,7 +288,10 @@ export class RidgeScene extends Phaser.Scene {
     this.add.line(x - 18, y - 32, -30, 0, -54, -10, 0x1f1f1d, 0.9).setLineWidth(5);
   }
 
-  private addStampedeBlanket(landmark: RidgeLandmark): void {
+  private addStampedeBlanket(
+    landmark: RidgeLandmark,
+    stampedeFirstClearLabel: string
+  ): void {
     const x = landmark.x;
     const y = RIDGE_FLOOR_Y - 46;
     const memory = getRidgeLandmarkMemory(
@@ -302,15 +305,19 @@ export class RidgeScene extends Phaser.Scene {
     this.add.circle(x + 28, y - 20, 9, 0x1f1f1d, 0.75);
     this.add.line(x, y - 42, -34, 6, 34, -6, 0x1f1f1d, 0.32).setLineWidth(3);
     if (memory === 'stampede-first-clear') {
-      this.addStampedeBlanketMemory(x, y);
+      this.addStampedeBlanketMemory(x, y, stampedeFirstClearLabel);
     }
   }
 
-  private addStampedeBlanketMemory(x: number, y: number): void {
+  private addStampedeBlanketMemory(
+    x: number,
+    y: number,
+    stampedeFirstClearLabel: string
+  ): void {
     this.add.rectangle(x + 42, y - 48, 58, 26, 0xf7f1df, 1)
       .setStrokeStyle(3, 0x1f1f1d, 0.95)
       .setAngle(-8);
-    this.add.text(x + 20, y - 57, 'HELD', {
+    this.add.text(x + 20, y - 57, stampedeFirstClearLabel, {
       fontFamily: 'monospace',
       fontSize: '12px',
       color: '#1f1f1d'

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -1,6 +1,10 @@
 import * as Phaser from 'phaser';
 import { PHASER_SCENE_KEYS } from '@/game/scenes/sceneIds';
-import { isItemEquipped, type OpenOverlayOptions } from '@/game/bridge/store';
+import {
+  bridgeStore,
+  isItemEquipped,
+  type OpenOverlayOptions
+} from '@/game/bridge/store';
 import { TRAIL_CARD_OVERLAY_ID, type OverlayId } from '@/game/overlays/overlayIds';
 import { getMessages } from '@/shared/i18n';
 import {
@@ -28,6 +32,7 @@ import {
   RIDGE_PLAYER_START,
   RIDGE_TRAIL_CARD_TARGETS,
   RIDGE_WORLD_WIDTH,
+  getRidgeLandmarkMemory,
   type RidgeTrailCardTargetId,
   type RidgeLandmark
 } from '../worldLayout';
@@ -286,12 +291,31 @@ export class RidgeScene extends Phaser.Scene {
   private addStampedeBlanket(landmark: RidgeLandmark): void {
     const x = landmark.x;
     const y = RIDGE_FLOOR_Y - 46;
+    const memory = getRidgeLandmarkMemory(
+      landmark,
+      bridgeStore.getState().progress.ridge
+    );
     this.add.rectangle(x, y, 104, 32, 0xb85f5a, 0.9);
     this.add.rectangle(x - 26, y, 18, 32, 0xf7f1df, 0.7);
     this.add.rectangle(x + 26, y, 18, 32, 0xf7f1df, 0.7);
     this.add.circle(x - 22, y - 26, 11, 0x1f1f1d, 0.92);
     this.add.circle(x + 28, y - 20, 9, 0x1f1f1d, 0.75);
     this.add.line(x, y - 42, -34, 6, 34, -6, 0x1f1f1d, 0.32).setLineWidth(3);
+    if (memory === 'stampede-first-clear') {
+      this.addStampedeBlanketMemory(x, y);
+    }
+  }
+
+  private addStampedeBlanketMemory(x: number, y: number): void {
+    this.add.rectangle(x + 42, y - 48, 58, 26, 0xf7f1df, 1)
+      .setStrokeStyle(3, 0x1f1f1d, 0.95)
+      .setAngle(-8);
+    this.add.text(x + 20, y - 57, 'HELD', {
+      fontFamily: 'monospace',
+      fontSize: '12px',
+      color: '#1f1f1d'
+    }).setAngle(-8).setDepth(5);
+    this.add.line(x + 9, y - 32, -12, 10, 12, -10, 0x1f1f1d, 0.52).setLineWidth(2);
   }
 
   private addTelegraphBag(landmark: RidgeLandmark): void {

--- a/src/game/scenes/ridge/worldLayout.test.ts
+++ b/src/game/scenes/ridge/worldLayout.test.ts
@@ -5,8 +5,10 @@ import {
   RIDGE_PLAYER_RESUME_CLAMP,
   RIDGE_PLAYER_START,
   RIDGE_TRAIL_CARD_TARGETS,
-  RIDGE_WORLD_WIDTH
+  RIDGE_WORLD_WIDTH,
+  getRidgeLandmarkMemory
 } from './worldLayout';
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
 import { STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
 
 describe('ridge world layout', () => {
@@ -55,5 +57,22 @@ describe('ridge world layout', () => {
     expect(stampede?.card.enterSceneId).toBe(STAMPEDE_SKETCH_SCENE_ID);
     expect(stampede?.card.unavailableReason).toBeUndefined();
     expect(unavailable.every((target) => target.card.unavailableReason && !target.card.enterSceneId)).toBe(true);
+  });
+
+  it('derives the Stampede blanket memory from the first-clear stamp', () => {
+    const stampedeBlanket = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'stampede-blanket');
+    const telegraphBag = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'telegraph-bag');
+
+    expect(stampedeBlanket).toBeDefined();
+    expect(telegraphBag).toBeDefined();
+    if (!stampedeBlanket || !telegraphBag) return;
+
+    expect(getRidgeLandmarkMemory(stampedeBlanket, { stampIds: [] })).toBeNull();
+    expect(getRidgeLandmarkMemory(stampedeBlanket, {
+      stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
+    })).toBe('stampede-first-clear');
+    expect(getRidgeLandmarkMemory(telegraphBag, {
+      stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
+    })).toBeNull();
   });
 });

--- a/src/game/scenes/ridge/worldLayout.ts
+++ b/src/game/scenes/ridge/worldLayout.ts
@@ -1,4 +1,6 @@
 import type { TrailCardOverlayParams } from '@/game/overlays/trailCard/types';
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+import type { BridgeRidgeProgressState } from '@/game/bridge/store';
 import { STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
 
 export const RIDGE_WORLD_WIDTH = 1800;
@@ -27,9 +29,11 @@ export interface RidgeLandmark {
 }
 
 export type RidgeTrailCardTargetId =
-  | 'stampede-sketch'
+  | typeof STAMPEDE_SKETCH_RIDGE_STAMP_ID
   | 'telegraph-terrace'
   | 'domino-desk';
+
+export type RidgeLandmarkMemoryKind = 'stampede-first-clear';
 
 export interface RidgeTrailCardTarget {
   id: RidgeTrailCardTargetId;
@@ -41,6 +45,19 @@ export interface RidgeTrailCardTarget {
     y: number;
   };
   card: TrailCardOverlayParams;
+}
+
+export function getRidgeLandmarkMemory(
+  landmark: Pick<RidgeLandmark, 'kind'>,
+  ridgeProgress: Pick<BridgeRidgeProgressState, 'stampIds'>
+): RidgeLandmarkMemoryKind | null {
+  if (
+    landmark.kind === 'stampede-blanket' &&
+    ridgeProgress.stampIds.includes(STAMPEDE_SKETCH_RIDGE_STAMP_ID)
+  ) {
+    return 'stampede-first-clear';
+  }
+  return null;
 }
 
 export const RIDGE_LANDMARKS: readonly RidgeLandmark[] = [
@@ -84,7 +101,7 @@ export const RIDGE_LANDMARKS: readonly RidgeLandmark[] = [
 
 export const RIDGE_TRAIL_CARD_TARGETS: readonly RidgeTrailCardTarget[] = [
   {
-    id: 'stampede-sketch',
+    id: STAMPEDE_SKETCH_RIDGE_STAMP_ID,
     landmarkKind: 'stampede-blanket',
     x: 430,
     distanceAnchorY: RIDGE_FLOOR_Y - 56,

--- a/src/game/scenes/stampedeSketch/runtime/StampedeSketchScene.ts
+++ b/src/game/scenes/stampedeSketch/runtime/StampedeSketchScene.ts
@@ -50,6 +50,7 @@ import {
   resolveStampedeRunFrame,
   STAMPEDE_PLAYER_CONTACT_RADIUS
 } from './runFlow';
+import { claimStampedeFirstClearReward } from './rewards';
 import {
   createStampedeResultViewModel,
   type StampedeResultViewModel
@@ -336,7 +337,10 @@ export class StampedeSketchScene extends Phaser.Scene {
       phase,
       elapsedMs: this.session.elapsedMs,
       durationMs: this.session.durationMs,
-      contacts: this.session.contacts
+      contacts: this.session.contacts,
+      rewardStatus: phase === 'cleared'
+        ? claimStampedeFirstClearReward()
+        : 'unavailable'
     });
     this.showResultPanel(view);
   }

--- a/src/game/scenes/stampedeSketch/runtime/resultPresentation.test.ts
+++ b/src/game/scenes/stampedeSketch/runtime/resultPresentation.test.ts
@@ -7,13 +7,14 @@ describe('stampede result presentation view model', () => {
       phase: 'cleared',
       elapsedMs: 75_000,
       durationMs: 75_000,
-      contacts: 1
+      contacts: 1,
+      rewardStatus: 'earned'
     });
 
     expect(view.title).toBe('Blanket held');
     expect(view.eyebrow).toBe('Run complete');
     expect(view.body).toBe('The sketch stayed calm through the whole stampede.');
-    expect(view.rewardNote).toBe('No stamp yet. Rewards are still taped over.');
+    expect(view.rewardNote).toBe('Stamp earned. One glide pip tucked into the Ridge.');
     expect(view.actions).toEqual([
       {
         id: 'backToRidge',
@@ -28,6 +29,20 @@ describe('stampede result presentation view model', () => {
     ]);
   });
 
+  it('marks repeat clears as already rewarded', () => {
+    const view = createStampedeResultViewModel({
+      phase: 'cleared',
+      elapsedMs: 75_000,
+      durationMs: 75_000,
+      contacts: 0,
+      rewardStatus: 'alreadyOwned'
+    });
+
+    expect(view.rewardNote).toBe(
+      'Stamp already owned. Glide pip already tucked into the Ridge.'
+    );
+  });
+
   it('prioritizes retry after a failure', () => {
     const view = createStampedeResultViewModel({
       phase: 'failed',
@@ -39,6 +54,9 @@ describe('stampede result presentation view model', () => {
     expect(view.title).toBe('Page got crowded');
     expect(view.eyebrow).toBe('Run ended');
     expect(view.body).toBe('Too many marks landed before the timer ran out.');
+    expect(view.rewardNote).toBe(
+      'Hold the blanket to earn the Stampede stamp and glide pip.'
+    );
     expect(view.actions).toEqual([
       {
         id: 'retry',

--- a/src/game/scenes/stampedeSketch/runtime/resultPresentation.test.ts
+++ b/src/game/scenes/stampedeSketch/runtime/resultPresentation.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { getMessages } from '@/shared/i18n';
 import { createStampedeResultViewModel } from './resultPresentation';
 
 describe('stampede result presentation view model', () => {
+  const copy = getMessages().scenes.stampedeSketch.result;
+
   it('prioritizes returning to Ridge after a clear', () => {
     const view = createStampedeResultViewModel({
       phase: 'cleared',
@@ -11,19 +14,19 @@ describe('stampede result presentation view model', () => {
       rewardStatus: 'earned'
     });
 
-    expect(view.title).toBe('Blanket held');
-    expect(view.eyebrow).toBe('Run complete');
-    expect(view.body).toBe('The sketch stayed calm through the whole stampede.');
-    expect(view.rewardNote).toBe('Stamp earned. One glide pip tucked into the Ridge.');
+    expect(view.title).toBe(copy.title.cleared);
+    expect(view.eyebrow).toBe(copy.eyebrow.cleared);
+    expect(view.body).toBe(copy.body.cleared);
+    expect(view.rewardNote).toBe(copy.rewardNote.earned);
     expect(view.actions).toEqual([
       {
         id: 'backToRidge',
-        label: 'Back to Ridge',
+        label: copy.actions.backToRidge,
         priority: 'primary'
       },
       {
         id: 'retry',
-        label: 'Retry',
+        label: copy.actions.retry,
         priority: 'secondary'
       }
     ]);
@@ -38,9 +41,7 @@ describe('stampede result presentation view model', () => {
       rewardStatus: 'alreadyOwned'
     });
 
-    expect(view.rewardNote).toBe(
-      'Stamp already owned. Glide pip already tucked into the Ridge.'
-    );
+    expect(view.rewardNote).toBe(copy.rewardNote.alreadyOwned);
   });
 
   it('prioritizes retry after a failure', () => {
@@ -51,21 +52,19 @@ describe('stampede result presentation view model', () => {
       contacts: 3
     });
 
-    expect(view.title).toBe('Page got crowded');
-    expect(view.eyebrow).toBe('Run ended');
-    expect(view.body).toBe('Too many marks landed before the timer ran out.');
-    expect(view.rewardNote).toBe(
-      'Hold the blanket to earn the Stampede stamp and glide pip.'
-    );
+    expect(view.title).toBe(copy.title.failed);
+    expect(view.eyebrow).toBe(copy.eyebrow.failed);
+    expect(view.body).toBe(copy.body.failed);
+    expect(view.rewardNote).toBe(copy.rewardNote.failed);
     expect(view.actions).toEqual([
       {
         id: 'retry',
-        label: 'Retry',
+        label: copy.actions.retry,
         priority: 'primary'
       },
       {
         id: 'backToRidge',
-        label: 'Back to Ridge',
+        label: copy.actions.backToRidge,
         priority: 'secondary'
       }
     ]);
@@ -82,12 +81,12 @@ describe('stampede result presentation view model', () => {
     expect(view.stats).toEqual([
       {
         id: 'time',
-        label: 'Time',
+        label: copy.stats.time,
         value: '1:02'
       },
       {
         id: 'contacts',
-        label: 'Contacts',
+        label: copy.stats.contacts,
         value: '2'
       }
     ]);

--- a/src/game/scenes/stampedeSketch/runtime/resultPresentation.ts
+++ b/src/game/scenes/stampedeSketch/runtime/resultPresentation.ts
@@ -1,12 +1,14 @@
 export type StampedeResultPhase = 'cleared' | 'failed';
 export type StampedeResultActionId = 'backToRidge' | 'retry';
 export type StampedeResultActionPriority = 'primary' | 'secondary';
+export type StampedeRewardStatus = 'earned' | 'alreadyOwned' | 'unavailable';
 
 export interface StampedeResultViewModelInput {
   phase: StampedeResultPhase;
   elapsedMs: number;
   durationMs: number;
   contacts: number;
+  rewardStatus?: StampedeRewardStatus;
 }
 
 export interface StampedeResultStatViewModel {
@@ -51,7 +53,7 @@ export function createStampedeResultViewModel(
     body: clear
       ? 'The sketch stayed calm through the whole stampede.'
       : 'Too many marks landed before the timer ran out.',
-    rewardNote: 'No stamp yet. Rewards are still taped over.',
+    rewardNote: getRewardNote(input.rewardStatus ?? 'unavailable', clear),
     stats: [
       {
         id: 'time',
@@ -90,6 +92,20 @@ export function createStampedeResultViewModel(
           }
         ]
   };
+}
+
+function getRewardNote(status: StampedeRewardStatus, clear: boolean): string {
+  if (!clear) {
+    return 'Hold the blanket to earn the Stampede stamp and glide pip.';
+  }
+  switch (status) {
+    case 'earned':
+      return 'Stamp earned. One glide pip tucked into the Ridge.';
+    case 'alreadyOwned':
+      return 'Stamp already owned. Glide pip already tucked into the Ridge.';
+    case 'unavailable':
+      return 'No stamp yet. Rewards are still taped over.';
+  }
 }
 
 function formatResultTime(elapsedMs: number, durationMs: number): string {

--- a/src/game/scenes/stampedeSketch/runtime/resultPresentation.ts
+++ b/src/game/scenes/stampedeSketch/runtime/resultPresentation.ts
@@ -1,7 +1,10 @@
+import { getMessages } from '@/shared/i18n';
+
 export type StampedeResultPhase = 'cleared' | 'failed';
 export type StampedeResultActionId = 'backToRidge' | 'retry';
 export type StampedeResultActionPriority = 'primary' | 'secondary';
 export type StampedeRewardStatus = 'earned' | 'alreadyOwned' | 'unavailable';
+export type StampedeResultCopy = ReturnType<typeof getMessages>['scenes']['stampedeSketch']['result'];
 
 export interface StampedeResultViewModelInput {
   phase: StampedeResultPhase;
@@ -45,24 +48,25 @@ export function createStampedeResultViewModel(
   input: StampedeResultViewModelInput
 ): StampedeResultViewModel {
   const clear = input.phase === 'cleared';
+  const copy = getMessages().scenes.stampedeSketch.result;
 
   return {
     phase: input.phase,
-    eyebrow: clear ? 'Run complete' : 'Run ended',
-    title: clear ? 'Blanket held' : 'Page got crowded',
+    eyebrow: clear ? copy.eyebrow.cleared : copy.eyebrow.failed,
+    title: clear ? copy.title.cleared : copy.title.failed,
     body: clear
-      ? 'The sketch stayed calm through the whole stampede.'
-      : 'Too many marks landed before the timer ran out.',
-    rewardNote: getRewardNote(input.rewardStatus ?? 'unavailable', clear),
+      ? copy.body.cleared
+      : copy.body.failed,
+    rewardNote: getRewardNote(input.rewardStatus ?? 'unavailable', clear, copy),
     stats: [
       {
         id: 'time',
-        label: 'Time',
+        label: copy.stats.time,
         value: formatResultTime(input.elapsedMs, input.durationMs)
       },
       {
         id: 'contacts',
-        label: 'Contacts',
+        label: copy.stats.contacts,
         value: `${Math.max(0, input.contacts)}`
       }
     ],
@@ -70,41 +74,45 @@ export function createStampedeResultViewModel(
       ? [
           {
             id: 'backToRidge',
-            label: 'Back to Ridge',
+            label: copy.actions.backToRidge,
             priority: 'primary'
           },
           {
             id: 'retry',
-            label: 'Retry',
+            label: copy.actions.retry,
             priority: 'secondary'
           }
         ]
       : [
           {
             id: 'retry',
-            label: 'Retry',
+            label: copy.actions.retry,
             priority: 'primary'
           },
           {
             id: 'backToRidge',
-            label: 'Back to Ridge',
+            label: copy.actions.backToRidge,
             priority: 'secondary'
           }
         ]
   };
 }
 
-function getRewardNote(status: StampedeRewardStatus, clear: boolean): string {
+function getRewardNote(
+  status: StampedeRewardStatus,
+  clear: boolean,
+  copy: StampedeResultCopy
+): string {
   if (!clear) {
-    return 'Hold the blanket to earn the Stampede stamp and glide pip.';
+    return copy.rewardNote.failed;
   }
   switch (status) {
     case 'earned':
-      return 'Stamp earned. One glide pip tucked into the Ridge.';
+      return copy.rewardNote.earned;
     case 'alreadyOwned':
-      return 'Stamp already owned. Glide pip already tucked into the Ridge.';
+      return copy.rewardNote.alreadyOwned;
     case 'unavailable':
-      return 'No stamp yet. Rewards are still taped over.';
+      return copy.rewardNote.unavailable;
   }
 }
 

--- a/src/game/scenes/stampedeSketch/runtime/rewards.test.ts
+++ b/src/game/scenes/stampedeSketch/runtime/rewards.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+import { bridgeActions, bridgeStore } from '@/game/bridge/store';
+import {
+  STAMPEDE_FIRST_CLEAR_GLIDE_PIPS,
+  claimStampedeFirstClearReward,
+  getStampedeFirstClearRewardStatus
+} from './rewards';
+
+describe('stampede durable rewards', () => {
+  beforeEach(() => {
+    bridgeActions.resetProgress();
+  });
+
+  it('awards the first-clear stamp and one glide pip once', () => {
+    expect(claimStampedeFirstClearReward()).toBe('earned');
+    expect(bridgeStore.getState().progress.ridge.stampIds).toEqual([
+      STAMPEDE_SKETCH_RIDGE_STAMP_ID
+    ]);
+    expect(bridgeStore.getState().progress.ridge.mobility.glidePips).toBe(
+      STAMPEDE_FIRST_CLEAR_GLIDE_PIPS
+    );
+
+    expect(claimStampedeFirstClearReward()).toBe('alreadyOwned');
+    expect(bridgeStore.getState().progress.ridge.stampIds).toEqual([
+      STAMPEDE_SKETCH_RIDGE_STAMP_ID
+    ]);
+    expect(bridgeStore.getState().progress.ridge.mobility.glidePips).toBe(
+      STAMPEDE_FIRST_CLEAR_GLIDE_PIPS
+    );
+  });
+
+  it('derives reward status from the Stampede stamp id', () => {
+    expect(getStampedeFirstClearRewardStatus({ stampIds: [] })).toBe('earned');
+    expect(getStampedeFirstClearRewardStatus({
+      stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
+    })).toBe('alreadyOwned');
+  });
+});

--- a/src/game/scenes/stampedeSketch/runtime/rewards.ts
+++ b/src/game/scenes/stampedeSketch/runtime/rewards.ts
@@ -1,0 +1,28 @@
+import {
+  bridgeActions,
+  bridgeStore,
+  type BridgeRidgeProgressState
+} from '@/game/bridge/store';
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+import type { StampedeRewardStatus } from './resultPresentation';
+
+export const STAMPEDE_FIRST_CLEAR_GLIDE_PIPS = 1;
+
+export function getStampedeFirstClearRewardStatus(
+  ridgeProgress: Pick<BridgeRidgeProgressState, 'stampIds'>
+): StampedeRewardStatus {
+  return ridgeProgress.stampIds.includes(STAMPEDE_SKETCH_RIDGE_STAMP_ID)
+    ? 'alreadyOwned'
+    : 'earned';
+}
+
+export function claimStampedeFirstClearReward(): StampedeRewardStatus {
+  const status = getStampedeFirstClearRewardStatus(
+    bridgeStore.getState().progress.ridge
+  );
+  if (status === 'alreadyOwned') return status;
+
+  bridgeActions.awardRidgeStamp(STAMPEDE_SKETCH_RIDGE_STAMP_ID);
+  bridgeActions.awardRidgeGlidePip(STAMPEDE_FIRST_CLEAR_GLIDE_PIPS);
+  return status;
+}

--- a/src/shared/i18n/messages/en/scenes.ts
+++ b/src/shared/i18n/messages/en/scenes.ts
@@ -24,4 +24,39 @@ export const sceneMessages = {
       dancing: "DANCE",
     },
   },
+  ridge: {
+    memory: {
+      stampedeFirstClearLabel: "HELD",
+    },
+  },
+  stampedeSketch: {
+    result: {
+      eyebrow: {
+        cleared: "Run complete",
+        failed: "Run ended",
+      },
+      title: {
+        cleared: "Blanket held",
+        failed: "Page got crowded",
+      },
+      body: {
+        cleared: "The sketch stayed calm through the whole stampede.",
+        failed: "Too many marks landed before the timer ran out.",
+      },
+      rewardNote: {
+        earned: "Stamp earned. One glide pip tucked into the Ridge.",
+        alreadyOwned: "Stamp already owned. Glide pip already tucked into the Ridge.",
+        unavailable: "No stamp yet. Rewards are still taped over.",
+        failed: "Hold the blanket to earn the Stampede stamp and glide pip.",
+      },
+      stats: {
+        time: "Time",
+        contacts: "Contacts",
+      },
+      actions: {
+        backToRidge: "Back to Ridge",
+        retry: "Retry",
+      },
+    },
+  },
 } as const;


### PR DESCRIPTION
## Summary
- Add durable first-clear Stampede rewards through the existing bridge progress store: one `stampede-sketch` stamp and one glide pip.
- Update Stampede result copy so clears report earned vs already-owned reward state.
- Render a small derived Stampede memory mark on the Ridge blanket when the stamp is present.
- Keep the M4f milestone notes aligned with the implemented slice.

## Testing
- Added and updated unit tests for reward claiming, result presentation, and Ridge memory derivation.
- Ran `vitest`, `tsc --noEmit`, `eslint .`, `docs:check`, and `vite build` successfully.
- Verified the result panel and Ridge memory mark in the local browser with Playwright.