### PR TITLE
Add Cicka interaction, walk-by bark, and Ridge memory polish

### DIFF
--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -317,19 +317,24 @@ Current checkpoint:
   storing sticker ids.
 - **M5b Cicka Memory + Dev Stamp Seed** accepted: `stampede-sketch` also derives
   the `cicka-stampede-note` memory at Cicka's perch, Ridge renders the tiny
-  `mrrp?` tease, and local dev can seed the known stamp with
+  Cicka memory tease, and local dev can seed the known stamp with
   `?mode=interactive&startScene=ridge&devRidgeStamp=stampede-sketch`.
+- **M5c Cicka Walk-By Memory** accepted for continuation: after the Stampede
+  stamp, Cicka gives one tiny walk-by bark per Ridge entry without stored Cicka
+  state.
+- **M5d Cicka First Interaction** is the current follow-up: Cicka can answer a
+  deliberate interact with pre-translator meow punctuation, while the permanent
+  Cicka memory becomes a paw/scratch decal instead of duplicate speech text.
 
 Next implementation slices:
 
-1. **M5c Cicka Walk-By Memory**: let Cicka acknowledge the player with one tiny
-   walk-by bark derived from the `stampede-sketch` stamp and the existing Cicka
-   memory. Keep it scene-owned and avoid a dialogue tree.
-2. **Later First Ridge Shortcut**: wait until the Ridge has enough repeat
+1. **Later First Ridge Shortcut**: wait until the Ridge has enough repeat
    traversal to make a shortcut feel like real relief rather than a proof of
    concept.
-3. **Ridge-Only Glide**: keep this as a separate HITL slice because input feel
+2. **Ridge-Only Glide**: keep this as a separate HITL slice because input feel
    and touch behavior need review.
+3. **Translator / Cicka Daydream**: keep translated Cicka subtitles and the
+   Cicka daydream mini-slice for later, after Ridge Memory proves return play.
 
 Do not add stored sticker state. Do not add Stampede upgrades, endless mode,
 shared memory architecture, or Ridge shortcuts inside Cicka memory slices.

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -324,7 +324,9 @@ Current checkpoint:
   state.
 - **M5d Cicka First Interaction** is the current follow-up: Cicka can answer a
   deliberate interact with pre-translator meow punctuation, while the permanent
-  Cicka memory becomes a paw/scratch decal instead of duplicate speech text.
+  Cicka memory becomes a paw/scratch decal instead of duplicate speech text;
+  the same PR includes a small primitive readability polish pass for Cicka,
+  her speech bubble, and the memory decal.
 
 Next implementation slices:
 

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -322,16 +322,17 @@ Current checkpoint:
 
 Next implementation slices:
 
-1. **M5c First Ridge Shortcut**: add one scene-owned shortcut derived from
-   durable progress. Keep it small and avoid Ridge glide.
-2. **Later Cicka Interaction**: let Cicka acknowledge the player when they walk
-   by or choose to talk, using short barks rather than a dialogue tree.
+1. **M5c Cicka Walk-By Memory**: let Cicka acknowledge the player with one tiny
+   walk-by bark derived from the `stampede-sketch` stamp and the existing Cicka
+   memory. Keep it scene-owned and avoid a dialogue tree.
+2. **Later First Ridge Shortcut**: wait until the Ridge has enough repeat
+   traversal to make a shortcut feel like real relief rather than a proof of
+   concept.
 3. **Ridge-Only Glide**: keep this as a separate HITL slice because input feel
    and touch behavior need review.
 
 Do not add stored sticker state. Do not add Stampede upgrades, endless mode,
-shared memory architecture, or functional shortcuts inside purely visual memory
-slices.
+shared memory architecture, or Ridge shortcuts inside Cicka memory slices.
 
 ### M6: Relay Spire First Ending
 

--- a/src/game/scenes/ridge/cickaInteraction.test.ts
+++ b/src/game/scenes/ridge/cickaInteraction.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CICKA_INTERACTION_TARGET_ID,
+  getCickaInteractionResponse,
+  shouldShowCickaInteractionPrompt
+} from './cickaInteraction';
+import { getRidgeWorldMemories } from './worldMemory';
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+
+const copy = {
+  fresh: 'meow.',
+  stampedeMemory: 'mrrp!'
+};
+
+describe('cicka interaction', () => {
+  it('returns the first-meeting line without Ridge memories', () => {
+    expect(getCickaInteractionResponse([], copy)).toEqual({
+      id: 'fresh',
+      line: 'meow.'
+    });
+  });
+
+  it('returns the post-Stampede line when the Cicka memory exists', () => {
+    const memories = getRidgeWorldMemories({
+      stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
+    });
+
+    expect(getCickaInteractionResponse(memories, copy)).toEqual({
+      id: 'stampede-memory',
+      line: 'mrrp!'
+    });
+  });
+
+  it('keeps unrelated memories on the first-meeting line', () => {
+    expect(getCickaInteractionResponse([{ id: 'stampede-held-sticker' }], copy)).toEqual({
+      id: 'fresh',
+      line: 'meow.'
+    });
+  });
+
+  it('replaces the Cicka interact prompt while her response is visible', () => {
+    expect(
+      shouldShowCickaInteractionPrompt({
+        activeTargetId: CICKA_INTERACTION_TARGET_ID,
+        responseVisible: true
+      })
+    ).toBe(false);
+
+    expect(
+      shouldShowCickaInteractionPrompt({
+        activeTargetId: CICKA_INTERACTION_TARGET_ID,
+        responseVisible: false
+      })
+    ).toBe(true);
+
+    expect(
+      shouldShowCickaInteractionPrompt({
+        activeTargetId: 'trail-card-sketchbook',
+        responseVisible: true
+      })
+    ).toBe(true);
+  });
+});

