### PR TITLE
Refine Ridge direction and archive boundaries

### DIFF
--- a/docs/game-design/README.md
+++ b/docs/game-design/README.md
@@ -29,7 +29,9 @@ This directory separates shipped player-facing behavior from future design conce
   These can guide future work, but should not override the active milestone or
   runtime docs.
 - **Archive:** `ai-competition/` is closed competition history. Do not treat it
-  as an active roadmap.
+  as an active roadmap or current source of truth. Search hits from
+  `ai-competition/archive/**` are historical by default; use the active Summit,
+  milestone, and runtime docs for current planning.
 
 ## Core Pillars
 

--- a/docs/game-design/ai-competition/README.md
+++ b/docs/game-design/ai-competition/README.md
@@ -7,7 +7,9 @@ The active production plan is now:
 - [Sketchbook Ridge Summit](../sketchbook-ridge-summit.md)
 
 Keep this folder as provenance for how the current direction was chosen. Do not
-treat these files as the source of truth for implementation planning.
+edit it to match current planning, and do not treat search hits from this
+archive as implementation guidance. Use the active Summit, milestone, and
+runtime docs for current work.
 
 ## Archived Rounds
 

--- a/docs/game-design/potassium-slip.md
+++ b/docs/game-design/potassium-slip.md
@@ -39,10 +39,11 @@ Potassium Slip is the existing arcade anchor for Sketchbook Ridge. It owns the
 ricochet lane and should remain the benchmark for a deep opt-in mini-game, not
 the template every future mini-game must match.
 
-The Circuit is Potassium's durable world reward and the alternate key for the
-first Relay Spire gate. Future Ridge gate code should check existing inventory
-ownership with `isItemOwned('circuit')`, or the equivalent bridge inventory read,
-instead of adding a separate Ridge progress flag such as `circuitOwned`.
+The Circuit is Potassium's durable world reward and one major proof toward the
+first Relay Spire gate, not a solo bypass. Future Ridge gate code should check
+existing inventory ownership with `isItemOwned('circuit')`, or the equivalent
+bridge inventory read, instead of adding a separate Ridge progress flag such as
+`circuitOwned`.
 
 Ridge signs, Trail Cards, NPCs, and stickers may acknowledge Potassium and the
 Circuit, but Potassium run behavior should stay scene-owned: fresh-start entry,
@@ -64,8 +65,8 @@ approved, filed, and made sensible before it can help the Ridge.
 
 The campaign reward should stay the **Circuit**. Fictionally, the Compliance
 Officer has withheld it because the Relay Spire signal is "not properly
-approved." Beating the boss recovers the Circuit and lets Potassium act as the
-alternate key to the first Relay Spire gate.
+approved." Beating the boss recovers the Circuit and lets Potassium count as one
+major proof toward the first Relay Spire gate.
 
 On return to the Ridge, Potassium should leave a visible memory rather than only
 an inventory flag. Good first candidates are:

--- a/docs/game-design/sketchbook-ridge-asset-staging-plan.md
+++ b/docs/game-design/sketchbook-ridge-asset-staging-plan.md
@@ -154,9 +154,13 @@ Reason:
 Recommended slice:
 
 - review `asset-sources/prepared/characters/cicka/`
-- decide whether it is a prepared prototype or active runtime source
+- promote only the chosen Cicka frames into runtime-wired Ridge assets
+- use the slice to establish the first scene-owned asset adoption pattern:
+  runtime asset location, manifest/key naming, preload ownership, and local
+  README expectations
 - if integrated, keep it lightweight: perch, blink, loaf, suspicious turn, and
   one movement read are enough
+- do not build a global asset framework from the first adoption slice
 
 ### 2. Stampede Objective Visual Pass
 
@@ -244,19 +248,14 @@ Riskier work that should be serialized:
 
 ## Recommended Next 1-3 Tasks
 
