### PR TITLE
[codex] Fix Ridge PR 57 CI failure

### DIFF
--- a/docs/game-design/ridge-map-inventory-canvas.html
+++ b/docs/game-design/ridge-map-inventory-canvas.html
@@ -162,713 +162,728 @@
     </main>
 
     <script>
-      const canvas = document.getElementById("ridgeMap");
-      const context = canvas.getContext("2d");
+      (() => {
+        const canvas = document.getElementById("ridgeMap");
+        const context = canvas instanceof HTMLCanvasElement ? canvas.getContext("2d") : null;
+        if (!canvas || !context) return;
 
-      const toggles = {
-        firstWalk: document.getElementById("firstWalk"),
-        shortcuts: document.getElementById("shortcuts"),
-        future: document.getElementById("future"),
-        numbers: document.getElementById("numbers"),
-      };
-
-      const rooms = {
-        outskirts: {
-          x: 88,
-          y: 770,
-          w: 278,
-          h: 96,
-          title: "Outskirts",
-          subtitle: "start, old portfolio edge",
-          order: 1,
-          icon: "START",
-        },
-        basement: {
-          x: 78,
-          y: 875,
-          w: 212,
-          h: 42,
-          title: "Basement Hatch",
-          subtitle: "potassium/glasses later",
-          future: true,
-        },
-        cicka: {
-          x: 458,
-          y: 650,
-          w: 246,
-          h: 104,
-          title: "Cicka Home",
-          subtitle: "hub, mementos, safe return",
-          order: 2,
-          hub: true,
-          icon: "HOME",
-        },
-        underpath: {
-          x: 264,
-          y: 710,
-          w: 148,
-          h: 54,
-          title: "Paw Underpath",
-          subtitle: "secret language",
-          future: true,
-        },
-        work: {
-          x: 365,
-          y: 510,
-          w: 264,
-          h: 76,
-          title: "Work Artifact Ledge",
-          subtitle: "Saturn sticker, feather",
-          order: 3,
-          artifact: true,
-        },
-        stampede: {
-          x: 738,
-          y: 496,
-          w: 254,
-          h: 96,
-          title: "Stampede Blanket",
-          subtitle: "mini-game, first proof",
-          order: 4,
-          danger: true,
-        },
-        dropPocket: {
-          x: 1025,
-          y: 420,
-          w: 246,
-          h: 162,
-          title: "Lucky Luna Drop Pocket",
-          subtitle: "optional fall/steer scrap",
-          optional: true,
-          future: true,
-        },
-        switchback: {
-          x: 692,
-          y: 350,
-          w: 306,
-          h: 78,
-          title: "Switchback Shelf",
-          subtitle: "see Cicka below",
-          order: 5,
-        },
-        telegraph: {
-          x: 360,
-          y: 282,
-          w: 280,
-          h: 94,
-          title: "Telegraph Terrace",
-          subtitle: "cord climb, TODO: AI",
-          order: 6,
-          danger: true,
-        },
-        guide: {
-          x: 754,
-          y: 214,
-          w: 272,
-          h: 82,
-          title: "Guide Overlook",
-          subtitle: "Relay visible again",
-          order: 7,
-        },
-        relay: {
-          x: 560,
-          y: 96,
-          w: 274,
-          h: 102,
-          title: "Relay Gate",
-          subtitle: "proof slots, destination",
-          order: 8,
-          gate: true,
-        },
-        domino: {
-          x: 975,
-          y: 86,
-          w: 274,
-          h: 98,
-          title: "Domino Desk / Lift",
-          subtitle: "future route compression",
-          order: 9,
-        },
-        high: {
-          x: 1018,
-          y: 18,
-          w: 246,
-          h: 54,
-          title: "High Ledge",
-          subtitle: "future movement reward",
-          future: true,
-          order: 10,
-        },
-      };
-
-      const colors = {
-        ink: "#1c1b18",
-        muted: "#5f5a51",
-        paper: "#efe7d4",
-        paperDeep: "#d7cab0",
-        roomFill: "#f7f0df",
-        roomShadow: "rgba(78, 63, 43, 0.18)",
-        route: "#181713",
-        shortcut: "#2f6d78",
-        future: "#79664a",
-        accent: "#9c3f33",
-        gold: "#a9732f",
-      };
-
-      const grain = Array.from({ length: 260 }, (_, index) => {
-        const x = (index * 97 + 53) % 1400;
-        const y = (index * 131 + 29) % 940;
-        return { x, y };
-      });
-
-      function center(room) {
-        return {
-          x: room.x + room.w / 2,
-          y: room.y + room.h / 2,
+        const toggles = {
+          firstWalk: document.getElementById("firstWalk"),
+          shortcuts: document.getElementById("shortcuts"),
+          future: document.getElementById("future"),
+          numbers: document.getElementById("numbers"),
         };
-      }
 
-      function edge(room, side) {
-        const c = center(room);
-        if (side === "left") return { x: room.x, y: c.y };
-        if (side === "right") return { x: room.x + room.w, y: c.y };
-        if (side === "top") return { x: c.x, y: room.y };
-        return { x: c.x, y: room.y + room.h };
-      }
+        const layerDefaults = {
+          firstWalk: true,
+          shortcuts: true,
+          future: false,
+          numbers: true,
+        };
 
-      function drawBackground() {
-        context.fillStyle = colors.paper;
-        context.fillRect(0, 0, canvas.width, canvas.height);
-
-        context.save();
-        context.globalAlpha = 0.14;
-        context.strokeStyle = "#6b5e4a";
-        context.lineWidth = 1;
-        for (let y = 28; y < canvas.height; y += 34) {
-          context.beginPath();
-          context.moveTo(0, y + Math.sin(y) * 2);
-          context.lineTo(canvas.width, y + Math.cos(y) * 2);
-          context.stroke();
-        }
-        context.globalAlpha = 0.08;
-        for (let x = 38; x < canvas.width; x += 48) {
-          context.beginPath();
-          context.moveTo(x, 0);
-          context.lineTo(x + Math.sin(x) * 4, canvas.height);
-          context.stroke();
-        }
-        context.restore();
-
-        context.save();
-        context.fillStyle = "rgba(122, 91, 57, 0.08)";
-        grain.forEach((point) => context.fillRect(point.x, point.y, 1.2, 1.2));
-        context.restore();
-
-        drawTitlePlate();
-      }
-
-      function drawTitlePlate() {
-        context.save();
-        context.translate(44, 36);
-        context.fillStyle = "rgba(247, 240, 223, 0.82)";
-        context.strokeStyle = colors.ink;
-        context.lineWidth = 2;
-        roundedRect(0, 0, 368, 92, 12);
-        context.fill();
-        context.stroke();
-
-        context.fillStyle = colors.ink;
-        context.font = "700 28px Georgia, serif";
-        context.fillText("Sketchbook Ridge", 22, 38);
-        context.font = "15px ui-sans-serif, system-ui, sans-serif";
-        context.fillStyle = colors.muted;
-        context.fillText("inventory-map topology, not final art", 24, 66);
-        context.restore();
-      }
-
-      function roundedRect(x, y, width, height, radius) {
-        const r = Math.min(radius, width / 2, height / 2);
-        context.beginPath();
-        context.moveTo(x + r, y);
-        context.arcTo(x + width, y, x + width, y + height, r);
-        context.arcTo(x + width, y + height, x, y + height, r);
-        context.arcTo(x, y + height, x, y, r);
-        context.arcTo(x, y, x + width, y, r);
-        context.closePath();
-      }
-
-      function drawConnection(points, options = {}) {
-        const {
-          color = colors.route,
-          width = 5,
-          dashed = false,
-          label = "",
-          labelOffset = { x: 0, y: 0 },
-          arrow = true,
-        } = options;
-
-        context.save();
-        context.strokeStyle = color;
-        context.lineWidth = width;
-        context.lineCap = "round";
-        context.lineJoin = "round";
-        if (dashed) context.setLineDash([14, 11]);
-
-        context.beginPath();
-        context.moveTo(points[0].x, points[0].y);
-        for (let i = 1; i < points.length; i += 1) {
-          context.lineTo(points[i].x, points[i].y);
-        }
-        context.stroke();
-
-        if (arrow) {
-          drawArrowHead(points[points.length - 2], points[points.length - 1], color, width);
+        function isLayerEnabled(layer) {
+          const toggle = toggles[layer];
+          return toggle instanceof HTMLInputElement ? toggle.checked : layerDefaults[layer];
         }
 
-        if (label) {
-          const mid = points[Math.floor(points.length / 2)];
-          drawPathLabel(label, mid.x + labelOffset.x, mid.y + labelOffset.y, color);
+        const rooms = {
+          outskirts: {
+            x: 88,
+            y: 770,
+            w: 278,
+            h: 96,
+            title: "Outskirts",
+            subtitle: "start, old portfolio edge",
+            order: 1,
+            icon: "START",
+          },
+          basement: {
+            x: 78,
+            y: 875,
+            w: 212,
+            h: 42,
+            title: "Basement Hatch",
+            subtitle: "potassium/glasses later",
+            future: true,
+          },
+          cicka: {
+            x: 458,
+            y: 650,
+            w: 246,
+            h: 104,
+            title: "Cicka Home",
+            subtitle: "hub, mementos, safe return",
+            order: 2,
+            hub: true,
+            icon: "HOME",
+          },
+          underpath: {
+            x: 264,
+            y: 710,
+            w: 148,
+            h: 54,
+            title: "Paw Underpath",
+            subtitle: "secret language",
+            future: true,
+          },
+          work: {
+            x: 365,
+            y: 510,
+            w: 264,
+            h: 76,
+            title: "Work Artifact Ledge",
+            subtitle: "Saturn sticker, feather",
+            order: 3,
+            artifact: true,
+          },
+          stampede: {
+            x: 738,
+            y: 496,
+            w: 254,
+            h: 96,
+            title: "Stampede Blanket",
+            subtitle: "mini-game, first proof",
+            order: 4,
+            danger: true,
+          },
+          dropPocket: {
+            x: 1025,
+            y: 420,
+            w: 246,
+            h: 162,
+            title: "Lucky Luna Drop Pocket",
+            subtitle: "optional fall/steer scrap",
+            optional: true,
+            future: true,
+          },
+          switchback: {
+            x: 692,
+            y: 350,
+            w: 306,
+            h: 78,
+            title: "Switchback Shelf",
+            subtitle: "see Cicka below",
+            order: 5,
+          },
+          telegraph: {
+            x: 360,
+            y: 282,
+            w: 280,
+            h: 94,
+            title: "Telegraph Terrace",
+            subtitle: "cord climb, TODO: AI",
+            order: 6,
+            danger: true,
+          },
+          guide: {
+            x: 754,
+            y: 214,
+            w: 272,
+            h: 82,
+            title: "Guide Overlook",
+            subtitle: "Relay visible again",
+            order: 7,
+          },
+          relay: {
+            x: 560,
+            y: 96,
+            w: 274,
+            h: 102,
+            title: "Relay Gate",
+            subtitle: "proof slots, destination",
+            order: 8,
+            gate: true,
+          },
+          domino: {
+            x: 975,
+            y: 86,
+            w: 274,
+            h: 98,
+            title: "Domino Desk / Lift",
+            subtitle: "future route compression",
+            order: 9,
+          },
+          high: {
+            x: 1018,
+            y: 18,
+            w: 246,
+            h: 54,
+            title: "High Ledge",
+            subtitle: "future movement reward",
+            future: true,
+            order: 10,
+          },
+        };
+
+        const colors = {
+          ink: "#1c1b18",
+          muted: "#5f5a51",
+          paper: "#efe7d4",
+          paperDeep: "#d7cab0",
+          roomFill: "#f7f0df",
+          roomShadow: "rgba(78, 63, 43, 0.18)",
+          route: "#181713",
+          shortcut: "#2f6d78",
+          future: "#79664a",
+          accent: "#9c3f33",
+          gold: "#a9732f",
+        };
+
+        const grain = Array.from({ length: 260 }, (_, index) => {
+          const x = (index * 97 + 53) % 1400;
+          const y = (index * 131 + 29) % 940;
+          return { x, y };
+        });
+
+        function center(room) {
+          return {
+            x: room.x + room.w / 2,
+            y: room.y + room.h / 2,
+          };
         }
 
-        context.restore();
-      }
+        function edge(room, side) {
+          const c = center(room);
+          if (side === "left") return { x: room.x, y: c.y };
+          if (side === "right") return { x: room.x + room.w, y: c.y };
+          if (side === "top") return { x: c.x, y: room.y };
+          return { x: c.x, y: room.y + room.h };
+        }
 
-      function drawArrowHead(from, to, color, width) {
-        const angle = Math.atan2(to.y - from.y, to.x - from.x);
-        const size = Math.max(12, width * 3);
+        function drawBackground() {
+          context.fillStyle = colors.paper;
+          context.fillRect(0, 0, canvas.width, canvas.height);
 
-        context.save();
-        context.fillStyle = color;
-        context.beginPath();
-        context.moveTo(to.x, to.y);
-        context.lineTo(
-          to.x - Math.cos(angle - Math.PI / 7) * size,
-          to.y - Math.sin(angle - Math.PI / 7) * size,
-        );
-        context.lineTo(
-          to.x - Math.cos(angle + Math.PI / 7) * size,
-          to.y - Math.sin(angle + Math.PI / 7) * size,
-        );
-        context.closePath();
-        context.fill();
-        context.restore();
-      }
-
-      function drawPathLabel(text, x, y, color) {
-        context.save();
-        context.font = "700 13px ui-sans-serif, system-ui, sans-serif";
-        const paddingX = 9;
-        const paddingY = 6;
-        const metrics = context.measureText(text);
-        const width = metrics.width + paddingX * 2;
-        const height = 24;
-        context.fillStyle = "rgba(247, 240, 223, 0.93)";
-        context.strokeStyle = color;
-        context.lineWidth = 1.5;
-        roundedRect(x - width / 2, y - height / 2, width, height, 7);
-        context.fill();
-        context.stroke();
-        context.fillStyle = color;
-        context.textAlign = "center";
-        context.textBaseline = "middle";
-        context.fillText(text, x, y + 0.5);
-        context.restore();
-      }
-
-      function drawRoom(key, room) {
-        const state = room.hub
-          ? "hub"
-          : room.future
-            ? "future"
-            : room.optional
-              ? "optional"
-              : room.danger
-                ? "danger"
-                : "default";
-
-        const fill = {
-          hub: "#fff8e7",
-          future: "#e7dcc4",
-          optional: "#f2ebd8",
-          danger: "#f7eadb",
-          default: colors.roomFill,
-        }[state];
-
-        context.save();
-        context.fillStyle = colors.roomShadow;
-        roundedRect(room.x + 8, room.y + 8, room.w, room.h, 14);
-        context.fill();
-
-        context.fillStyle = fill;
-        context.strokeStyle = room.hub ? colors.accent : colors.ink;
-        context.lineWidth = room.hub ? 4 : room.gate ? 3.5 : 2.5;
-        roundedRect(room.x, room.y, room.w, room.h, 14);
-        context.fill();
-        context.stroke();
-
-        if (room.gate) {
-          context.strokeStyle = colors.gold;
-          context.lineWidth = 2;
-          for (let x = room.x + 34; x < room.x + room.w - 28; x += 48) {
+          context.save();
+          context.globalAlpha = 0.14;
+          context.strokeStyle = "#6b5e4a";
+          context.lineWidth = 1;
+          for (let y = 28; y < canvas.height; y += 34) {
             context.beginPath();
-            context.arc(x, room.y + room.h - 23, 9, 0, Math.PI * 2);
+            context.moveTo(0, y + Math.sin(y) * 2);
+            context.lineTo(canvas.width, y + Math.cos(y) * 2);
             context.stroke();
+          }
+          context.globalAlpha = 0.08;
+          for (let x = 38; x < canvas.width; x += 48) {
+            context.beginPath();
+            context.moveTo(x, 0);
+            context.lineTo(x + Math.sin(x) * 4, canvas.height);
+            context.stroke();
+          }
+          context.restore();
+
+          context.save();
+          context.fillStyle = "rgba(122, 91, 57, 0.08)";
+          grain.forEach((point) => context.fillRect(point.x, point.y, 1.2, 1.2));
+          context.restore();
+
+          drawTitlePlate();
+        }
+
+        function drawTitlePlate() {
+          context.save();
+          context.translate(44, 36);
+          context.fillStyle = "rgba(247, 240, 223, 0.82)";
+          context.strokeStyle = colors.ink;
+          context.lineWidth = 2;
+          roundedRect(0, 0, 368, 92, 12);
+          context.fill();
+          context.stroke();
+
+          context.fillStyle = colors.ink;
+          context.font = "700 28px Georgia, serif";
+          context.fillText("Sketchbook Ridge", 22, 38);
+          context.font = "15px ui-sans-serif, system-ui, sans-serif";
+          context.fillStyle = colors.muted;
+          context.fillText("inventory-map topology, not final art", 24, 66);
+          context.restore();
+        }
+
+        function roundedRect(x, y, width, height, radius) {
+          const r = Math.min(radius, width / 2, height / 2);
+          context.beginPath();
+          context.moveTo(x + r, y);
+          context.arcTo(x + width, y, x + width, y + height, r);
+          context.arcTo(x + width, y + height, x, y + height, r);
+          context.arcTo(x, y + height, x, y, r);
+          context.arcTo(x, y, x + width, y, r);
+          context.closePath();
+        }
+
+        function drawConnection(points, options = {}) {
+          const {
+            color = colors.route,
+            width = 5,
+            dashed = false,
+            label = "",
+            labelOffset = { x: 0, y: 0 },
+            arrow = true,
+          } = options;
+
+          context.save();
+          context.strokeStyle = color;
+          context.lineWidth = width;
+          context.lineCap = "round";
+          context.lineJoin = "round";
+          if (dashed) context.setLineDash([14, 11]);
+
+          context.beginPath();
+          context.moveTo(points[0].x, points[0].y);
+          for (let i = 1; i < points.length; i += 1) {
+            context.lineTo(points[i].x, points[i].y);
+          }
+          context.stroke();
+
+          if (arrow) {
+            drawArrowHead(points[points.length - 2], points[points.length - 1], color, width);
+          }
+
+          if (label) {
+            const mid = points[Math.floor(points.length / 2)];
+            drawPathLabel(label, mid.x + labelOffset.x, mid.y + labelOffset.y, color);
+          }
+
+          context.restore();
+        }
+
+        function drawArrowHead(from, to, color, width) {
+          const angle = Math.atan2(to.y - from.y, to.x - from.x);
+          const size = Math.max(12, width * 3);
+
+          context.save();
+          context.fillStyle = color;
+          context.beginPath();
+          context.moveTo(to.x, to.y);
+          context.lineTo(
+            to.x - Math.cos(angle - Math.PI / 7) * size,
+            to.y - Math.sin(angle - Math.PI / 7) * size,
+          );
+          context.lineTo(
+            to.x - Math.cos(angle + Math.PI / 7) * size,
+            to.y - Math.sin(angle + Math.PI / 7) * size,
+          );
+          context.closePath();
+          context.fill();
+          context.restore();
+        }
+
+        function drawPathLabel(text, x, y, color) {
+          context.save();
+          context.font = "700 13px ui-sans-serif, system-ui, sans-serif";
+          const paddingX = 9;
+          const paddingY = 6;
+          const metrics = context.measureText(text);
+          const width = metrics.width + paddingX * 2;
+          const height = 24;
+          context.fillStyle = "rgba(247, 240, 223, 0.93)";
+          context.strokeStyle = color;
+          context.lineWidth = 1.5;
+          roundedRect(x - width / 2, y - height / 2, width, height, 7);
+          context.fill();
+          context.stroke();
+          context.fillStyle = color;
+          context.textAlign = "center";
+          context.textBaseline = "middle";
+          context.fillText(text, x, y + 0.5);
+          context.restore();
+        }
+
+        function drawRoom(key, room) {
+          const state = room.hub
+            ? "hub"
+            : room.future
+              ? "future"
+              : room.optional
+                ? "optional"
+                : room.danger
+                  ? "danger"
+                  : "default";
+
+          const fill = {
+            hub: "#fff8e7",
+            future: "#e7dcc4",
+            optional: "#f2ebd8",
+            danger: "#f7eadb",
+            default: colors.roomFill,
+          }[state];
+
+          context.save();
+          context.fillStyle = colors.roomShadow;
+          roundedRect(room.x + 8, room.y + 8, room.w, room.h, 14);
+          context.fill();
+
+          context.fillStyle = fill;
+          context.strokeStyle = room.hub ? colors.accent : colors.ink;
+          context.lineWidth = room.hub ? 4 : room.gate ? 3.5 : 2.5;
+          roundedRect(room.x, room.y, room.w, room.h, 14);
+          context.fill();
+          context.stroke();
+
+          if (room.gate) {
+            context.strokeStyle = colors.gold;
+            context.lineWidth = 2;
+            for (let x = room.x + 34; x < room.x + room.w - 28; x += 48) {
+              context.beginPath();
+              context.arc(x, room.y + room.h - 23, 9, 0, Math.PI * 2);
+              context.stroke();
+            }
+          }
+
+          if (room.artifact) drawArtifactMark(room);
+          if (room.danger) drawDangerMark(room);
+          if (room.optional) drawDropMark(room);
+          if (room.hub) drawHomeMark(room);
+          if (room.future) drawFutureHatch(room);
+
+          context.fillStyle = colors.ink;
+          context.font = room.title.length > 18 ? "700 19px Georgia, serif" : "700 22px Georgia, serif";
+          context.textAlign = "left";
+          context.textBaseline = "top";
+          context.fillText(room.title, room.x + 18, room.y + 17);
+
+          context.fillStyle = colors.muted;
+          context.font = "14px ui-sans-serif, system-ui, sans-serif";
+          context.fillText(room.subtitle, room.x + 18, room.y + 49);
+
+          if (room.icon) {
+            context.font = "700 12px ui-sans-serif, system-ui, sans-serif";
+            context.fillStyle = room.hub ? colors.accent : colors.muted;
+            context.textAlign = "right";
+            context.fillText(room.icon, room.x + room.w - 18, room.y + 20);
+          }
+
+          if (isLayerEnabled("numbers") && room.order) {
+            drawOrder(room.order, room.x - 10, room.y - 10);
+          }
+
+          context.restore();
+        }
+
+        function drawOrder(number, x, y) {
+          context.save();
+          context.fillStyle = colors.ink;
+          context.beginPath();
+          context.arc(x, y, 17, 0, Math.PI * 2);
+          context.fill();
+          context.fillStyle = "#fff7e5";
+          context.font = "700 16px ui-sans-serif, system-ui, sans-serif";
+          context.textAlign = "center";
+          context.textBaseline = "middle";
+          context.fillText(String(number), x, y + 1);
+          context.restore();
+        }
+
+        function drawArtifactMark(room) {
+          context.save();
+          context.translate(room.x + room.w - 48, room.y + room.h - 30);
+          context.fillStyle = colors.gold;
+          context.strokeStyle = colors.ink;
+          context.lineWidth = 1.5;
+          context.beginPath();
+          context.arc(0, 0, 12, 0, Math.PI * 2);
+          context.fill();
+          context.stroke();
+          context.fillStyle = colors.ink;
+          context.font = "700 11px ui-sans-serif, system-ui, sans-serif";
+          context.textAlign = "center";
+          context.textBaseline = "middle";
+          context.fillText("A", 0, 1);
+          context.restore();
+        }
+
+        function drawDangerMark(room) {
+          context.save();
+          context.strokeStyle = colors.accent;
+          context.lineWidth = 2;
+          const y = room.y + room.h - 23;
+          for (let x = room.x + 25; x < room.x + room.w - 20; x += 18) {
+            context.beginPath();
+            context.arc(x, y + Math.sin(x) * 2, 4, 0, Math.PI * 2);
+            context.stroke();
+          }
+          context.restore();
+        }
+
+        function drawDropMark(room) {
+          context.save();
+          context.strokeStyle = colors.shortcut;
+          context.lineWidth = 2;
+          for (let i = 0; i < 6; i += 1) {
+            context.beginPath();
+            context.moveTo(room.x + 42 + i * 28, room.y + 76);
+            context.lineTo(room.x + 42 + i * 28, room.y + 112);
+            context.stroke();
+            drawArrowHead(
+              { x: room.x + 42 + i * 28, y: room.y + 96 },
+              { x: room.x + 42 + i * 28, y: room.y + 118 },
+              colors.shortcut,
+              2,
+            );
+          }
+          context.restore();
+        }
+
+        function drawHomeMark(room) {
+          context.save();
+          context.fillStyle = "rgba(156, 63, 51, 0.15)";
+          context.beginPath();
+          context.arc(room.x + room.w - 42, room.y + room.h - 35, 20, 0, Math.PI * 2);
+          context.fill();
+          context.fillStyle = colors.accent;
+          context.font = "700 25px Georgia, serif";
+          context.textAlign = "center";
+          context.fillText("*", room.x + room.w - 42, room.y + room.h - 25);
+          context.restore();
+        }
+
+        function drawFutureHatch(room) {
+          context.save();
+          context.globalAlpha = 0.55;
+          context.strokeStyle = colors.future;
+          context.lineWidth = 2;
+          context.setLineDash([7, 6]);
+          roundedRect(room.x + 7, room.y + 7, room.w - 14, room.h - 14, 10);
+          context.stroke();
+          context.restore();
+        }
+
+        function drawRoutes() {
+          if (isLayerEnabled("firstWalk")) {
+            drawConnection(
+              [edge(rooms.outskirts, "right"), { x: 386, y: 808 }, { x: 430, y: 716 }, edge(rooms.cicka, "left")],
+              { label: "stairs + climb", labelOffset: { x: 8, y: -24 } },
+            );
+            drawConnection(
+              [edge(rooms.cicka, "top"), { x: 548, y: 620 }, edge(rooms.work, "bottom")],
+              { label: "paper steps", labelOffset: { x: -62, y: 0 } },
+            );
+            drawConnection(
+              [edge(rooms.work, "right"), { x: 675, y: 546 }, edge(rooms.stampede, "left")],
+              { label: "wide jump", labelOffset: { x: 0, y: -24 } },
+            );
+            drawConnection(
+              [edge(rooms.stampede, "top"), { x: 842, y: 466 }, edge(rooms.switchback, "bottom")],
+              { label: "climb out", labelOffset: { x: 58, y: -6 } },
+            );
+            drawConnection(
+              [edge(rooms.switchback, "left"), { x: 656, y: 388 }, { x: 666, y: 320 }, edge(rooms.telegraph, "right")],
+              { label: "back left", labelOffset: { x: 0, y: -34 } },
+            );
+            drawConnection(
+              [edge(rooms.telegraph, "right"), { x: 704, y: 318 }, edge(rooms.guide, "left")],
+              { label: "cord climb", labelOffset: { x: 0, y: -22 } },
+            );
+            drawConnection(
+              [edge(rooms.guide, "top"), { x: 890, y: 176 }, edge(rooms.relay, "right")],
+              { label: "final shelf", labelOffset: { x: 22, y: -18 } },
+            );
+            drawConnection(
+              [edge(rooms.relay, "right"), { x: 900, y: 132 }, edge(rooms.domino, "left")],
+              { label: "lift promise", labelOffset: { x: 0, y: 28 } },
+            );
+          }
+
+          if (isLayerEnabled("shortcuts")) {
+            drawConnection(
+              [
+                { x: rooms.switchback.x + 230, y: rooms.switchback.y + rooms.switchback.h },
+                { x: 960, y: 515 },
+                { x: 840, y: 630 },
+                edge(rooms.cicka, "right"),
+              ],
+              {
+                color: colors.shortcut,
+                width: 4,
+                dashed: true,
+                label: "Stampede clear: fold/drop home",
+                labelOffset: { x: -18, y: 24 },
+              },
+            );
+            drawConnection(
+              [
+                { x: rooms.telegraph.x + 44, y: rooms.telegraph.y + rooms.telegraph.h },
+                { x: 320, y: 486 },
+                { x: 402, y: 680 },
+                edge(rooms.cicka, "left"),
+              ],
+              {
+                color: colors.shortcut,
+                width: 4,
+                dashed: true,
+                label: "Telegraph drop",
+                labelOffset: { x: -20, y: 76 },
+              },
+            );
+          }
+
+          if (isLayerEnabled("future")) {
+            drawConnection(
+              [edge(rooms.domino, "top"), edge(rooms.high, "bottom")],
+              { color: colors.future, dashed: true, label: "future", labelOffset: { x: 58, y: 0 } },
+            );
+            drawConnection(
+              [edge(rooms.cicka, "left"), edge(rooms.underpath, "right")],
+              {
+                color: colors.future,
+                width: 3,
+                dashed: true,
+              },
+            );
+            drawConnection(
+              [edge(rooms.underpath, "left"), { x: 240, y: 740 }, edge(rooms.outskirts, "top")],
+              {
+                color: colors.future,
+                width: 3,
+                dashed: true,
+              },
+            );
+            drawConnection(
+              [edge(rooms.outskirts, "bottom"), edge(rooms.basement, "top")],
+              {
+                color: colors.future,
+                width: 3,
+                dashed: true,
+              },
+            );
+            drawConnection(
+              [
+                { x: rooms.guide.x + rooms.guide.w, y: rooms.guide.y + 56 },
+                { x: 1104, y: 338 },
+                edge(rooms.dropPocket, "top"),
+              ],
+              {
+                color: colors.future,
+                width: 3.5,
+                dashed: true,
+                label: "optional descent",
+                labelOffset: { x: 36, y: 0 },
+              },
+            );
+            drawConnection(
+              [edge(rooms.dropPocket, "bottom"), { x: 1024, y: 615 }, edge(rooms.stampede, "right")],
+              {
+                color: colors.future,
+                width: 3.5,
+                dashed: true,
+                label: "returns near Stampede",
+                labelOffset: { x: -8, y: 16 },
+              },
+            );
+            drawConnection(
+              [
+                { x: rooms.domino.x + 218, y: rooms.domino.y + rooms.domino.h },
+                { x: 1268, y: 342 },
+                { x: 1154, y: 654 },
+                edge(rooms.cicka, "right"),
+              ],
+              {
+                color: colors.shortcut,
+                width: 4,
+                dashed: true,
+                label: "lift home",
+                labelOffset: { x: -58, y: -18 },
+              },
+            );
           }
         }
 
-        if (room.artifact) drawArtifactMark(room);
-        if (room.danger) drawDangerMark(room);
-        if (room.optional) drawDropMark(room);
-        if (room.hub) drawHomeMark(room);
-        if (room.future) drawFutureHatch(room);
-
-        context.fillStyle = colors.ink;
-        context.font = room.title.length > 18 ? "700 19px Georgia, serif" : "700 22px Georgia, serif";
-        context.textAlign = "left";
-        context.textBaseline = "top";
-        context.fillText(room.title, room.x + 18, room.y + 17);
-
-        context.fillStyle = colors.muted;
-        context.font = "14px ui-sans-serif, system-ui, sans-serif";
-        context.fillText(room.subtitle, room.x + 18, room.y + 49);
-
-        if (room.icon) {
-          context.font = "700 12px ui-sans-serif, system-ui, sans-serif";
-          context.fillStyle = room.hub ? colors.accent : colors.muted;
-          context.textAlign = "right";
-          context.fillText(room.icon, room.x + room.w - 18, room.y + 20);
-        }
-
-        if (toggles.numbers.checked && room.order) {
-          drawOrder(room.order, room.x - 10, room.y - 10);
-        }
-
-        context.restore();
-      }
-
-      function drawOrder(number, x, y) {
-        context.save();
-        context.fillStyle = colors.ink;
-        context.beginPath();
-        context.arc(x, y, 17, 0, Math.PI * 2);
-        context.fill();
-        context.fillStyle = "#fff7e5";
-        context.font = "700 16px ui-sans-serif, system-ui, sans-serif";
-        context.textAlign = "center";
-        context.textBaseline = "middle";
-        context.fillText(String(number), x, y + 1);
-        context.restore();
-      }
-
-      function drawArtifactMark(room) {
-        context.save();
-        context.translate(room.x + room.w - 48, room.y + room.h - 30);
-        context.fillStyle = colors.gold;
-        context.strokeStyle = colors.ink;
-        context.lineWidth = 1.5;
-        context.beginPath();
-        context.arc(0, 0, 12, 0, Math.PI * 2);
-        context.fill();
-        context.stroke();
-        context.fillStyle = colors.ink;
-        context.font = "700 11px ui-sans-serif, system-ui, sans-serif";
-        context.textAlign = "center";
-        context.textBaseline = "middle";
-        context.fillText("A", 0, 1);
-        context.restore();
-      }
-
-      function drawDangerMark(room) {
-        context.save();
-        context.strokeStyle = colors.accent;
-        context.lineWidth = 2;
-        const y = room.y + room.h - 23;
-        for (let x = room.x + 25; x < room.x + room.w - 20; x += 18) {
-          context.beginPath();
-          context.arc(x, y + Math.sin(x) * 2, 4, 0, Math.PI * 2);
-          context.stroke();
-        }
-        context.restore();
-      }
-
-      function drawDropMark(room) {
-        context.save();
-        context.strokeStyle = colors.shortcut;
-        context.lineWidth = 2;
-        for (let i = 0; i < 6; i += 1) {
-          context.beginPath();
-          context.moveTo(room.x + 42 + i * 28, room.y + 76);
-          context.lineTo(room.x + 42 + i * 28, room.y + 112);
-          context.stroke();
-          drawArrowHead(
-            { x: room.x + 42 + i * 28, y: room.y + 96 },
-            { x: room.x + 42 + i * 28, y: room.y + 118 },
-            colors.shortcut,
-            2,
-          );
-        }
-        context.restore();
-      }
-
-      function drawHomeMark(room) {
-        context.save();
-        context.fillStyle = "rgba(156, 63, 51, 0.15)";
-        context.beginPath();
-        context.arc(room.x + room.w - 42, room.y + room.h - 35, 20, 0, Math.PI * 2);
-        context.fill();
-        context.fillStyle = colors.accent;
-        context.font = "700 25px Georgia, serif";
-        context.textAlign = "center";
-        context.fillText("*", room.x + room.w - 42, room.y + room.h - 25);
-        context.restore();
-      }
-
-      function drawFutureHatch(room) {
-        context.save();
-        context.globalAlpha = 0.55;
-        context.strokeStyle = colors.future;
-        context.lineWidth = 2;
-        context.setLineDash([7, 6]);
-        roundedRect(room.x + 7, room.y + 7, room.w - 14, room.h - 14, 10);
-        context.stroke();
-        context.restore();
-      }
-
-      function drawRoutes() {
-        if (toggles.firstWalk.checked) {
-          drawConnection(
-            [edge(rooms.outskirts, "right"), { x: 386, y: 808 }, { x: 430, y: 716 }, edge(rooms.cicka, "left")],
-            { label: "stairs + climb", labelOffset: { x: 8, y: -24 } },
-          );
-          drawConnection(
-            [edge(rooms.cicka, "top"), { x: 548, y: 620 }, edge(rooms.work, "bottom")],
-            { label: "paper steps", labelOffset: { x: -62, y: 0 } },
-          );
-          drawConnection(
-            [edge(rooms.work, "right"), { x: 675, y: 546 }, edge(rooms.stampede, "left")],
-            { label: "wide jump", labelOffset: { x: 0, y: -24 } },
-          );
-          drawConnection(
-            [edge(rooms.stampede, "top"), { x: 842, y: 466 }, edge(rooms.switchback, "bottom")],
-            { label: "climb out", labelOffset: { x: 58, y: -6 } },
-          );
-          drawConnection(
-            [edge(rooms.switchback, "left"), { x: 656, y: 388 }, { x: 666, y: 320 }, edge(rooms.telegraph, "right")],
-            { label: "back left", labelOffset: { x: 0, y: -34 } },
-          );
-          drawConnection(
-            [edge(rooms.telegraph, "right"), { x: 704, y: 318 }, edge(rooms.guide, "left")],
-            { label: "cord climb", labelOffset: { x: 0, y: -22 } },
-          );
-          drawConnection(
-            [edge(rooms.guide, "top"), { x: 890, y: 176 }, edge(rooms.relay, "right")],
-            { label: "final shelf", labelOffset: { x: 22, y: -18 } },
-          );
-          drawConnection(
-            [edge(rooms.relay, "right"), { x: 900, y: 132 }, edge(rooms.domino, "left")],
-            { label: "lift promise", labelOffset: { x: 0, y: 28 } },
-          );
-        }
-
-        if (toggles.shortcuts.checked) {
-          drawConnection(
-            [
-              { x: rooms.switchback.x + 230, y: rooms.switchback.y + rooms.switchback.h },
-              { x: 960, y: 515 },
-              { x: 840, y: 630 },
-              edge(rooms.cicka, "right"),
-            ],
-            {
-              color: colors.shortcut,
-              width: 4,
-              dashed: true,
-              label: "Stampede clear: fold/drop home",
-              labelOffset: { x: -18, y: 24 },
-            },
-          );
-          drawConnection(
-            [
-              { x: rooms.telegraph.x + 44, y: rooms.telegraph.y + rooms.telegraph.h },
-              { x: 320, y: 486 },
-              { x: 402, y: 680 },
-              edge(rooms.cicka, "left"),
-            ],
-            {
-              color: colors.shortcut,
-              width: 4,
-              dashed: true,
-              label: "Telegraph drop",
-              labelOffset: { x: -20, y: 76 },
-            },
-          );
-        }
-
-        if (toggles.future.checked) {
-          drawConnection(
-            [edge(rooms.domino, "top"), edge(rooms.high, "bottom")],
-            { color: colors.future, dashed: true, label: "future", labelOffset: { x: 58, y: 0 } },
-          );
-          drawConnection(
-            [edge(rooms.cicka, "left"), edge(rooms.underpath, "right")],
-            {
-              color: colors.future,
-              width: 3,
-              dashed: true,
-            },
-          );
-          drawConnection(
-            [edge(rooms.underpath, "left"), { x: 240, y: 740 }, edge(rooms.outskirts, "top")],
-            {
-              color: colors.future,
-              width: 3,
-              dashed: true,
-            },
-          );
-          drawConnection(
-            [edge(rooms.outskirts, "bottom"), edge(rooms.basement, "top")],
-            {
-              color: colors.future,
-              width: 3,
-              dashed: true,
-            },
-          );
-          drawConnection(
-            [
-              { x: rooms.guide.x + rooms.guide.w, y: rooms.guide.y + 56 },
-              { x: 1104, y: 338 },
-              edge(rooms.dropPocket, "top"),
-            ],
-            {
-              color: colors.future,
-              width: 3.5,
-              dashed: true,
-              label: "optional descent",
-              labelOffset: { x: 36, y: 0 },
-            },
-          );
-          drawConnection(
-            [edge(rooms.dropPocket, "bottom"), { x: 1024, y: 615 }, edge(rooms.stampede, "right")],
-            {
-              color: colors.future,
-              width: 3.5,
-              dashed: true,
-              label: "returns near Stampede",
-              labelOffset: { x: -8, y: 16 },
-            },
-          );
-          drawConnection(
-            [
-              { x: rooms.domino.x + 218, y: rooms.domino.y + rooms.domino.h },
-              { x: 1268, y: 342 },
-              { x: 1154, y: 654 },
-              edge(rooms.cicka, "right"),
-            ],
-            {
-              color: colors.shortcut,
-              width: 4,
-              dashed: true,
-              label: "lift home",
-              labelOffset: { x: -58, y: -18 },
-            },
-          );
-        }
-      }
-
-      function drawRoomLayer() {
-        [
-          "basement",
-          "underpath",
-          "outskirts",
-          "cicka",
-          "work",
-          "stampede",
-          "dropPocket",
-          "switchback",
-          "telegraph",
-          "guide",
-          "relay",
-          "domino",
-          "high",
-        ].forEach((key) => {
-          const room = rooms[key];
-          if (room.future && !toggles.future.checked) return;
-          drawRoom(key, room);
-        });
-      }
-
-      function drawLegend() {
-        const x = 44;
-        const y = 150;
-        const rows = [
-          { color: colors.route, text: "first walk: learn geography once", dashed: false },
-          { color: colors.shortcut, text: "earned shortcut: fast Cicka return", dashed: true },
-          { color: colors.future, text: "future secret / ability-gated route", dashed: true },
-          { color: colors.gold, text: "artifact slot: Danilo memory item", dashed: false },
-        ];
-
-        context.save();
-        context.fillStyle = "rgba(247, 240, 223, 0.82)";
-        context.strokeStyle = colors.ink;
-        context.lineWidth = 2;
-        roundedRect(x, y, 374, 162, 12);
-        context.fill();
-        context.stroke();
-
-        context.fillStyle = colors.ink;
-        context.font = "700 17px ui-sans-serif, system-ui, sans-serif";
-        context.fillText("Traversal read", x + 22, y + 27);
-
-        rows.forEach((row, index) => {
-          const rowY = y + 55 + index * 26;
-          context.strokeStyle = row.color;
-          context.lineWidth = 4;
-          context.lineCap = "round";
-          if (row.dashed) context.setLineDash([10, 8]);
-          else context.setLineDash([]);
-          context.beginPath();
-          context.moveTo(x + 24, rowY);
-          context.lineTo(x + 74, rowY);
-          context.stroke();
-          context.setLineDash([]);
-          context.fillStyle = colors.muted;
-          context.font = "14px ui-sans-serif, system-ui, sans-serif";
-          context.fillText(row.text, x + 90, rowY - 8);
-        });
-
-        context.restore();
-      }
-
-      function drawCameraNotes() {
-        const notes = [
-          { text: "Cicka visible from above", x: 900, y: 330 },
-          { text: "non-linear feel comes from loops,\nnot random branching", x: 1120, y: 690 },
-          { text: "start is reachable again\nthrough underpath/lifts", x: 245, y: 624 },
-        ];
-
-        context.save();
-        context.fillStyle = colors.muted;
-        context.strokeStyle = "rgba(95, 90, 81, 0.4)";
-        context.lineWidth = 1.4;
-        context.font = "italic 15px Georgia, serif";
-        notes.forEach((note) => {
-          const lines = note.text.split("\n");
-          lines.forEach((line, index) => {
-            context.fillText(line, note.x, note.y + index * 19);
+        function drawRoomLayer() {
+          [
+            "basement",
+            "underpath",
+            "outskirts",
+            "cicka",
+            "work",
+            "stampede",
+            "dropPocket",
+            "switchback",
+            "telegraph",
+            "guide",
+            "relay",
+            "domino",
+            "high",
+          ].forEach((key) => {
+            const room = rooms[key];
+            if (room.future && !isLayerEnabled("future")) return;
+            drawRoom(key, room);
           });
-        });
-        context.restore();
-      }
+        }
 
-      function draw() {
-        drawBackground();
-        drawRoutes();
-        drawRoomLayer();
-        drawLegend();
-      }
+        function drawLegend() {
+          const x = 44;
+          const y = 150;
+          const rows = [
+            { color: colors.route, text: "first walk: learn geography once", dashed: false },
+            { color: colors.shortcut, text: "earned shortcut: fast Cicka return", dashed: true },
+            { color: colors.future, text: "future secret / ability-gated route", dashed: true },
+            { color: colors.gold, text: "artifact slot: Danilo memory item", dashed: false },
+          ];
 
-      Object.values(toggles).forEach((toggle) => toggle.addEventListener("change", draw));
+          context.save();
+          context.fillStyle = "rgba(247, 240, 223, 0.82)";
+          context.strokeStyle = colors.ink;
+          context.lineWidth = 2;
+          roundedRect(x, y, 374, 162, 12);
+          context.fill();
+          context.stroke();
 
-      draw();
+          context.fillStyle = colors.ink;
+          context.font = "700 17px ui-sans-serif, system-ui, sans-serif";
+          context.fillText("Traversal read", x + 22, y + 27);
+
+          rows.forEach((row, index) => {
+            const rowY = y + 55 + index * 26;
+            context.strokeStyle = row.color;
+            context.lineWidth = 4;
+            context.lineCap = "round";
+            if (row.dashed) context.setLineDash([10, 8]);
+            else context.setLineDash([]);
+            context.beginPath();
+            context.moveTo(x + 24, rowY);
+            context.lineTo(x + 74, rowY);
+            context.stroke();
+            context.setLineDash([]);
+            context.fillStyle = colors.muted;
+            context.font = "14px ui-sans-serif, system-ui, sans-serif";
+            context.fillText(row.text, x + 90, rowY - 8);
+          });
+
+          context.restore();
+        }
+
+        function drawCameraNotes() {
+          const notes = [
+            { text: "Cicka visible from above", x: 900, y: 330 },
+            { text: "non-linear feel comes from loops,\nnot random branching", x: 1120, y: 690 },
+            { text: "start is reachable again\nthrough underpath/lifts", x: 245, y: 624 },
+          ];
+
+          context.save();
+          context.fillStyle = colors.muted;
+          context.strokeStyle = "rgba(95, 90, 81, 0.4)";
+          context.lineWidth = 1.4;
+          context.font = "italic 15px Georgia, serif";
+          notes.forEach((note) => {
+            const lines = note.text.split("\n");
+            lines.forEach((line, index) => {
+              context.fillText(line, note.x, note.y + index * 19);
+            });
+          });
+          context.restore();
+        }
+
+        function draw() {
+          drawBackground();
+          drawRoutes();
+          drawRoomLayer();
+          drawLegend();
+        }
+
+        Object.values(toggles).forEach((toggle) => toggle?.addEventListener("change", draw));
+
+        draw();
+      })();
     </script>
   </body>
 </html>

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -230,7 +230,7 @@ export class RidgeScene extends Phaser.Scene {
   }
 
   private createPlayer(platforms: readonly Phaser.GameObjects.Zone[]): void {
-    this.playerRuntime = createSideViewPlayerRuntime({
+    const playerRuntime = createSideViewPlayerRuntime({
       scene: this,
       start: RIDGE_PLAYER_START,
       resumePosition: this.resumePosition,
@@ -271,9 +271,11 @@ export class RidgeScene extends Phaser.Scene {
         }
       }
     });
-    this.player = this.playerRuntime.player;
+    this.playerRuntime = playerRuntime;
+    const player = playerRuntime.player;
+    this.player = player;
     platforms.forEach((platform) => {
-      this.physics.add.collider(this.player, platform);
+      this.physics.add.collider(player, platform);
     });
   }
 

--- a/src/game/scenes/ridge/worldLayout.ts
+++ b/src/game/scenes/ridge/worldLayout.ts
@@ -58,13 +58,18 @@ export interface RidgeShortcut {
   label: string;
 }
 
+const RIDGE_STAMPEDE_SHORTCUT_START_X = 520;
+const RIDGE_STAMPEDE_SHORTCUT_END_X = 282;
+const RIDGE_STAMPEDE_SHORTCUT_FORGIVENESS_WIDTH = 42;
+
 export const RIDGE_STAMPEDE_SHORTCUT = {
   id: 'stampede-paper-fold',
   sourceStampId: STAMPEDE_SKETCH_RIDGE_STAMP_ID,
-  startX: 520,
-  endX: 282,
+  startX: RIDGE_STAMPEDE_SHORTCUT_START_X,
+  endX: RIDGE_STAMPEDE_SHORTCUT_END_X,
   y: RIDGE_FLOOR_Y - 134,
-  width: 280,
+  width: Math.abs(RIDGE_STAMPEDE_SHORTCUT_START_X - RIDGE_STAMPEDE_SHORTCUT_END_X)
+    + RIDGE_STAMPEDE_SHORTCUT_FORGIVENESS_WIDTH,
   height: 18,
   label: 'Stampede paper fold'
 } as const satisfies RidgeShortcut;


### PR DESCRIPTION
## Summary
- Fix Ridge collider registration to pass the non-optional runtime player to Phaser
- Harden the Ridge map inventory canvas against missing DOM elements
- Derive the Stampede shortcut width from endpoints plus a named forgiveness margin

## Root Cause
PR #57 left Ridge collider setup passing optional scene state into physics.add.collider. TypeScript rejected that during CI because the value could be undefined.

## Validation
- npm run build
- npm run lint
- npm test -- src/game/scenes/ridge/worldLayout.test.ts
- npm run docs:check