### PR TITLE
Add derived Ridge memory layer and dev stamp seeding

### DIFF
--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -44,7 +44,16 @@ Anything beyond that is future scope unless a slice explicitly pulls it in.
   match the visible notebook page, added HP/contact readability, softened the
   contact limit, and added respawn telegraphs. The tuning pass is accepted for
   continuation; the respawn warning improved fairness and added useful route
-  planning. Durable reward wiring remains held for the next slice.
+  planning. M4f durable rewards are accepted for continuation: first clear
+  awards the `stampede-sketch` Ridge stamp and one glide pip, repeat clears do
+  not duplicate rewards, and the result panel reports earned/already-owned
+  reward state.
+- **M5 Ridge Memory** has its first visual slices accepted for continuation:
+  M5a derives Ridge-owned sticker/world-change memories from durable progress
+  without stored sticker state, and M5b adds the first Cicka note/translator
+  tease plus a dev-only `devRidgeStamp=stampede-sketch` seed for fast local
+  testing. Cicka proximity chatter or direct talk interaction is desired, but
+  held for a later Cicka interaction slice.
 - **Asset staging is now an active coordination concern**: prepared POC assets
   exist for Cicka, Potassium, and Stampede enemy families. Keep them documented
   and adopt them in small scene-owned slices instead of turning them into a
@@ -278,13 +287,13 @@ Current checkpoint:
 
 Next implementation slices:
 
-1. **M5 Ridge Memory**: broaden reward memory from the one Stampede first-clear
-   response into the planned Ridge sticker/world-change layer.
+1. **M5 Ridge Memory continuation**: add the first small Ridge shortcut or the
+   first Cicka proximity/talk interaction as its own scene-owned slice.
 
 Hold until later:
 
 - Enemy-enemy avoidance beyond pressure-aware steering.
-- Broad Ridge memory rendering beyond the one Stampede first-clear response.
+- More Stampede upgrades and endless mode.
 - Player manual updates; Stampede is still dev/prototype behavior.
 
 ### M5: Ridge Memory
@@ -300,7 +309,29 @@ Outputs:
 - Ridge-only glide behavior.
 - first Cicka Note or translator tease.
 
-Do not start until reward ids and first real reward are stable.
+Current checkpoint:
+
+- **M5a Durable Sticker Layer** accepted: `worldMemory.ts` derives visible
+  Ridge memory ids from durable progress, empty progress returns no memories,
+  and the `stampede-sketch` stamp renders Stampede blanket memories without
+  storing sticker ids.
+- **M5b Cicka Memory + Dev Stamp Seed** accepted: `stampede-sketch` also derives
+  the `cicka-stampede-note` memory at Cicka's perch, Ridge renders the tiny
+  `mrrp?` tease, and local dev can seed the known stamp with
+  `?mode=interactive&startScene=ridge&devRidgeStamp=stampede-sketch`.
+
+Next implementation slices:
+
+1. **M5c First Ridge Shortcut**: add one scene-owned shortcut derived from
+   durable progress. Keep it small and avoid Ridge glide.
+2. **Later Cicka Interaction**: let Cicka acknowledge the player when they walk
+   by or choose to talk, using short barks rather than a dialogue tree.
+3. **Ridge-Only Glide**: keep this as a separate HITL slice because input feel
+   and touch behavior need review.
+
+Do not add stored sticker state. Do not add Stampede upgrades, endless mode,
+shared memory architecture, or functional shortcuts inside purely visual memory
+slices.
 
 ### M6: Relay Spire First Ending
 

--- a/src/game/bridge/store.test.ts
+++ b/src/game/bridge/store.test.ts
@@ -249,6 +249,17 @@ describe('bridgeStore', () => {
       expect(isRidgeShortcutUnlocked('outskirts-lift')).toBe(true);
     });
 