-1. Keep the long-term topology ideas doc as planning-only and out of milestone
-   requirements.
-2. Open a small implementation slice for either Cicka adoption in Ridge or the
-   Stampede calm-patch / proximity-aggro pass, but not both plus Potassium at
-   once.
+1. Open **Cicka Runtime Asset Adoption** as the next asset implementation slice.
+2. Follow with a **Ridge / Outskirts Topology Spike** before committing to
+   shortcut, glide, wall-cling, or full Overworld replacement behavior.
+3. Keep Stampede calm-patch / proximity-aggro and Potassium visual upgrades as
+   later scene-owned asset slices.
 
 ## Decision Needed From Danilo
 
-The highest-leverage taste/production call is:
-
-- should the next asset integration slice be **Cicka in Ridge** or
-  **Stampede calm patch + proximity aggro**
-
-My recommendation is **Cicka first for warmth**, unless you want the current
-active gameplay slice to stay purely on Stampede, in which case **Stampede calm
-patch + proximity aggro** is the better follow-through.
+Current decision: **Cicka first**, then Ridge / Outskirts topology. Stampede and
+Potassium asset adoption stay queued until those two slices clarify the main
+world and asset standard.

--- a/docs/game-design/sketchbook-ridge-long-term-topology-ideas.md
+++ b/docs/game-design/sketchbook-ridge-long-term-topology-ideas.md
@@ -29,6 +29,11 @@ grow into a denser tiny overworld with:
 - *Hollow Knight* shortcut relief and route compression
 - *Tunic* reinterpretation secrets and "oh, wait" moments
 
+The locked long-term world direction is **2D side-view interconnected Ridge**.
+This means Hollow Knight-style topology is the structural reference, not a
+top-down/isometric/3D-like pivot. The mood remains gentle and personal, and the
+re-reading layer remains closer to Tunic than to a combat metroidvania.
+
 The key rule is: expand **density**, not **size**.
 
 ## Long-Term World Thesis
@@ -40,16 +45,21 @@ It should not become:
 
 - a huge metroidvania map
 - a biome tour
+- a top-down or isometric world unless a dedicated future spike proves the cost
+  is worth it
 - a puzzle-box that hides progress behind obscure logic
 - a lore-heavy world that forgets Danilo is the primary audience
 
 It should become:
 
 - one memorable summit route
+- an interconnected 2D side-view map with loops, shafts, and compressed returns
 - several hidden parallel strata
 - a web of satisfying shortcuts
 - a place where old landmarks gain new meaning after mobility, manual, or
   Cicka discoveries
+- eventual movement flavors such as wall cling and double jump, treated as
+  optional or later topology payoffs before they ever become main-ending gates
 
 Late-game, the player should be able to cross the Ridge quickly, but still feel
 there are a few corners worth revisiting.

--- a/docs/game-design/sketchbook-ridge-long-term-topology-ideas.md
+++ b/docs/game-design/sketchbook-ridge-long-term-topology-ideas.md
@@ -228,7 +228,7 @@ Good uses:
 - banana-law signage
 - rebound diagrams as jokes
 - NPC commentary
-- alternate finale key recognition through the Circuit
+- major-proof recognition through the Circuit
 
 Avoid:
 

--- a/docs/game-design/sketchbook-ridge-m3-audio-pack.md
+++ b/docs/game-design/sketchbook-ridge-m3-audio-pack.md
@@ -123,7 +123,7 @@ Do not:
 - Add ricochet-heavy sounds to the Ridge; Potassium owns that lane.
 - Make the Circuit stinger louder than a Stampede clear.
 - Add stored Ridge flags for Circuit audio. Implementation should read existing
-  inventory ownership, same as the Ridge gate direction.
+  inventory ownership, same as the Ridge major-proof gate direction.
 
 Suggested names:
 

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -330,12 +330,16 @@ Current checkpoint:
 
 Next implementation slices:
 
