### PR TITLE
Refine Ridge memory derivation and render lookup

### DIFF
--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -36,7 +36,7 @@ import {
   type RidgeLandmark
 } from '../worldLayout';
 import {
-  getRidgeLandmarkMemories,
+  getRidgeWorldMemories,
   hasRidgeWorldMemory,
   type RidgeWorldMemory
 } from '../worldMemory';
@@ -261,13 +261,19 @@ export class RidgeScene extends Phaser.Scene {
     stampedeFirstClearLabel: string,
     cickaStampedeNoteLabel: string
   ): void {
+    const worldMemories = getRidgeWorldMemories(bridgeStore.getState().progress.ridge);
+
     RIDGE_LANDMARKS.forEach((landmark) => {
+      const landmarkMemories = worldMemories.filter(
+        (memory) => memory.landmarkKind === landmark.kind
+      );
+
       switch (landmark.kind) {
         case 'cicka-perch':
-          this.addCickaPerch(landmark, cickaStampedeNoteLabel);
+          this.addCickaPerch(landmark, cickaStampedeNoteLabel, landmarkMemories);
           break;
         case 'stampede-blanket':
-          this.addStampedeBlanket(landmark, stampedeFirstClearLabel);
+          this.addStampedeBlanket(landmark, stampedeFirstClearLabel, landmarkMemories);
           break;
         case 'telegraph-bag':
           this.addTelegraphBag(landmark);
@@ -288,14 +294,11 @@ export class RidgeScene extends Phaser.Scene {
 
   private addCickaPerch(
     landmark: RidgeLandmark,
-    cickaStampedeNoteLabel: string
+    cickaStampedeNoteLabel: string,
+    memories: readonly RidgeWorldMemory[]
   ): void {
     const x = landmark.x;
     const y = RIDGE_FLOOR_Y - 74;
-    const memories = getRidgeLandmarkMemories(
-      landmark,
-      bridgeStore.getState().progress.ridge
-    );
     this.add.rectangle(x, y + 28, 10, 86, 0x1f1f1d, 0.88);
     this.add.rectangle(x, y - 12, 86, 10, 0x1f1f1d, 0.88);
     this.add.ellipse(x + 16, y - 36, 54, 28, 0x1f1f1d, 0.95);
@@ -326,14 +329,11 @@ export class RidgeScene extends Phaser.Scene {
 
   private addStampedeBlanket(
     landmark: RidgeLandmark,
-    stampedeFirstClearLabel: string
+    stampedeFirstClearLabel: string,
+    memories: readonly RidgeWorldMemory[]
   ): void {
     const x = landmark.x;
     const y = RIDGE_FLOOR_Y - 46;
-    const memories = getRidgeLandmarkMemories(
-      landmark,
-      bridgeStore.getState().progress.ridge
-    );
     this.add.rectangle(x, y, 104, 32, 0xb85f5a, 0.9);
     this.add.rectangle(x - 26, y, 18, 32, 0xf7f1df, 0.7);
     this.add.rectangle(x + 26, y, 18, 32, 0xf7f1df, 0.7);

--- a/src/game/scenes/ridge/worldMemory.test.ts
+++ b/src/game/scenes/ridge/worldMemory.test.ts
@@ -12,6 +12,10 @@ describe('ridge world memory', () => {
     expect(getRidgeWorldMemories({ stampIds: [] })).toEqual([]);
   });
 
+  it('ignores unrelated stamp ids', () => {
+    expect(getRidgeWorldMemories({ stampIds: ['future-stamp'] })).toEqual([]);
+  });
+
   it('derives the Stampede blanket memory layer from the first-clear stamp', () => {
     const memories = getRidgeWorldMemories({
       stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]

--- a/src/game/scenes/ridge/worldMemory.ts
+++ b/src/game/scenes/ridge/worldMemory.ts
@@ -1,11 +1,11 @@
 import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
-import type { BridgeRidgeProgressState } from '@/game/bridge/store';
+import type { BridgeRidgeProgressState, RidgeStampId } from '@/game/bridge/store';
 import type { RidgeLandmark, RidgeLandmarkKind } from './worldLayout';
 
 type RidgeMemorySource =
   | {
       kind: 'stamp';
-      id: typeof STAMPEDE_SKETCH_RIDGE_STAMP_ID;
+      id: RidgeStampId;
     };
 
 export type RidgeWorldMemoryId =
@@ -27,7 +27,7 @@ export interface RidgeWorldMemory {
   source: RidgeMemorySource;
 }
 
-const STAMPEDE_FIRST_CLEAR_MEMORIES: readonly RidgeWorldMemory[] = [
+const RIDGE_WORLD_MEMORIES: readonly RidgeWorldMemory[] = [
   {
     id: 'stampede-held-sticker',
     kind: 'reward-sticker',
@@ -69,10 +69,9 @@ const STAMPEDE_FIRST_CLEAR_MEMORIES: readonly RidgeWorldMemory[] = [
 export function getRidgeWorldMemories(
   ridgeProgress: Pick<BridgeRidgeProgressState, 'stampIds'>
 ): readonly RidgeWorldMemory[] {
-  if (!ridgeProgress.stampIds.includes(STAMPEDE_SKETCH_RIDGE_STAMP_ID)) {
-    return [];
-  }
-  return STAMPEDE_FIRST_CLEAR_MEMORIES;
+  return RIDGE_WORLD_MEMORIES.filter((memory) =>
+    ridgeProgress.stampIds.includes(memory.source.id)
+  );
 }
 
 export function getRidgeLandmarkMemories(


### PR DESCRIPTION
## Summary
- Make Ridge memory derivation data-driven by filtering a private memory list from unlocked stamp ids.
- Read Ridge progress once in `RidgeScene` and derive landmark memories once before rendering Cicka and Stampede markers.
- Add regression coverage for unrelated stamp ids so empty or unknown progress stays inert.

## Testing
- `src/game/scenes/ridge/worldMemory.test.ts`, `src/game/scenes/ridge/worldLayout.test.ts`, `src/game/bridge/store.test.ts`, `src/game/scenes/stampedeSketch/runtime/rewards.test.ts`, and `src/game/shell/devRidgeProgressParams.test.ts` all pass.
- Type checking passed.
- Diff whitespace check passed.