--- a/src/game/scenes/ridge/cickaInteraction.ts
+++ b/src/game/scenes/ridge/cickaInteraction.ts
@@ -1,0 +1,47 @@
+import type { RidgeWorldMemory, RidgeWorldMemoryId } from './worldMemory';
+
+export const CICKA_INTERACTION_TARGET_ID = 'cicka-perch' as const;
+export const CICKA_INTERACTION_RESPONSE_DURATION_MS = 2600;
+
+export type CickaInteractionResponseId = 'fresh' | 'stampede-memory';
+
+export interface CickaInteractionCopy {
+  fresh: string;
+  stampedeMemory: string;
+}
+
+export interface CickaInteractionResponse {
+  id: CickaInteractionResponseId;
+  line: string;
+}
+
+export function shouldShowCickaInteractionPrompt(input: {
+  activeTargetId: string | null;
+  responseVisible: boolean;
+}): boolean {
+  return input.activeTargetId !== CICKA_INTERACTION_TARGET_ID || !input.responseVisible;
+}
+
+export function getCickaInteractionResponse(
+  memories: readonly Pick<RidgeWorldMemory, 'id'>[],
+  copy: CickaInteractionCopy
+): CickaInteractionResponse {
+  if (hasMemory(memories, 'cicka-stampede-note')) {
+    return {
+      id: 'stampede-memory',
+      line: copy.stampedeMemory
+    };
+  }
+
+  return {
+    id: 'fresh',
+    line: copy.fresh
+  };
+}
+
+function hasMemory(
+  memories: readonly Pick<RidgeWorldMemory, 'id'>[],
+  memoryId: RidgeWorldMemoryId
+): boolean {
+  return memories.some((memory) => memory.id === memoryId);
+}

--- a/src/game/scenes/ridge/cickaWalkBy.test.ts
+++ b/src/game/scenes/ridge/cickaWalkBy.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CICKA_WALK_BY_BARK_DURATION_MS,
+  createCickaWalkByState,
+  updateCickaWalkBy,
+  type CickaWalkByFrame
+} from './cickaWalkBy';
+
+function createFrame(overrides: Partial<CickaWalkByFrame> = {}): CickaWalkByFrame {
+  return {
+    enabled: true,
+    playerX: 220,
+    playerY: 446,
+    cickaX: 220,
+    cickaY: 446,
+    nowMs: 1000,
+    ...overrides
+  };
+}
+
+describe('cicka walk-by memory', () => {
+  it('does not trigger when the memory is unavailable', () => {
+    const initialState = createCickaWalkByState();
+
+    const update = updateCickaWalkBy(initialState, createFrame({ enabled: false }));
+
+    expect(update).toEqual({
+      state: initialState,
+      triggered: false,
+      visible: false
+    });
+  });
+
+  it('does not trigger outside the walk-by radius', () => {
+    const initialState = createCickaWalkByState();
+
+    const update = updateCickaWalkBy(initialState, createFrame({ playerX: 360 }));
+
+    expect(update).toEqual({
+      state: initialState,
+      triggered: false,
+      visible: false
+    });
+  });
+
+  it('triggers once when the player enters range with the memory available', () => {
+    const update = updateCickaWalkBy(createCickaWalkByState(), createFrame());
+
+    expect(update.triggered).toBe(true);
+    expect(update.visible).toBe(true);
+    expect(update.state).toEqual({
+      hasBarked: true,
+      visibleUntilMs: 1000 + CICKA_WALK_BY_BARK_DURATION_MS
+    });
+  });
+
+  it('does not duplicate on repeated in-range frames', () => {
+    const firstUpdate = updateCickaWalkBy(createCickaWalkByState(), createFrame());
+    const secondUpdate = updateCickaWalkBy(firstUpdate.state, createFrame({ nowMs: 1200 }));
+
+    expect(secondUpdate.triggered).toBe(false);
+    expect(secondUpdate.visible).toBe(true);
+    expect(secondUpdate.state).toBe(firstUpdate.state);
+  });
+
+  it('hides after the bark duration elapses', () => {
+    const firstUpdate = updateCickaWalkBy(createCickaWalkByState(), createFrame());
+    const hiddenUpdate = updateCickaWalkBy(
+      firstUpdate.state,
+      createFrame({ nowMs: 1000 + CICKA_WALK_BY_BARK_DURATION_MS })
+    );
+
+    expect(hiddenUpdate.triggered).toBe(false);
+    expect(hiddenUpdate.visible).toBe(false);
+  });
+});