-1. **Later First Ridge Shortcut**: wait until the Ridge has enough repeat
-   traversal to make a shortcut feel like real relief rather than a proof of
-   concept.
-2. **Ridge-Only Glide**: keep this as a separate HITL slice because input feel
-   and touch behavior need review.
-3. **Translator / Cicka Daydream**: keep translated Cicka subtitles and the
+1. **Cicka Runtime Asset Adoption**: promote the prepared Cicka runtime
+   candidate into Ridge in a small scene-owned slice. Use this to establish the
+   first asset adoption standard without creating a broad asset framework.
+2. **Ridge / Outskirts Topology Spike**: design and lightly prototype how the
+   current Overworld becomes Outskirts/Trailhead and Ridge becomes a connected
+   Hollow-Knight-topology side-view world. Do not fully replace the default
+   Overworld in the same PR.
+3. **Later First Ridge Shortcut / Ridge-Only Glide**: revisit these after the
+   topology spike gives shortcuts and movement rewards a real route shape.
+4. **Translator / Cicka Daydream**: keep translated Cicka subtitles and the
    Cicka daydream mini-slice for later, after Ridge Memory proves return play.
 
 Do not add stored sticker state. Do not add Stampede upgrades, endless mode,
@@ -349,9 +353,12 @@ Owner: integration + Ridge.
 
 Outputs:
 
-- final gate: any three stamps or Circuit, plus one manual insight.
+- final gate: at least three major clears / proofs, with Potassium Circuit
+  counting as one proof, plus one Cicka / translator / manual insight.
 - short ending/contact overlay.
 - return to Ridge after ending.
+- post-ending Ridge state where Micka first appears after the player completes
+  or replays one mini-game and returns.
 - player manual updated when behavior ships.
 
 ### M7: Telegraph Terrace Prototype
@@ -553,7 +560,8 @@ Blocked by: issues 6, 10, and 11
 
 What to build:
 
-- Gate on any three stamps or Circuit, plus one manual insight.
+- Gate on at least three major clears / proofs, with Potassium Circuit counting
+  as one proof, plus one Cicka / translator / manual insight.
 - Add short ending/contact overlay.
 - Return to Ridge after ending.
 

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -323,7 +323,7 @@ Current checkpoint:
   stamp, Cicka gives one tiny walk-by bark per Ridge entry without stored Cicka
   state.
 - **M5d Cicka First Interaction** accepted for continuation: Cicka can answer a
-  deliberate interact with pre-translator meow punctuation, while the permanent
+  deliberate interaction with pre-translator meow punctuation, while the permanent
   Cicka memory becomes a paw/scratch decal instead of duplicate speech text;
   the same PR includes a small primitive readability polish pass for Cicka,
   her speech bubble, and the memory decal.
@@ -335,7 +335,7 @@ Next implementation slices:
    first asset adoption standard without creating a broad asset framework.
 2. **Ridge / Outskirts Topology Spike**: design and lightly prototype how the
    current Overworld becomes Outskirts/Trailhead and Ridge becomes a connected
-   Hollow-Knight-topology side-view world. Do not fully replace the default
+   Hollow Knight topology side-view world. Do not fully replace the default
    Overworld in the same PR.
 3. **Later First Ridge Shortcut / Ridge-Only Glide**: revisit these after the
    topology spike gives shortcuts and movement rewards a real route shape.

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -52,8 +52,8 @@ Anything beyond that is future scope unless a slice explicitly pulls it in.
   M5a derives Ridge-owned sticker/world-change memories from durable progress
   without stored sticker state, and M5b adds the first Cicka note/translator
   tease plus a dev-only `devRidgeStamp=stampede-sketch` seed for fast local
-  testing. Cicka proximity chatter or direct talk interaction is desired, but
-  held for a later Cicka interaction slice.
+  testing. M5c/M5d add Cicka's Stampede-gated walk-by bark, first deliberate
+  pre-translator interaction, and a primitive readability polish pass.
 - **Asset staging is now an active coordination concern**: prepared POC assets
   exist for Cicka, Potassium, and Stampede enemy families. Keep them documented
   and adopt them in small scene-owned slices instead of turning them into a