+    it('keeps Ridge stickers derived instead of stored', () => {
+      bridgeActions.awardRidgeStamp('stampede-sketch');
+      expect(bridgeStore.getState().progress.ridge).not.toHaveProperty('stickerIds');
+      expect(Object.keys(bridgeStore.getState().progress.ridge).sort()).toEqual([
+        'manualPageIds',
+        'mobility',
+        'shortcutIds',
+        'stampIds'
+      ]);
+    });
+
     it('keeps Potassium Circuit ownership derived from inventory', () => {
       bridgeActions.awardRidgeStamp('stampede-sketch');
       expect(isItemOwned('circuit')).toBe(false);

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -32,10 +32,14 @@ import {
   RIDGE_PLAYER_START,
   RIDGE_TRAIL_CARD_TARGETS,
   RIDGE_WORLD_WIDTH,
-  getRidgeLandmarkMemory,
   type RidgeTrailCardTargetId,
   type RidgeLandmark
 } from '../worldLayout';
+import {
+  getRidgeLandmarkMemories,
+  hasRidgeWorldMemory,
+  type RidgeWorldMemory
+} from '../worldMemory';
 import type { TrailCardOverlayParams } from '@/game/overlays/trailCard/types';
 
 interface RidgeSceneStartData {
@@ -294,7 +298,7 @@ export class RidgeScene extends Phaser.Scene {
   ): void {
     const x = landmark.x;
     const y = RIDGE_FLOOR_Y - 46;
-    const memory = getRidgeLandmarkMemory(
+    const memories = getRidgeLandmarkMemories(
       landmark,
       bridgeStore.getState().progress.ridge
     );
@@ -304,12 +308,29 @@ export class RidgeScene extends Phaser.Scene {
     this.add.circle(x - 22, y - 26, 11, 0x1f1f1d, 0.92);
     this.add.circle(x + 28, y - 20, 9, 0x1f1f1d, 0.75);
     this.add.line(x, y - 42, -34, 6, 34, -6, 0x1f1f1d, 0.32).setLineWidth(3);
-    if (memory === 'stampede-first-clear') {
-      this.addStampedeBlanketMemory(x, y, stampedeFirstClearLabel);
+    if (memories.length) {
+      this.addStampedeBlanketMemories(x, y, stampedeFirstClearLabel, memories);
     }
   }
 
-  private addStampedeBlanketMemory(
+  private addStampedeBlanketMemories(
+    x: number,
+    y: number,
+    stampedeFirstClearLabel: string,
+    memories: readonly RidgeWorldMemory[]
+  ): void {
+    if (hasRidgeWorldMemory(memories, 'stampede-settled-swarm')) {
+      this.addStampedeSettledSwarmMemory(x, y);
+    }
+    if (hasRidgeWorldMemory(memories, 'stampede-held-sticker')) {
+      this.addStampedeHeldStickerMemory(x, y, stampedeFirstClearLabel);
+    }
+    if (hasRidgeWorldMemory(memories, 'stampede-glide-pip-decal')) {
+      this.addStampedeGlidePipMemory(x, y);
+    }
+  }
+
+  private addStampedeHeldStickerMemory(
     x: number,
     y: number,
     stampedeFirstClearLabel: string
@@ -323,6 +344,27 @@ export class RidgeScene extends Phaser.Scene {
       color: '#1f1f1d'
     }).setAngle(-8).setDepth(5);
     this.add.line(x + 9, y - 32, -12, 10, 12, -10, 0x1f1f1d, 0.52).setLineWidth(2);
+  }
+
+  private addStampedeSettledSwarmMemory(x: number, y: number): void {
+    [
+      { x: -55, y: -36, radius: 4 },
+      { x: -42, y: -49, radius: 3 },
+      { x: -30, y: -39, radius: 2 },
+      { x: 54, y: -30, radius: 3 },
+      { x: 66, y: -43, radius: 2 }
+    ].forEach((dot) => {
+      this.add.circle(x + dot.x, y + dot.y, dot.radius, 0x1f1f1d, 0.24);
+    });
+    this.add.line(x - 64, y - 24, -12, 4, 12, -4, 0x1f1f1d, 0.22).setLineWidth(2);
+    this.add.line(x + 58, y - 18, -10, -3, 10, 3, 0x1f1f1d, 0.2).setLineWidth(2);
+  }
+
+  private addStampedeGlidePipMemory(x: number, y: number): void {
+    this.add.circle(x + 74, y - 18, 11, 0xf7f1df, 1)
+      .setStrokeStyle(2, 0x1f1f1d, 0.9);
+    this.add.line(x + 74, y - 18, -6, 6, 6, -6, 0x1f1f1d, 0.85).setLineWidth(2);
+    this.add.circle(x + 80, y - 24, 2, 0x1f1f1d, 0.85);
   }
 
   private addTelegraphBag(landmark: RidgeLandmark): void {

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -101,7 +101,10 @@ export class RidgeScene extends Phaser.Scene {
     const ground = this.createGround();
 
     this.addBackdrop();
-    this.addLandmarks(messages.scenes.ridge.memory.stampedeFirstClearLabel);
+    this.addLandmarks(
+      messages.scenes.ridge.memory.stampedeFirstClearLabel,
+      messages.scenes.ridge.memory.cickaStampedeNoteLabel
+    );
     this.addPlaceholderCopy();
     this.createPlayer(ground);
     this.createTrailCardInteractions(messages.navigation.interact);
@@ -254,11 +257,14 @@ export class RidgeScene extends Phaser.Scene {
     this.add.circle(x + 46, 166, 12, 0xf0d35f, 0.9);
   }
 
-  private addLandmarks(stampedeFirstClearLabel: string): void {
+  private addLandmarks(
+    stampedeFirstClearLabel: string,
+    cickaStampedeNoteLabel: string
+  ): void {
     RIDGE_LANDMARKS.forEach((landmark) => {
       switch (landmark.kind) {
         case 'cicka-perch':
-          this.addCickaPerch(landmark);
+          this.addCickaPerch(landmark, cickaStampedeNoteLabel);
           break;
         case 'stampede-blanket':
           this.addStampedeBlanket(landmark, stampedeFirstClearLabel);
@@ -280,9 +286,16 @@ export class RidgeScene extends Phaser.Scene {
     });
   }
 
-  private addCickaPerch(landmark: RidgeLandmark): void {
+  private addCickaPerch(
+    landmark: RidgeLandmark,
+    cickaStampedeNoteLabel: string
+  ): void {
     const x = landmark.x;
     const y = RIDGE_FLOOR_Y - 74;
+    const memories = getRidgeLandmarkMemories(
+      landmark,
+      bridgeStore.getState().progress.ridge
+    );
     this.add.rectangle(x, y + 28, 10, 86, 0x1f1f1d, 0.88);
     this.add.rectangle(x, y - 12, 86, 10, 0x1f1f1d, 0.88);
     this.add.ellipse(x + 16, y - 36, 54, 28, 0x1f1f1d, 0.95);
@@ -290,6 +303,25 @@ export class RidgeScene extends Phaser.Scene {
     this.add.triangle(x + 18, y - 50, 0, 14, 12, 0, 22, 14, 0x1f1f1d, 0.95);
     this.add.circle(x + 30, y - 38, 3, 0xf7f1df, 1);
     this.add.line(x - 18, y - 32, -30, 0, -54, -10, 0x1f1f1d, 0.9).setLineWidth(5);
+    if (hasRidgeWorldMemory(memories, 'cicka-stampede-note')) {
+      this.addCickaStampedeNoteMemory(x, y, cickaStampedeNoteLabel);
+    }
+  }
+
+  private addCickaStampedeNoteMemory(
+    x: number,
+    y: number,
+    cickaStampedeNoteLabel: string
+  ): void {
+    this.add.rectangle(x + 58, y - 70, 50, 24, 0xf7f1df, 1)
+      .setStrokeStyle(2, 0x1f1f1d, 0.88)
+      .setAngle(5);
+    this.add.text(x + 38, y - 78, cickaStampedeNoteLabel, {
+      fontFamily: 'monospace',
+      fontSize: '11px',
+      color: '#1f1f1d'
+    }).setAngle(5).setDepth(5);
+    this.add.line(x + 35, y - 51, -8, 8, 12, -6, 0x1f1f1d, 0.38).setLineWidth(2);
   }
 
   private addStampedeBlanket(

--- a/src/game/scenes/ridge/worldLayout.test.ts
+++ b/src/game/scenes/ridge/worldLayout.test.ts
@@ -5,11 +5,11 @@ import {
   RIDGE_PLAYER_RESUME_CLAMP,
   RIDGE_PLAYER_START,
   RIDGE_TRAIL_CARD_TARGETS,
-  RIDGE_WORLD_WIDTH,
-  getRidgeLandmarkMemory
+  RIDGE_WORLD_WIDTH
 } from './worldLayout';
 import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
 import { STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
+import { getRidgeLandmarkMemories } from './worldMemory';
 
 describe('ridge world layout', () => {
   it('keeps the first movement shell flat and inside world bounds', () => {
@@ -59,7 +59,7 @@ describe('ridge world layout', () => {
     expect(unavailable.every((target) => target.card.unavailableReason && !target.card.enterSceneId)).toBe(true);
   });
 
-  it('derives the Stampede blanket memory from the first-clear stamp', () => {
+  it('keeps Ridge memory derivation anchored to the Stampede landmark', () => {
     const stampedeBlanket = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'stampede-blanket');
     const telegraphBag = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'telegraph-bag');
 
@@ -67,12 +67,16 @@ describe('ridge world layout', () => {
     expect(telegraphBag).toBeDefined();
     if (!stampedeBlanket || !telegraphBag) return;
 
-    expect(getRidgeLandmarkMemory(stampedeBlanket, { stampIds: [] })).toBeNull();
-    expect(getRidgeLandmarkMemory(stampedeBlanket, {
+    expect(getRidgeLandmarkMemories(stampedeBlanket, { stampIds: [] })).toEqual([]);
+    expect(getRidgeLandmarkMemories(stampedeBlanket, {
       stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
-    })).toBe('stampede-first-clear');
-    expect(getRidgeLandmarkMemory(telegraphBag, {
+    }).map((memory) => memory.id)).toEqual([
+      'stampede-held-sticker',
+      'stampede-settled-swarm',
+      'stampede-glide-pip-decal'
+    ]);
+    expect(getRidgeLandmarkMemories(telegraphBag, {
       stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
-    })).toBeNull();
+    })).toEqual([]);
   });
 });

--- a/src/game/scenes/ridge/worldLayout.test.ts
+++ b/src/game/scenes/ridge/worldLayout.test.ts
@@ -60,20 +60,28 @@ describe('ridge world layout', () => {
   });
 
   it('keeps Ridge memory derivation anchored to the Stampede landmark', () => {
+    const cickaPerch = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'cicka-perch');
     const stampedeBlanket = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'stampede-blanket');
     const telegraphBag = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'telegraph-bag');
 
+    expect(cickaPerch).toBeDefined();
     expect(stampedeBlanket).toBeDefined();
     expect(telegraphBag).toBeDefined();
-    if (!stampedeBlanket || !telegraphBag) return;
+    if (!cickaPerch || !stampedeBlanket || !telegraphBag) return;
 
     expect(getRidgeLandmarkMemories(stampedeBlanket, { stampIds: [] })).toEqual([]);
+    expect(getRidgeLandmarkMemories(cickaPerch, { stampIds: [] })).toEqual([]);
     expect(getRidgeLandmarkMemories(stampedeBlanket, {
       stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
     }).map((memory) => memory.id)).toEqual([
       'stampede-held-sticker',
       'stampede-settled-swarm',
       'stampede-glide-pip-decal'
+    ]);
+    expect(getRidgeLandmarkMemories(cickaPerch, {
+      stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
+    }).map((memory) => memory.id)).toEqual([
+      'cicka-stampede-note'
     ]);
     expect(getRidgeLandmarkMemories(telegraphBag, {
       stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]

--- a/src/game/scenes/ridge/worldLayout.ts
+++ b/src/game/scenes/ridge/worldLayout.ts
@@ -1,6 +1,5 @@
 import type { TrailCardOverlayParams } from '@/game/overlays/trailCard/types';
 import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
-import type { BridgeRidgeProgressState } from '@/game/bridge/store';
 import { STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
 
 export const RIDGE_WORLD_WIDTH = 1800;
@@ -33,8 +32,6 @@ export type RidgeTrailCardTargetId =
   | 'telegraph-terrace'
   | 'domino-desk';
 
-export type RidgeLandmarkMemoryKind = 'stampede-first-clear';
-
 export interface RidgeTrailCardTarget {
   id: RidgeTrailCardTargetId;
   landmarkKind: Extract<RidgeLandmarkKind, 'stampede-blanket' | 'telegraph-bag' | 'domino-desk'>;
@@ -45,19 +42,6 @@ export interface RidgeTrailCardTarget {
     y: number;
   };
   card: TrailCardOverlayParams;
-}
-
-export function getRidgeLandmarkMemory(
-  landmark: Pick<RidgeLandmark, 'kind'>,
-  ridgeProgress: Pick<BridgeRidgeProgressState, 'stampIds'>
-): RidgeLandmarkMemoryKind | null {
-  if (
-    landmark.kind === 'stampede-blanket' &&
-    ridgeProgress.stampIds.includes(STAMPEDE_SKETCH_RIDGE_STAMP_ID)
-  ) {
-    return 'stampede-first-clear';
-  }
-  return null;
 }
 
 export const RIDGE_LANDMARKS: readonly RidgeLandmark[] = [

--- a/src/game/scenes/ridge/worldMemory.test.ts
+++ b/src/game/scenes/ridge/worldMemory.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+import { RIDGE_LANDMARKS } from './worldLayout';
+import {
+  getRidgeLandmarkMemories,
+  getRidgeWorldMemories,
+  hasRidgeWorldMemory
+} from './worldMemory';
+
+describe('ridge world memory', () => {
+  it('returns no derived memories for empty Ridge progress', () => {
+    expect(getRidgeWorldMemories({ stampIds: [] })).toEqual([]);
+  });
+
+  it('derives the Stampede blanket memory layer from the first-clear stamp', () => {
+    const memories = getRidgeWorldMemories({
+      stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
+    });
+
+    expect(memories.map((memory) => memory.id)).toEqual([
+      'stampede-held-sticker',
+      'stampede-settled-swarm',
+      'stampede-glide-pip-decal'
+    ]);
+    expect(memories.every((memory) => memory.landmarkKind === 'stampede-blanket')).toBe(true);
+    expect(hasRidgeWorldMemory(memories, 'stampede-held-sticker')).toBe(true);
+  });
+
+  it('anchors Stampede memories to the blanket without changing unrelated landmarks', () => {
+    const stampedeBlanket = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'stampede-blanket');
+    const telegraphBag = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'telegraph-bag');
+
+    expect(stampedeBlanket).toBeDefined();
+    expect(telegraphBag).toBeDefined();
+    if (!stampedeBlanket || !telegraphBag) return;
+
+    const ridgeProgress = {
+      stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
+    };
+
+    expect(getRidgeLandmarkMemories(stampedeBlanket, ridgeProgress).map((memory) => memory.id)).toEqual([
+      'stampede-held-sticker',
+      'stampede-settled-swarm',
+      'stampede-glide-pip-decal'
+    ]);
+    expect(getRidgeLandmarkMemories(telegraphBag, ridgeProgress)).toEqual([]);
+  });
+});

--- a/src/game/scenes/ridge/worldMemory.test.ts
+++ b/src/game/scenes/ridge/worldMemory.test.ts
@@ -20,19 +20,22 @@ describe('ridge world memory', () => {
     expect(memories.map((memory) => memory.id)).toEqual([
       'stampede-held-sticker',
       'stampede-settled-swarm',
-      'stampede-glide-pip-decal'
+      'stampede-glide-pip-decal',
+      'cicka-stampede-note'
     ]);
-    expect(memories.every((memory) => memory.landmarkKind === 'stampede-blanket')).toBe(true);
     expect(hasRidgeWorldMemory(memories, 'stampede-held-sticker')).toBe(true);
+    expect(hasRidgeWorldMemory(memories, 'cicka-stampede-note')).toBe(true);
   });
 
-  it('anchors Stampede memories to the blanket without changing unrelated landmarks', () => {
+  it('anchors Stampede memories to the blanket and Cicka perch without changing unrelated landmarks', () => {
+    const cickaPerch = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'cicka-perch');
     const stampedeBlanket = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'stampede-blanket');
     const telegraphBag = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'telegraph-bag');
 
+    expect(cickaPerch).toBeDefined();
     expect(stampedeBlanket).toBeDefined();
     expect(telegraphBag).toBeDefined();
-    if (!stampedeBlanket || !telegraphBag) return;
+    if (!cickaPerch || !stampedeBlanket || !telegraphBag) return;
 
     const ridgeProgress = {
       stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
@@ -42,6 +45,9 @@ describe('ridge world memory', () => {
       'stampede-held-sticker',
       'stampede-settled-swarm',
       'stampede-glide-pip-decal'
+    ]);
+    expect(getRidgeLandmarkMemories(cickaPerch, ridgeProgress).map((memory) => memory.id)).toEqual([
+      'cicka-stampede-note'
     ]);
     expect(getRidgeLandmarkMemories(telegraphBag, ridgeProgress)).toEqual([]);
   });

--- a/src/game/scenes/ridge/worldMemory.ts
+++ b/src/game/scenes/ridge/worldMemory.ts
@@ -11,17 +11,19 @@ type RidgeMemorySource =
 export type RidgeWorldMemoryId =
   | 'stampede-held-sticker'
   | 'stampede-settled-swarm'
-  | 'stampede-glide-pip-decal';
+  | 'stampede-glide-pip-decal'
+  | 'cicka-stampede-note';
 
 export type RidgeWorldMemoryKind =
   | 'reward-sticker'
   | 'settled-swarm'
-  | 'glide-pip-decal';
+  | 'glide-pip-decal'
+  | 'cicka-note';
 
 export interface RidgeWorldMemory {
   id: RidgeWorldMemoryId;
   kind: RidgeWorldMemoryKind;
-  landmarkKind: Extract<RidgeLandmarkKind, 'stampede-blanket'>;
+  landmarkKind: Extract<RidgeLandmarkKind, 'cicka-perch' | 'stampede-blanket'>;
   source: RidgeMemorySource;
 }
 
@@ -48,6 +50,15 @@ const STAMPEDE_FIRST_CLEAR_MEMORIES: readonly RidgeWorldMemory[] = [
     id: 'stampede-glide-pip-decal',
     kind: 'glide-pip-decal',
     landmarkKind: 'stampede-blanket',
+    source: {
+      kind: 'stamp',
+      id: STAMPEDE_SKETCH_RIDGE_STAMP_ID
+    }
+  },
+  {
+    id: 'cicka-stampede-note',
+    kind: 'cicka-note',
+    landmarkKind: 'cicka-perch',
     source: {
       kind: 'stamp',
       id: STAMPEDE_SKETCH_RIDGE_STAMP_ID

--- a/src/game/scenes/ridge/worldMemory.ts
+++ b/src/game/scenes/ridge/worldMemory.ts
@@ -1,0 +1,81 @@
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+import type { BridgeRidgeProgressState } from '@/game/bridge/store';
+import type { RidgeLandmark, RidgeLandmarkKind } from './worldLayout';
+
+type RidgeMemorySource =
+  | {
+      kind: 'stamp';
+      id: typeof STAMPEDE_SKETCH_RIDGE_STAMP_ID;
+    };
+
+export type RidgeWorldMemoryId =
+  | 'stampede-held-sticker'
+  | 'stampede-settled-swarm'
+  | 'stampede-glide-pip-decal';
+
+export type RidgeWorldMemoryKind =
+  | 'reward-sticker'
+  | 'settled-swarm'
+  | 'glide-pip-decal';
+
+export interface RidgeWorldMemory {
+  id: RidgeWorldMemoryId;
+  kind: RidgeWorldMemoryKind;
+  landmarkKind: Extract<RidgeLandmarkKind, 'stampede-blanket'>;
+  source: RidgeMemorySource;
+}
+
+const STAMPEDE_FIRST_CLEAR_MEMORIES: readonly RidgeWorldMemory[] = [
+  {
+    id: 'stampede-held-sticker',
+    kind: 'reward-sticker',
+    landmarkKind: 'stampede-blanket',
+    source: {
+      kind: 'stamp',
+      id: STAMPEDE_SKETCH_RIDGE_STAMP_ID
+    }
+  },
+  {
+    id: 'stampede-settled-swarm',
+    kind: 'settled-swarm',
+    landmarkKind: 'stampede-blanket',
+    source: {
+      kind: 'stamp',
+      id: STAMPEDE_SKETCH_RIDGE_STAMP_ID
+    }
+  },
+  {
+    id: 'stampede-glide-pip-decal',
+    kind: 'glide-pip-decal',
+    landmarkKind: 'stampede-blanket',
+    source: {
+      kind: 'stamp',
+      id: STAMPEDE_SKETCH_RIDGE_STAMP_ID
+    }
+  }
+];
+
+export function getRidgeWorldMemories(
+  ridgeProgress: Pick<BridgeRidgeProgressState, 'stampIds'>
+): readonly RidgeWorldMemory[] {
+  if (!ridgeProgress.stampIds.includes(STAMPEDE_SKETCH_RIDGE_STAMP_ID)) {
+    return [];
+  }
+  return STAMPEDE_FIRST_CLEAR_MEMORIES;
+}
+
+export function getRidgeLandmarkMemories(
+  landmark: Pick<RidgeLandmark, 'kind'>,
+  ridgeProgress: Pick<BridgeRidgeProgressState, 'stampIds'>
+): readonly RidgeWorldMemory[] {
+  return getRidgeWorldMemories(ridgeProgress).filter(
+    (memory) => memory.landmarkKind === landmark.kind
+  );
+}
+
+export function hasRidgeWorldMemory(
+  memories: readonly RidgeWorldMemory[],
+  memoryId: RidgeWorldMemoryId
+): boolean {
+  return memories.some((memory) => memory.id === memoryId);
+}

--- a/src/game/shell/devRidgeProgressParams.test.ts
+++ b/src/game/shell/devRidgeProgressParams.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+import {
+  DEV_RIDGE_STAMP_QUERY_PARAM,
+  getDevRidgeProgressSeed
+} from './devRidgeProgressParams';
+
+describe('dev Ridge progress params', () => {
+  it('derives a known Ridge stamp seed and marks the param for consumption', () => {
+    const searchParams = new URLSearchParams(
+      `${DEV_RIDGE_STAMP_QUERY_PARAM}=${STAMPEDE_SKETCH_RIDGE_STAMP_ID}&startScene=ridge`
+    );
+
+    expect(getDevRidgeProgressSeed(searchParams)).toEqual({
+      stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID],
+      consumedParams: [DEV_RIDGE_STAMP_QUERY_PARAM]
+    });
+    expect(searchParams.get(DEV_RIDGE_STAMP_QUERY_PARAM)).toBe(STAMPEDE_SKETCH_RIDGE_STAMP_ID);
+  });
+
+  it('ignores unknown Ridge stamp ids without consuming the param', () => {
+    const searchParams = new URLSearchParams(
+      `${DEV_RIDGE_STAMP_QUERY_PARAM}=future-stamp`
+    );
+
+    expect(getDevRidgeProgressSeed(searchParams)).toEqual({
+      stampIds: [],
+      consumedParams: []
+    });
+    expect(searchParams.get(DEV_RIDGE_STAMP_QUERY_PARAM)).toBe('future-stamp');
+  });
+
+  it('ignores absent Ridge stamp params', () => {
+    expect(getDevRidgeProgressSeed(new URLSearchParams('startScene=ridge'))).toEqual({
+      stampIds: [],
+      consumedParams: []
+    });
+  });
+});

--- a/src/game/shell/devRidgeProgressParams.ts
+++ b/src/game/shell/devRidgeProgressParams.ts
@@ -1,0 +1,35 @@
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+
+export const DEV_RIDGE_STAMP_QUERY_PARAM = 'devRidgeStamp';
+
+export const DEV_RIDGE_STAMP_IDS = [
+  STAMPEDE_SKETCH_RIDGE_STAMP_ID
+] as const;
+
+export type DevRidgeStampId = (typeof DEV_RIDGE_STAMP_IDS)[number];
+
+export interface DevRidgeProgressSeed {
+  stampIds: readonly DevRidgeStampId[];
+  consumedParams: readonly string[];
+}
+
+export function getDevRidgeProgressSeed(
+  searchParams: Pick<URLSearchParams, 'get'>
+): DevRidgeProgressSeed {
+  const stampId = searchParams.get(DEV_RIDGE_STAMP_QUERY_PARAM);
+  if (!stampId || !isDevRidgeStampId(stampId)) {
+    return {
+      stampIds: [],
+      consumedParams: []
+    };
+  }
+
+  return {
+    stampIds: [stampId],
+    consumedParams: [DEV_RIDGE_STAMP_QUERY_PARAM]
+  };
+}
+
+function isDevRidgeStampId(stampId: string): stampId is DevRidgeStampId {
+  return (DEV_RIDGE_STAMP_IDS as readonly string[]).includes(stampId);
+}

--- a/src/game/shell/usePhaserGameBoot.ts
+++ b/src/game/shell/usePhaserGameBoot.ts
@@ -11,6 +11,7 @@ import { SceneLifecycleController } from '@/game/sceneLifecycle/SceneLifecycleCo
 import { SceneManager } from '@/game/sceneLifecycle/SceneManager';
 import { getGameConfig } from '@/game/sharedSceneRuntime/config';
 import { getSceneStartResume, prepareSceneStart } from '@/game/sharedSceneRuntime/sceneResumePolicy';
+import { getDevRidgeProgressSeed } from './devRidgeProgressParams';
 
 interface UsePhaserGameBootOptions {
   bridgeRef: RefObject<{
@@ -83,14 +84,28 @@ export function usePhaserGameBoot({
     const sceneLifecycle = new SceneLifecycleController(sceneManager);
     sceneLifecycle.start();
 
-    // Dev-only helper: `?startScene=<sceneId>` (e.g. `potassium`, `hobbies`, `basement`).
-    // Useful for fast iteration without walking to a trigger each reload.
+    // Dev-only helpers: seed progress and/or start scenes without walking to triggers.
     if (import.meta.env.DEV) {
-      const startScene = new URLSearchParams(window.location.search).get('startScene');
+      const url = new URL(window.location.href);
+      let shouldReplaceUrl = false;
+
+      const ridgeProgressSeed = getDevRidgeProgressSeed(url.searchParams);
+      ridgeProgressSeed.stampIds.forEach((stampId) => {
+        bridgeActions.awardRidgeStamp(stampId);
+      });
+      ridgeProgressSeed.consumedParams.forEach((param) => {
+        url.searchParams.delete(param);
+        shouldReplaceUrl = true;
+      });
+
+      const startScene = url.searchParams.get('startScene');
       if (startScene && isSceneId(startScene)) {
         bridgeActions.enterScene(startScene);
-        const url = new URL(window.location.href);
         url.searchParams.delete('startScene');
+        shouldReplaceUrl = true;
+      }
+
+      if (shouldReplaceUrl) {
         window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
       }
     }

--- a/src/shared/i18n/messages/en/scenes.ts
+++ b/src/shared/i18n/messages/en/scenes.ts
@@ -27,6 +27,7 @@ export const sceneMessages = {
   ridge: {
     memory: {
       stampedeFirstClearLabel: "HELD",
+      cickaStampedeNoteLabel: "mrrp?",
     },
   },
   stampedeSketch: {


### PR DESCRIPTION
## Summary
- Derive Ridge-visible memory stickers from durable progress instead of storing sticker state
- Add the first Cicka note tease at her perch when `stampede-sketch` is earned
- Add a dev-only `devRidgeStamp` URL seed for fast local Ridge memory testing
- Update the milestone plan to mark the M5 memory slices as accepted

## Testing
- Added and updated unit coverage for Ridge world memory, Ridge layout, bridge progress, and dev stamp seed parsing
- Ran local validation for the affected game and shell tests, plus browser smoke checks for fresh and seeded Ridge startup