--- a/src/game/scenes/ridge/cickaWalkBy.ts
+++ b/src/game/scenes/ridge/cickaWalkBy.ts
@@ -1,0 +1,73 @@
+export const CICKA_WALK_BY_RADIUS = 88;
+export const CICKA_WALK_BY_BARK_DURATION_MS = 2600;
+
+export interface CickaWalkByState {
+  hasBarked: boolean;
+  visibleUntilMs: number;
+}
+
+export interface CickaWalkByFrame {
+  enabled: boolean;
+  playerX: number;
+  playerY: number;
+  cickaX: number;
+  cickaY: number;
+  nowMs: number;
+}
+
+export interface CickaWalkByUpdate {
+  state: CickaWalkByState;
+  triggered: boolean;
+  visible: boolean;
+}
+
+export function createCickaWalkByState(): CickaWalkByState {
+  return {
+    hasBarked: false,
+    visibleUntilMs: 0
+  };
+}
+
+export function updateCickaWalkBy(
+  state: CickaWalkByState,
+  frame: CickaWalkByFrame
+): CickaWalkByUpdate {
+  const visible = frame.nowMs < state.visibleUntilMs;
+  if (!frame.enabled) {
+    return {
+      state,
+      triggered: false,
+      visible: false
+    };
+  }
+
+  if (state.hasBarked) {
+    return {
+      state,
+      triggered: false,
+      visible
+    };
+  }
+
+  const dx = frame.playerX - frame.cickaX;
+  const dy = frame.playerY - frame.cickaY;
+  const isNearCicka = dx * dx + dy * dy <= CICKA_WALK_BY_RADIUS * CICKA_WALK_BY_RADIUS;
+  if (!isNearCicka) {
+    return {
+      state,
+      triggered: false,
+      visible: false
+    };
+  }
+
+  const nextState = {
+    hasBarked: true,
+    visibleUntilMs: frame.nowMs + CICKA_WALK_BY_BARK_DURATION_MS
+  };
+
+  return {
+    state: nextState,
+    triggered: true,
+    visible: true
+  };
+}

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -144,8 +144,7 @@ export class RidgeScene extends Phaser.Scene {
     this.createPlayer(ground);
     this.createRidgeInteractions(
       messages.navigation.interact,
-      messages.scenes.ridge.cicka.interaction,
-      worldMemories
+      messages.scenes.ridge.cicka.interaction
     );
     this.setPaused(this.isPaused);
     this.playerRuntime?.syncAppearance();
@@ -202,6 +201,7 @@ export class RidgeScene extends Phaser.Scene {
     const cickaPerch = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'cicka-perch');
     this.cickaWalkByState = createCickaWalkByState();
     this.cickaWalkByEnabled = hasRidgeWorldMemory(memories, 'cicka-stampede-note') && !!cickaPerch;
+    this.cickaSpeechBubble?.destroy();
     this.cickaSpeechBubble = undefined;
     this.cickaSpeechBubbleLabel = undefined;
     this.cickaSpeechVisibleUntilMs = 0;
@@ -333,9 +333,10 @@ export class RidgeScene extends Phaser.Scene {
 
   private createRidgeInteractions(
     promptText: string,
-    cickaInteractionCopy: CickaInteractionCopy,
-    worldMemories: readonly RidgeWorldMemory[]
+    cickaInteractionCopy: CickaInteractionCopy
   ): void {
+    this.interactPrompt?.destroy();
+
     this.interactPrompt = createUiText(this, 0, 0, promptText, {
       fontSize: '16px',
       color: '#1a1a1a',
@@ -362,7 +363,10 @@ export class RidgeScene extends Phaser.Scene {
           interactRadius: 78,
           effect: (): RidgeInteractionEffect => ({
             kind: 'showCickaResponse',
-            response: getCickaInteractionResponse(worldMemories, cickaInteractionCopy)
+            response: getCickaInteractionResponse(
+              getRidgeWorldMemories(bridgeStore.getState().progress.ridge),
+              cickaInteractionCopy
+            )
           })
         },
         ...RIDGE_TRAIL_CARD_TARGETS.map((target) => ({
@@ -421,6 +425,8 @@ export class RidgeScene extends Phaser.Scene {
   }
 
   private addCickaSpeechBubble(): void {
+    this.cickaSpeechBubble?.destroy();
+
     const bubble = this.add.container(
       this.cickaWalkByAnchor.x - 20,
       this.cickaWalkByAnchor.y - 98

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -40,6 +40,11 @@ import {
   hasRidgeWorldMemory,
   type RidgeWorldMemory
 } from '../worldMemory';
+import {
+  createCickaWalkByState,
+  updateCickaWalkBy,
+  type CickaWalkByState
+} from '../cickaWalkBy';
 import type { TrailCardOverlayParams } from '@/game/overlays/trailCard/types';
 
 interface RidgeSceneStartData {
@@ -53,12 +58,21 @@ type RidgeInteractionEffect =
   | { kind: 'close' }
   | { kind: 'openTrailCard'; params: TrailCardOverlayParams };
 
+const CICKA_WALK_BY_ANCHOR_Y = RIDGE_FLOOR_Y - 74;
+
 export class RidgeScene extends Phaser.Scene {
   player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
   interactPrompt?: Phaser.GameObjects.Text;
 
   private playerRuntime?: SideViewPlayerRuntime;
   private interactionRuntime?: InteriorInteractionRuntime<RidgeTrailCardTargetId, RidgeInteractionEffect>;
+  private cickaWalkByBubble?: Phaser.GameObjects.Container;
+  private cickaWalkByEnabled = false;
+  private cickaWalkByState: CickaWalkByState = createCickaWalkByState();
+  private cickaWalkByAnchor = {
+    x: RIDGE_PLAYER_START.x,
+    y: CICKA_WALK_BY_ANCHOR_Y
+  };
   private onClose: () => void = () => {};
   private onOpenOverlay?: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   private isPaused = false;
@@ -99,12 +113,17 @@ export class RidgeScene extends Phaser.Scene {
     this.physics.world.setBounds(0, 0, RIDGE_WORLD_WIDTH, GAME_DESIGN_HEIGHT);
 
     const ground = this.createGround();
+    const worldMemories = getRidgeWorldMemories(bridgeStore.getState().progress.ridge);
+
+    this.configureCickaWalkByMemory(worldMemories);
 
     this.addBackdrop();
     this.addLandmarks(
       messages.scenes.ridge.memory.stampedeFirstClearLabel,
-      messages.scenes.ridge.memory.cickaStampedeNoteLabel
+      messages.scenes.ridge.memory.cickaStampedeNoteLabel,
+      worldMemories
     );
+    this.addCickaWalkByBubble(messages.scenes.ridge.memory.cickaWalkByBark);
     this.addPlaceholderCopy();
     this.createPlayer(ground);
     this.createTrailCardInteractions(messages.navigation.interact);
@@ -120,6 +139,8 @@ export class RidgeScene extends Phaser.Scene {
       this.onClose();
       return;
     }
+
+    this.updateCickaWalkByMemory();
 
     const interaction = this.interactionRuntime?.update({
       playerX: this.player?.x ?? 0,
@@ -140,6 +161,37 @@ export class RidgeScene extends Phaser.Scene {
         returnToSceneId: PHASER_SCENE_KEYS.ridge
       });
     }
+  }
+
+  private configureCickaWalkByMemory(memories: readonly RidgeWorldMemory[]): void {
+    const cickaPerch = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'cicka-perch');
+    this.cickaWalkByState = createCickaWalkByState();
+    this.cickaWalkByEnabled = hasRidgeWorldMemory(memories, 'cicka-stampede-note') && !!cickaPerch;
+    this.cickaWalkByBubble = undefined;
+    if (!cickaPerch) return;
+    this.cickaWalkByAnchor = {
+      x: cickaPerch.x,
+      y: CICKA_WALK_BY_ANCHOR_Y
+    };
+  }
+
+  private updateCickaWalkByMemory(): void {
+    if (!this.player) {
+      this.cickaWalkByBubble?.setVisible(false);
+      return;
+    }
+
+    const walkByUpdate = updateCickaWalkBy(this.cickaWalkByState, {
+      enabled: this.cickaWalkByEnabled,
+      playerX: this.player.x,
+      playerY: this.player.y,
+      cickaX: this.cickaWalkByAnchor.x,
+      cickaY: this.cickaWalkByAnchor.y,
+      nowMs: this.time.now
+    });
+
+    this.cickaWalkByState = walkByUpdate.state;
+    this.cickaWalkByBubble?.setVisible(walkByUpdate.visible);
   }
 
   private createGround(): Phaser.GameObjects.Zone {
@@ -259,10 +311,9 @@ export class RidgeScene extends Phaser.Scene {
 
   private addLandmarks(
     stampedeFirstClearLabel: string,
-    cickaStampedeNoteLabel: string
+    cickaStampedeNoteLabel: string,
+    worldMemories: readonly RidgeWorldMemory[]
   ): void {
-    const worldMemories = getRidgeWorldMemories(bridgeStore.getState().progress.ridge);
-
     RIDGE_LANDMARKS.forEach((landmark) => {
       const landmarkMemories = worldMemories.filter(
         (memory) => memory.landmarkKind === landmark.kind
@@ -290,6 +341,25 @@ export class RidgeScene extends Phaser.Scene {
       }
       this.addLandmarkLabel(landmark);
     });
+  }
+
+  private addCickaWalkByBubble(cickaWalkByBark: string): void {
+    if (!this.cickaWalkByEnabled) return;
+    const bubble = this.add.container(
+      this.cickaWalkByAnchor.x - 18,
+      this.cickaWalkByAnchor.y - 92
+    ).setDepth(45).setVisible(false);
+    const panel = this.add.rectangle(0, 0, 54, 24, 0xf7f1df, 1)
+      .setStrokeStyle(2, 0x1f1f1d, 0.88);
+    const tail = this.add.line(20, 12, 0, 0, 12, 12, 0x1f1f1d, 0.5).setLineWidth(2);
+    const label = this.add.text(0, -1, cickaWalkByBark, {
+      fontFamily: 'monospace',
+      fontSize: '11px',
+      color: '#1f1f1d'
+    }).setOrigin(0.5);
+
+    bubble.add([panel, tail, label]);
+    this.cickaWalkByBubble = bubble;
   }
 
   private addCickaPerch(

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -422,15 +422,15 @@ export class RidgeScene extends Phaser.Scene {
 
   private addCickaSpeechBubble(): void {
     const bubble = this.add.container(
-      this.cickaWalkByAnchor.x - 18,
-      this.cickaWalkByAnchor.y - 92
+      this.cickaWalkByAnchor.x - 20,
+      this.cickaWalkByAnchor.y - 98
     ).setDepth(45).setVisible(false);
-    const panel = this.add.rectangle(0, 0, 54, 24, 0xf7f1df, 1)
+    const panel = this.add.rectangle(0, 0, 66, 28, 0xf7f1df, 1)
       .setStrokeStyle(2, 0x1f1f1d, 0.88);
-    const tail = this.add.line(20, 12, 0, 0, 12, 12, 0x1f1f1d, 0.5).setLineWidth(2);
+    const tail = this.add.line(22, 14, 0, 0, 13, 13, 0x1f1f1d, 0.5).setLineWidth(2);
     const label = this.add.text(0, -1, '', {
       fontFamily: 'monospace',
-      fontSize: '11px',
+      fontSize: '12px',
       color: '#1f1f1d'
     }).setOrigin(0.5);
 
@@ -447,11 +447,21 @@ export class RidgeScene extends Phaser.Scene {
     const y = RIDGE_FLOOR_Y - 74;
     this.add.rectangle(x, y + 28, 10, 86, 0x1f1f1d, 0.88);
     this.add.rectangle(x, y - 12, 86, 10, 0x1f1f1d, 0.88);
-    this.add.ellipse(x + 16, y - 36, 54, 28, 0x1f1f1d, 0.95);
-    this.add.triangle(x - 8, y - 50, 0, 14, 12, 0, 22, 14, 0x1f1f1d, 0.95);
-    this.add.triangle(x + 18, y - 50, 0, 14, 12, 0, 22, 14, 0x1f1f1d, 0.95);
+    this.add.rectangle(x + 18, y - 32, 72, 32, 0xf7f1df, 0.94)
+      .setStrokeStyle(2, 0x1f1f1d, 0.22)
+      .setAngle(-2);
+    this.add.line(x + 8, y - 42, -20, 0, 20, 0, 0x1f1f1d, 0.16).setLineWidth(2);
+    this.add.line(x + 8, y - 31, -22, 0, 18, 0, 0x1f1f1d, 0.12).setLineWidth(2);
+    this.add.line(x - 10, y - 36, 0, 0, -28, -13, 0x1f1f1d, 0.9).setLineWidth(5);
+    this.add.line(x - 38, y - 49, 0, 0, -16, 11, 0x1f1f1d, 0.9).setLineWidth(5);
+    this.add.circle(x - 55, y - 37, 3, 0xf7f1df, 0.9);
+    this.add.ellipse(x + 16, y - 36, 56, 29, 0x1f1f1d, 0.96);
+    this.add.triangle(x - 8, y - 51, 0, 15, 12, 0, 23, 15, 0x1f1f1d, 0.96);
+    this.add.triangle(x + 19, y - 51, 0, 15, 12, 0, 23, 15, 0x1f1f1d, 0.96);
     this.add.circle(x + 30, y - 38, 3, 0xf7f1df, 1);
-    this.add.line(x - 18, y - 32, -30, 0, -54, -10, 0x1f1f1d, 0.9).setLineWidth(5);
+    this.add.ellipse(x + 9, y - 30, 6, 3, 0xf7f1df, 0.88).setAngle(-10);
+    this.add.circle(x + 4, y - 23, 2, 0xf7f1df, 0.9);
+    this.add.circle(x + 21, y - 23, 2, 0xf7f1df, 0.9);
     if (hasRidgeWorldMemory(memories, 'cicka-stampede-note')) {
       this.addCickaStampedeNoteMemory(x, y);
     }
@@ -461,15 +471,16 @@ export class RidgeScene extends Phaser.Scene {
     x: number,
     y: number
   ): void {
-    this.add.rectangle(x + 58, y - 70, 34, 24, 0xf7f1df, 1)
+    this.add.rectangle(x + 62, y - 72, 42, 30, 0xf7f1df, 1)
       .setStrokeStyle(2, 0x1f1f1d, 0.88)
       .setAngle(5);
-    this.add.circle(x + 56, y - 68, 4, 0x1f1f1d, 0.72);
-    this.add.circle(x + 50, y - 76, 2, 0x1f1f1d, 0.72);
-    this.add.circle(x + 56, y - 78, 2, 0x1f1f1d, 0.72);
-    this.add.circle(x + 62, y - 76, 2, 0x1f1f1d, 0.72);
-    this.add.line(x + 70, y - 66, -6, 4, 8, -4, 0x1f1f1d, 0.42).setLineWidth(2);
-    this.add.line(x + 70, y - 60, -5, 3, 7, -3, 0x1f1f1d, 0.34).setLineWidth(2);
+    this.add.line(x + 42, y - 63, -8, 5, 8, -5, 0x1f1f1d, 0.3).setLineWidth(2);
+    this.add.circle(x + 59, y - 70, 5, 0x1f1f1d, 0.72);
+    this.add.circle(x + 51, y - 81, 3, 0x1f1f1d, 0.72);
+    this.add.circle(x + 60, y - 84, 3, 0x1f1f1d, 0.72);
+    this.add.circle(x + 69, y - 81, 3, 0x1f1f1d, 0.72);
+    this.add.line(x + 78, y - 70, -7, 5, 10, -5, 0x1f1f1d, 0.48).setLineWidth(2);
+    this.add.line(x + 79, y - 63, -6, 4, 9, -4, 0x1f1f1d, 0.38).setLineWidth(2);
   }
 
   private addStampedeBlanket(

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -85,7 +85,7 @@ export class RidgeScene extends Phaser.Scene {
   private cickaWalkByEnabled = false;
   private cickaWalkByBark = '';
   private cickaWalkByState: CickaWalkByState = createCickaWalkByState();
-  private cickaWalkByAnchor = {
+  private cickaWalkByAnchor: { x: number; y: number } = {
     x: RIDGE_PLAYER_START.x,
     y: CICKA_WALK_BY_ANCHOR_Y
   };

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -45,6 +45,14 @@ import {
   updateCickaWalkBy,
   type CickaWalkByState
 } from '../cickaWalkBy';
+import {
+  CICKA_INTERACTION_RESPONSE_DURATION_MS,
+  CICKA_INTERACTION_TARGET_ID,
+  getCickaInteractionResponse,
+  shouldShowCickaInteractionPrompt,
+  type CickaInteractionCopy,
+  type CickaInteractionResponse
+} from '../cickaInteraction';
 import type { TrailCardOverlayParams } from '@/game/overlays/trailCard/types';
 
 interface RidgeSceneStartData {
@@ -56,7 +64,12 @@ interface RidgeSceneStartData {
 
 type RidgeInteractionEffect =
   | { kind: 'close' }
-  | { kind: 'openTrailCard'; params: TrailCardOverlayParams };
+  | { kind: 'openTrailCard'; params: TrailCardOverlayParams }
+  | { kind: 'showCickaResponse'; response: CickaInteractionResponse };
+
+type RidgeInteractionTargetId =
+  | RidgeTrailCardTargetId
+  | typeof CICKA_INTERACTION_TARGET_ID;
 
 const CICKA_WALK_BY_ANCHOR_Y = RIDGE_FLOOR_Y - 74;
 
@@ -65,9 +78,12 @@ export class RidgeScene extends Phaser.Scene {
   interactPrompt?: Phaser.GameObjects.Text;
 
   private playerRuntime?: SideViewPlayerRuntime;
-  private interactionRuntime?: InteriorInteractionRuntime<RidgeTrailCardTargetId, RidgeInteractionEffect>;
-  private cickaWalkByBubble?: Phaser.GameObjects.Container;
+  private interactionRuntime?: InteriorInteractionRuntime<RidgeInteractionTargetId, RidgeInteractionEffect>;
+  private cickaSpeechBubble?: Phaser.GameObjects.Container;
+  private cickaSpeechBubbleLabel?: Phaser.GameObjects.Text;
+  private cickaSpeechVisibleUntilMs = 0;
   private cickaWalkByEnabled = false;
+  private cickaWalkByBark = '';
   private cickaWalkByState: CickaWalkByState = createCickaWalkByState();
   private cickaWalkByAnchor = {
     x: RIDGE_PLAYER_START.x,
@@ -120,13 +136,17 @@ export class RidgeScene extends Phaser.Scene {
     this.addBackdrop();
     this.addLandmarks(
       messages.scenes.ridge.memory.stampedeFirstClearLabel,
-      messages.scenes.ridge.memory.cickaStampedeNoteLabel,
       worldMemories
     );
-    this.addCickaWalkByBubble(messages.scenes.ridge.memory.cickaWalkByBark);
+    this.cickaWalkByBark = messages.scenes.ridge.memory.cickaWalkByBark;
+    this.addCickaSpeechBubble();
     this.addPlaceholderCopy();
     this.createPlayer(ground);
-    this.createTrailCardInteractions(messages.navigation.interact);
+    this.createRidgeInteractions(
+      messages.navigation.interact,
+      messages.scenes.ridge.cicka.interaction,
+      worldMemories
+    );
     this.setPaused(this.isPaused);
     this.playerRuntime?.syncAppearance();
   }
@@ -141,6 +161,7 @@ export class RidgeScene extends Phaser.Scene {
     }
 
     this.updateCickaWalkByMemory();
+    this.updateCickaSpeechBubble();
 
     const interaction = this.interactionRuntime?.update({
       playerX: this.player?.x ?? 0,
@@ -149,25 +170,41 @@ export class RidgeScene extends Phaser.Scene {
       exitRequested: playerUpdate.commands.exitContext
     });
 
-    if (!interaction || !interaction.prompt.visible) {
+    if (!interaction) {
       this.interactPrompt?.setVisible(false);
       return;
     }
 
-    this.interactPrompt?.setPosition(interaction.prompt.x, interaction.prompt.y).setVisible(true);
     if (interaction.effect?.kind === 'openTrailCard') {
       this.onOpenOverlay?.(TRAIL_CARD_OVERLAY_ID, {
         params: interaction.effect.params,
         returnToSceneId: PHASER_SCENE_KEYS.ridge
       });
+    } else if (interaction.effect?.kind === 'showCickaResponse') {
+      this.showCickaSpeechBubble(interaction.effect.response.line);
     }
+
+    if (
+      !interaction.prompt.visible ||
+      !shouldShowCickaInteractionPrompt({
+        activeTargetId: interaction.activeTarget?.id ?? null,
+        responseVisible: this.isCickaSpeechBubbleVisible()
+      })
+    ) {
+      this.interactPrompt?.setVisible(false);
+      return;
+    }
+
+    this.interactPrompt?.setPosition(interaction.prompt.x, interaction.prompt.y).setVisible(true);
   }
 
   private configureCickaWalkByMemory(memories: readonly RidgeWorldMemory[]): void {
     const cickaPerch = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'cicka-perch');
     this.cickaWalkByState = createCickaWalkByState();
     this.cickaWalkByEnabled = hasRidgeWorldMemory(memories, 'cicka-stampede-note') && !!cickaPerch;
-    this.cickaWalkByBubble = undefined;
+    this.cickaSpeechBubble = undefined;
+    this.cickaSpeechBubbleLabel = undefined;
+    this.cickaSpeechVisibleUntilMs = 0;
     if (!cickaPerch) return;
     this.cickaWalkByAnchor = {
       x: cickaPerch.x,
@@ -177,7 +214,7 @@ export class RidgeScene extends Phaser.Scene {
 
   private updateCickaWalkByMemory(): void {
     if (!this.player) {
-      this.cickaWalkByBubble?.setVisible(false);
+      this.cickaSpeechBubble?.setVisible(false);
       return;
     }
 
@@ -191,7 +228,27 @@ export class RidgeScene extends Phaser.Scene {
     });
 
     this.cickaWalkByState = walkByUpdate.state;
-    this.cickaWalkByBubble?.setVisible(walkByUpdate.visible);
+    if (walkByUpdate.triggered) {
+      this.showCickaSpeechBubble(this.cickaWalkByBark, walkByUpdate.state.visibleUntilMs);
+    }
+  }
+
+  private showCickaSpeechBubble(
+    line: string,
+    visibleUntilMs: number = this.time.now + CICKA_INTERACTION_RESPONSE_DURATION_MS
+  ): void {
+    if (!this.cickaSpeechBubble || !this.cickaSpeechBubbleLabel) return;
+    this.cickaSpeechBubbleLabel.setText(line);
+    this.cickaSpeechVisibleUntilMs = visibleUntilMs;
+    this.cickaSpeechBubble.setVisible(true);
+  }
+
+  private updateCickaSpeechBubble(): void {
+    this.cickaSpeechBubble?.setVisible(this.isCickaSpeechBubbleVisible());
+  }
+
+  private isCickaSpeechBubbleVisible(): boolean {
+    return this.time.now < this.cickaSpeechVisibleUntilMs;
   }
 
   private createGround(): Phaser.GameObjects.Zone {
@@ -274,7 +331,11 @@ export class RidgeScene extends Phaser.Scene {
     this.physics.add.collider(this.player, ground);
   }
 
-  private createTrailCardInteractions(promptText: string): void {
+  private createRidgeInteractions(
+    promptText: string,
+    cickaInteractionCopy: CickaInteractionCopy,
+    worldMemories: readonly RidgeWorldMemory[]
+  ): void {
     this.interactPrompt = createUiText(this, 0, 0, promptText, {
       fontSize: '16px',
       color: '#1a1a1a',
@@ -283,22 +344,39 @@ export class RidgeScene extends Phaser.Scene {
     }).setOrigin(0.5).setDepth(100).setVisible(false);
 
     this.interactionRuntime = createInteriorInteractionRuntime<
-      RidgeTrailCardTargetId,
+      RidgeInteractionTargetId,
       RidgeInteractionEffect
     >({
       interactRadius: 72,
       exitEffect: { kind: 'close' },
-      targets: RIDGE_TRAIL_CARD_TARGETS.map((target) => ({
-        id: target.id,
-        kind: 'trail-card',
-        x: target.x,
-        distanceAnchorY: target.distanceAnchorY,
-        prompt: target.prompt,
-        effect: {
-          kind: 'openTrailCard',
-          params: target.card
-        } satisfies RidgeInteractionEffect
-      }))
+      targets: [
+        {
+          id: CICKA_INTERACTION_TARGET_ID,
+          kind: 'cicka',
+          x: this.cickaWalkByAnchor.x,
+          distanceAnchorY: this.cickaWalkByAnchor.y,
+          prompt: {
+            x: this.cickaWalkByAnchor.x,
+            y: this.cickaWalkByAnchor.y - 86
+          },
+          interactRadius: 78,
+          effect: (): RidgeInteractionEffect => ({
+            kind: 'showCickaResponse',
+            response: getCickaInteractionResponse(worldMemories, cickaInteractionCopy)
+          })
+        },
+        ...RIDGE_TRAIL_CARD_TARGETS.map((target) => ({
+          id: target.id,
+          kind: 'trail-card',
+          x: target.x,
+          distanceAnchorY: target.distanceAnchorY,
+          prompt: target.prompt,
+          effect: {
+            kind: 'openTrailCard',
+            params: target.card
+          } satisfies RidgeInteractionEffect
+        }))
+      ]
     });
   }
 
@@ -311,7 +389,6 @@ export class RidgeScene extends Phaser.Scene {
 
   private addLandmarks(
     stampedeFirstClearLabel: string,
-    cickaStampedeNoteLabel: string,
     worldMemories: readonly RidgeWorldMemory[]
   ): void {
     RIDGE_LANDMARKS.forEach((landmark) => {
@@ -321,7 +398,7 @@ export class RidgeScene extends Phaser.Scene {
 
       switch (landmark.kind) {
         case 'cicka-perch':
-          this.addCickaPerch(landmark, cickaStampedeNoteLabel, landmarkMemories);
+          this.addCickaPerch(landmark, landmarkMemories);
           break;
         case 'stampede-blanket':
           this.addStampedeBlanket(landmark, stampedeFirstClearLabel, landmarkMemories);
@@ -343,8 +420,7 @@ export class RidgeScene extends Phaser.Scene {
     });
   }
 
-  private addCickaWalkByBubble(cickaWalkByBark: string): void {
-    if (!this.cickaWalkByEnabled) return;
+  private addCickaSpeechBubble(): void {
     const bubble = this.add.container(
       this.cickaWalkByAnchor.x - 18,
       this.cickaWalkByAnchor.y - 92
@@ -352,19 +428,19 @@ export class RidgeScene extends Phaser.Scene {
     const panel = this.add.rectangle(0, 0, 54, 24, 0xf7f1df, 1)
       .setStrokeStyle(2, 0x1f1f1d, 0.88);
     const tail = this.add.line(20, 12, 0, 0, 12, 12, 0x1f1f1d, 0.5).setLineWidth(2);
-    const label = this.add.text(0, -1, cickaWalkByBark, {
+    const label = this.add.text(0, -1, '', {
       fontFamily: 'monospace',
       fontSize: '11px',
       color: '#1f1f1d'
     }).setOrigin(0.5);
 
     bubble.add([panel, tail, label]);
-    this.cickaWalkByBubble = bubble;
+    this.cickaSpeechBubble = bubble;
+    this.cickaSpeechBubbleLabel = label;
   }
 
   private addCickaPerch(
     landmark: RidgeLandmark,
-    cickaStampedeNoteLabel: string,
     memories: readonly RidgeWorldMemory[]
   ): void {
     const x = landmark.x;
@@ -377,24 +453,23 @@ export class RidgeScene extends Phaser.Scene {
     this.add.circle(x + 30, y - 38, 3, 0xf7f1df, 1);
     this.add.line(x - 18, y - 32, -30, 0, -54, -10, 0x1f1f1d, 0.9).setLineWidth(5);
     if (hasRidgeWorldMemory(memories, 'cicka-stampede-note')) {
-      this.addCickaStampedeNoteMemory(x, y, cickaStampedeNoteLabel);
+      this.addCickaStampedeNoteMemory(x, y);
     }
   }
 
   private addCickaStampedeNoteMemory(
     x: number,
-    y: number,
-    cickaStampedeNoteLabel: string
+    y: number
   ): void {
-    this.add.rectangle(x + 58, y - 70, 50, 24, 0xf7f1df, 1)
+    this.add.rectangle(x + 58, y - 70, 34, 24, 0xf7f1df, 1)
       .setStrokeStyle(2, 0x1f1f1d, 0.88)
       .setAngle(5);
-    this.add.text(x + 38, y - 78, cickaStampedeNoteLabel, {
-      fontFamily: 'monospace',
-      fontSize: '11px',
-      color: '#1f1f1d'
-    }).setAngle(5).setDepth(5);
-    this.add.line(x + 35, y - 51, -8, 8, 12, -6, 0x1f1f1d, 0.38).setLineWidth(2);
+    this.add.circle(x + 56, y - 68, 4, 0x1f1f1d, 0.72);
+    this.add.circle(x + 50, y - 76, 2, 0x1f1f1d, 0.72);
+    this.add.circle(x + 56, y - 78, 2, 0x1f1f1d, 0.72);
+    this.add.circle(x + 62, y - 76, 2, 0x1f1f1d, 0.72);
+    this.add.line(x + 70, y - 66, -6, 4, 8, -4, 0x1f1f1d, 0.42).setLineWidth(2);
+    this.add.line(x + 70, y - 60, -5, 3, 7, -3, 0x1f1f1d, 0.34).setLineWidth(2);
   }
 
   private addStampedeBlanket(

--- a/src/game/scenes/ridge/worldLayout.test.ts
+++ b/src/game/scenes/ridge/worldLayout.test.ts
@@ -10,6 +10,7 @@ import {
 import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
 import { STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
 import { getRidgeLandmarkMemories } from './worldMemory';
+import { CICKA_INTERACTION_TARGET_ID } from './cickaInteraction';
 
 describe('ridge world layout', () => {
   it('keeps the first movement shell flat and inside world bounds', () => {
@@ -43,6 +44,9 @@ describe('ridge world layout', () => {
       'telegraph-terrace',
       'domino-desk'
     ]);
+    expect(RIDGE_TRAIL_CARD_TARGETS.map((target) => target.id)).not.toContain(
+      CICKA_INTERACTION_TARGET_ID
+    );
     expect(RIDGE_TRAIL_CARD_TARGETS.map((target) => target.landmarkKind)).toEqual([
       'stampede-blanket',
       'telegraph-bag',

--- a/src/shared/i18n/messages/en/scenes.ts
+++ b/src/shared/i18n/messages/en/scenes.ts
@@ -28,6 +28,7 @@ export const sceneMessages = {
     memory: {
       stampedeFirstClearLabel: "HELD",
       cickaStampedeNoteLabel: "mrrp?",
+      cickaWalkByBark: "mrrp.",
     },
   },
   stampedeSketch: {

--- a/src/shared/i18n/messages/en/scenes.ts
+++ b/src/shared/i18n/messages/en/scenes.ts
@@ -27,8 +27,13 @@ export const sceneMessages = {
   ridge: {
     memory: {
       stampedeFirstClearLabel: "HELD",
-      cickaStampedeNoteLabel: "mrrp?",
       cickaWalkByBark: "mrrp.",
+    },
+    cicka: {
+      interaction: {
+        fresh: "meow.",
+        stampedeMemory: "mrrp!",
+      },
     },
   },
   stampedeSketch: {


### PR DESCRIPTION
## Summary
- Adds a first Cicka interaction on Ridge with pre-translator responses that change after the `stampede-sketch` memory exists.
- Keeps the Stampede-derived walk-by bark, but makes it a one-shot Ridge entry reaction instead of stored state.
- Reworks the Cicka memory mark into a small paw/scratch decal and improves speech-bubble readability so it no longer clashes with the interact prompt.
- Updates Ridge milestone planning to reflect the Cicka-first interaction and primitive readability polish slice.

## Testing
- Added and updated unit coverage for Cicka interaction, walk-by behavior, Ridge memory derivation, and Ridge layout boundaries.
- Ran the focused Ridge/store test set, typecheck, and diff check.
- Verified the fresh and seeded Ridge flows in the browser so Cicka reads clearly and the prompt does not overlap her speech bubble.