@@ -307,7 +307,7 @@ Outputs:
 - sticker/world-change rendering from stamps and manual pages.
 - one shortcut.
 - Ridge-only glide behavior.
-- first Cicka Note or translator tease.
+- first Cicka Note, memory reaction, or pre-translator interaction.
 
 Current checkpoint:
 
@@ -322,7 +322,7 @@ Current checkpoint:
 - **M5c Cicka Walk-By Memory** accepted for continuation: after the Stampede
   stamp, Cicka gives one tiny walk-by bark per Ridge entry without stored Cicka
   state.
-- **M5d Cicka First Interaction** is the current follow-up: Cicka can answer a
+- **M5d Cicka First Interaction** accepted for continuation: Cicka can answer a
   deliberate interact with pre-translator meow punctuation, while the permanent
   Cicka memory becomes a paw/scratch decal instead of duplicate speech text;
   the same PR includes a small primitive readability polish pass for Cicka,
@@ -407,7 +407,8 @@ Blocked by: none
 
 What to build:
 
-- Update docs so Potassium's Circuit is clearly the alternate finale key.
+- Update docs so Potassium's Circuit is clearly one major proof toward the
+  Relay Spire gate, not a solo ending bypass.
 - Record the exact ownership check future Ridge gates should use.
 - Keep Potassium behavior unchanged.
 
@@ -538,7 +539,7 @@ What to build:
 
 - Render placeholder sticker/world changes from progress.
 - Add one shortcut.
-- Add first Cicka Note or translator tease.
+- Add first Cicka Note, memory reaction, or pre-translator interaction.
 
 ### 12. Add Ridge-Only Glide
 

--- a/docs/game-design/sketchbook-ridge-summit.md
+++ b/docs/game-design/sketchbook-ridge-summit.md
@@ -149,9 +149,9 @@ Ending beat:
 - The player understands she is going somewhere the player cannot follow.
 - The farewell is tender but not literal-heavy: no on-screen death scene, no long grief speech.
 - Cicka leaves a final paw mark or page mark, and the Ridge remains replayable after the ending.
-- Micka, a small kitten/child presence, appears only after the player returns to the normal Ridge, not during the ending sequence.
-- Micka first appears when the player returns to the Ridge after completing or
-  replaying one mini-game post-ending.
+- Micka, a small kitten/child presence, appears only after the player returns
+  to the normal Ridge and completes or replays one mini-game post-ending, not
+  during the ending sequence.
 
 ## Main Loop
 

--- a/docs/game-design/sketchbook-ridge-summit.md
+++ b/docs/game-design/sketchbook-ridge-summit.md
@@ -173,7 +173,7 @@ The repeatable pleasure is not just "new content." It is returning to the same p
 - **Manual Pages**: one-screen clues that reinterpret a route, sign, or mechanic.
 - **Glide Pips**: movement upgrades inspired by *A Short Hike* feathers.
 - **Shortcuts**: route changes inspired by *Hollow Knight* relief moments.
-- **Circuit**: Potassium Slip's major reward and alternate finale key. Derive this from the existing inventory item instead of duplicating `potassium.circuitOwned` in progress.
+- **Circuit**: Potassium Slip's major reward and one major proof toward the Relay Spire gate. Derive this from the existing inventory item instead of duplicating `potassium.circuitOwned` in progress.
 - **Cicka Notes**: tiny cat-side observations that reinterpret nearby props without becoming a full language system.
 
 Bridge-owned progress should stay small and serializable. Exact naming should follow the current bridge store shape. A likely implementation is to extend `BridgeProgressState` with a `ridge` object and add explicit award actions:
@@ -201,12 +201,12 @@ Role:
 
 - anchor secret
 - Ball x Pit fun already captured
-- alternate finale key through Circuit
+- one major proof toward the first ending through Circuit
 - benchmark for mini-game depth and documentation
 
 Do:
 
-- integrate the Circuit into Ridge progression
+- integrate the Circuit into Ridge progression as one major proof
 - let Ridge signs and NPCs acknowledge Potassium
 - preserve vertical-board controls
 
@@ -645,7 +645,8 @@ Tasks:
 - one shortcut opens
 - glide pip affects overworld movement
 - manual page overlay explains one existing sign
-- first Cicka Note or translator tease makes an old prop feel newly readable
+- first Cicka Note, memory reaction, or pre-translator interaction makes an old
+  prop feel newly readable
 
 Done when:
 

--- a/docs/game-design/sketchbook-ridge-summit.md
+++ b/docs/game-design/sketchbook-ridge-summit.md
@@ -40,11 +40,15 @@ Danilo explores a compact hand-drawn ridge inside his own sketchbook, climbing t
 
 This is **Danilo's tiny private mountain**, not a portfolio theme park.
 
-The goal is to reach the **Relay Spire** and "send the sketchbook." On paper, that means shipping the portfolio. Emotionally, it means noticing that the unfinished jokes, hobbies, game tastes, tools, and half-serious obsessions already form a coherent world.
+The goal is to reach the **Relay Spire** and "send the sketchbook." On paper, that means shipping the portfolio. Emotionally, it means noticing that the unfinished jokes, hobbies, game tastes, tools, and half-serious obsessions already form a coherent world. Cicka is the emotional spine of that realization: she starts as a tiny resident, becomes the guide who teaches the player how to notice the Ridge, and makes the first ending a quiet farewell and tribute rather than only a contact/credits beat.
 
 The ending should not say "you became perfect." It should say:
 
 > You shipped something alive.
+
+It should also say, softly:
+
+> Thank you for walking with me.
 
 ## Fun Pillars
 
@@ -71,7 +75,16 @@ The ending should not say "you became perfect." It should say:
 
 ## Overworld Plan
 
-The overworld is a side-view ridge that can be crossed quickly once learned. The player sees the Relay Spire early, like a destination silhouette.
+The overworld is a side-view ridge that can be crossed quickly once learned.
+Long-term, it should use **Hollow Knight topology, A Short Hike mood, and
+Tunic re-reading**: connected 2D side-view rooms/screens, vertical shafts,
+shortcut relief, gentle movement rewards, and old props becoming newly legible.
+The player sees the Relay Spire early, like a destination silhouette.
+
+Do not pivot the main world toward top-down, isometric, or 3D-like exploration
+without a deliberate future spike. Phaser's 2D strengths fit a layered
+side-view Ridge better, and the current Ridge shell should grow into that
+direction rather than being discarded.
 
 ### Zone 1: Outskirts / Trailhead
 
@@ -110,17 +123,35 @@ Level shape:
 - one late vertical shortcut shaft
 - no separate biomes in v1
 - palette shifts through ink density, paper texture, and stickers rather than new tile sets
+- future expansion can add double-jump / wall-cling style mobility, but the
+  main path should stay low-cortisol and mobile-feasible
+- the first Cicka farewell ending should not require wall cling or double jump;
+  save those as optional or later topology payoffs unless a mobile control
+  spike proves they are effortless
 
-### Zone 3: Relay Spire / Contact Peak
+### Zone 3: Relay Spire / Farewell Peak
 
-Purpose: final shipping/contact/credits route.
+Purpose: final shipping/contact/credits route, and the first Cicka farewell.
 
 Gate:
 
-- any three hobby stamps **or** Potassium Circuit
-- plus one manual-page insight that decodes the Relay sign
+- at least three major clears / proofs, with Potassium Circuit counting as one
+  proof rather than a solo bypass
+- plus one Cicka / translator / manual insight that decodes the Relay sign
 
-The gate should feel like a knowledge nudge, not a puzzle wall. If Danilo has played around, the answer should feel obvious in retrospect.
+The gate should feel earned but not tedious. It should not require every
+mini-game or every optional mastery scene, but it should ask the player to spend
+real time with the Ridge before the farewell.
+
+Ending beat:
+
+- Cicka is present at the Relay Spire as a guide to a threshold.
+- The player understands she is going somewhere the player cannot follow.
+- The farewell is tender but not literal-heavy: no on-screen death scene, no long grief speech.
+- Cicka leaves a final paw mark or page mark, and the Ridge remains replayable after the ending.
+- Micka, a small kitten/child presence, appears only after the player returns to the normal Ridge, not during the ending sequence.
+- Micka first appears when the player returns to the Ridge after completing or
+  replaying one mini-game post-ending.
 
 ## Main Loop
 
@@ -458,12 +489,22 @@ Behavior:
 - sometimes blocks a path for no reason until the player returns with a sticker or manual clue
 - reacts to cleared mini-games with new "meow" punctuation
 - leaves paw-print margin marks near hidden details
+- grows from side resident into the emotional guide for the first ending
+- leaves through a symbolic farewell at the Relay Spire, toward somewhere the player cannot follow
 
 Design:
 
 - small black-ink silhouette with very readable tail shapes
 - stepped animation: blink, loaf, stretch, suspicious turn, tiny hop
 - subtitles should use paper-cut dialogue bubbles, but only after the translator moment
+
+Ending and tribute rule:
+
+- Cicka's farewell is a tribute beat, not a literal death scene.
+- Use presence, absence, paw marks, and one or two translated lines instead of heavy exposition.
+- After the ending, the Ridge remains open for replay, and Cicka's final mark should persist.
+- Micka appears after the player returns to the Ridge from completing or
+  replaying one post-ending mini-game. She is continuity, not replacement.
 
 Translator fantasy:
 
@@ -506,6 +547,10 @@ Use the *Oyasumi Punpun* taste signal carefully. The goal is not to make the por
 6. No main-path jump should require precision platforming.
 7. Optional mastery paths can be hard, but must be clearly optional.
 8. A mobile player should be able to reach the first Trail Card within one minute.
+9. Long-term topology should stay 2D side-view and interconnected, not
+   top-down/isometric by default.
+10. Wall cling / double jump are desirable long-term movement flavors, but not
+    required gates for the first farewell ending.
 
 ## Architecture Rules For This Plan
 
@@ -628,20 +673,24 @@ Done when:
 
 ### Slice 5: Relay Spire First Ending
 
-Goal: close the loop.
+Goal: close the loop with Cicka as the emotional spine.
 
 Tasks:
 
 - add final gate logic
-- allow any three stamps or Circuit as path
-- require one manual insight
-- add short ending overlay
+- require at least three major clears / proofs, with Potassium Circuit counting
+  as one proof
+- require one Cicka / translator / manual insight
+- add short ending overlay / paper-cut farewell beat
 - return player to Ridge after ending
+- keep mini-games replayable after the ending
+- introduce Micka after the player returns from completing or replaying one
+  post-ending mini-game, not inside the ending sequence
 
 Done when:
 
 - Danilo can finish a complete route in roughly 20 to 35 minutes
-- the ending feels like shipping a living sketchbook
+- the ending feels like shipping a living sketchbook and saying goodbye with care
 
 ## Design Validation
 
@@ -665,6 +714,7 @@ Cut or defer these until the core loop is proven:
 - full Tunic cipher language
 - second ricochet mini-game
 - large overworld map
+- top-down/isometric overworld pivot before a dedicated spike
 - multi-biome asset set
 - generic mini-game framework
 - meta-progression shop


### PR DESCRIPTION
## Summary
- Clarify the current Ridge direction around Cicka, the farewell ending, Micka post-ending continuity, and the 3-proof Relay Spire gate.
- Lock the long-term world shape as a 2D side-view interconnected Ridge with Hollow Knight-style topology and optional later wall-cling/double-jump mobility.
- Tighten the asset staging plan so Cicka runtime adoption and the Ridge/Outskirts topology spike are the next planned slices.
- Mark the AI competition docs as historical provenance and separate them more clearly from active planning docs.

## Testing
- `docs:check` passed.
- Reviewed the updated planning and archive docs for consistency with the current Cicka/Ridge direction.