### PR TITLE
Refine Ridge blockout sourcing and research docs

### DIFF
--- a/.agents/skills/level-design-reviewer/SKILL.md
+++ b/.agents/skills/level-design-reviewer/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: level-design-reviewer
+description: Reviews handcrafted indie 2D levels for pacing, readability, mechanic onboarding, spatial guidance, exploration rewards, and emotional environmental storytelling. Use only when the user explicitly invokes level-design-reviewer, level-design review, the Level Designer, or directly asks for critique of a level brief, room screenshot, whitebox/blockout, progression plan, mini-game sequence, interaction map, or player flow.
+---
+
+# Level Design Reviewer
+
+Advisory-only reviewer for handcrafted indie levels and Sketchbook Ridge spaces. Protect the author's identity and improve the player's understanding; do not silently redesign the work.
+
+## Load First
+
+- Read the artifact being reviewed: brief, screenshot, blockout, map, sequence, interaction list, telemetry notes, or player-flow description.
+- For Sketchbook Ridge work, read `docs/design/style-guide.md` and the relevant `docs/game-design/` file before critique.
+- Use these research files as background when the review needs deeper theory:
+  - `docs/research/Level Design Resources for Indie 2D Games.md`
+  - `docs/research/level-design-subagent-deep-research-report.md`
+- If the artifact lacks genre, intended player, critical verb, or success goal, infer cautiously and label the assumption. Ask only when the missing detail would change the recommendation.
+
+## Review Workflow
+
+1. Name the artifact, intended player experience, and review lenses used.
+2. Separate observed facts from inferences about player perception.
+3. Identify whether ambiguity is intentional mystery or accidental confusion.
+4. List findings by severity, grounded in concrete locations, beats, or objects.
+5. Recommend the smallest useful iteration before proposing larger alternatives.
+6. End with 2-4 playtest questions or checks that would validate the critique.
+
+## Rule Lenses
+
+- `F1 Intent Clarity`: Opening spaces should quickly communicate whether the space is exploratory, narrative, mechanical, dangerous, or transitional.
+- `F2 Tension and Release`: Alternate high-focus interaction with quiet recovery; avoid constant intensity and emotional flatness.
+- `F3 Gameplay Readability`: Gameplay-critical objects, hazards, routes, and prompts must remain readable above notebook decoration or atmosphere.
+- `F4 Mechanic Escalation`: Introduce mechanics safely, then combine them with known skills, risk, and pressure.
+- `F5 Rewarded Curiosity`: Optional paths should reward observation, experimentation, mastery, or emotional discovery.
+- `F6 Spatial Guidance`: Guide with composition, contrast, landmarks, geometry, motion, framing, and readable affordances before adding text instructions.
+- `F7 Cognitive Load and Accessibility`: Avoid excessive simultaneous focal points, color-only or sound-only critical cues, precision overload, and competing interaction prompts.
+- `F8 Emotional Environment`: Spaces should feel lived-in, specific, and emotionally traceable rather than sterile, symmetric, or generic.
+
+## Specialist Modes
+
+Use only the modes relevant to the artifact:
+
+- `world_structure_architect`: macro progression, area sequencing, gates, shortcuts, repetition, transitions, and emotional rhythm.
+- `spatial_guidance_auditor`: screenshots or layouts for objectives, focal points, landmarks, affordances, clutter, and dead visual zones.
+- `mechanic_onboarding_reviewer`: first exposure, safe practice, difficulty spikes, mechanic layering, and unfair combinations.
+- `notebook_storytelling_reviewer`: lived-in authenticity, narrative objects, asymmetry, emotional traces, and style-consistent environmental details.
+- `flow_and_rest_analyzer`: fatigue risk, quiet rooms, density, decompression, and interaction rhythm across a sequence.
+- `metroidvania_locksmith`: locks, keys, foreshadowing loops, backtracking burden, hub memory, shortcuts, and disconnected areas.
+
+## Output Shape
+
+Default to this compact structure:
+
+```md
+**Verdict**
+[1-3 sentences on the strongest design risk and strongest existing quality.]
+
+**Findings**
+- `[severity] [rule/lens] issue`
+  Why it matters: [psychological or flow reason]
+  Player impact: [what the player may do or feel]
+  Recommendation: [smallest practical change]
+  Optional alternative: [only when useful]
+
+**Validation**
+- [playtest question, telemetry check, or screenshot/blockout comparison]
+```
+
+Severity is `low`, `medium`, `high`, or `critical`. Use `critical` only when progression, comprehension, accessibility, or core fantasy is likely broken.
+
+## Guardrails
+
+- Do not redesign an entire level unless Danilo explicitly asks.
+- Prefer iterative refinement over replacement.
+- Preserve the Digital Sketchbook identity: hand-drawn clarity, readable ink silhouettes, paper-like spaces, and emotionally specific environmental traces.
+- Avoid generic AAA homogenization and generic procedural-feeling layouts.
+- Do not turn every critique into more tutorial text; prefer interactive, compositional, and environmental fixes.
+- Keep recommendations indie-scale: one clear beat, prop, affordance, checkpoint, shortcut, or composition change is often enough.
+
+## Example Prompts
+
+- "Use level-design-reviewer on this notebook-style room screenshot."
+- "Review this mini-game sequence for pacing fatigue and repetition."
+- "Audit this blockout for spatial guidance and landmark clarity."
+- "Check whether this mechanic onboarding is fair and readable."
+- "Does this space feel emotionally authentic or artificially staged?"

--- a/.agents/skills/producer/SKILL.md
+++ b/.agents/skills/producer/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: mira-producer
-description: Coordinates Sketchbook Ridge Summit work as Mira, the producer and agent coordinator. Use when Danilo says "Hey Mira", asks for the coordinator/producer, wants next steps, delegation, issue planning, milestone status, hiring/firing team members, or updates to Ridge team roles/skills/rules.
+name: producer
+description: Coordinates Sketchbook Ridge Summit work as the producer and agent coordinator. Use when Danilo asks for the Producer, coordinator, next steps, delegation, issue planning, milestone status, hiring/firing team members, or updates to Ridge team roles/skills/rules.
 ---
 
-# Mira Producer
+# Producer
 
-You are **Mira, Producer / Agent Coordinator** for Sketchbook Ridge Summit.
+You are the **Producer / Agent Coordinator** for Sketchbook Ridge Summit.
 
 ## Load First
 
@@ -52,14 +52,14 @@ When planning agent work:
 1. Identify the milestone and blocking shared seams.
 2. Pick one to three issues or tasks.
 3. Assign each task to the smallest fitting owner:
-   - Zoran: architecture/shared seams.
-   - Aleksa: level design/pacing.
-   - Iva: emotional tone/story.
-   - Vuk: systems/mobile feasibility.
-   - Milena: NPCs/Cicka.
-   - Rade: silhouettes/landmarks.
-   - Aleksandra: overlays/readability.
-   - Django: music/SFX.
+   - Architect: architecture/shared seams.
+   - Level Designer: route shape, pacing, and landmarks.
+   - Story / Tone Designer: emotional tone and story feel.
+   - Systems / Production Designer: systems, mobile feasibility, and build order.
+   - Character Designer: NPCs and Cicka.
+   - Visual Direction Artist: silhouettes, landmarks, and ink-memory vocabulary.
+   - Overlay Readability Designer: overlays, manual pages, and mobile readability.
+   - Audio Designer: music and SFX.
 4. Name files or folders each owner should avoid.
 5. Define acceptance criteria and verification.
 6. Say whether the task is AFK or HITL.
@@ -96,8 +96,3 @@ When Danilo asks to create issues:
 3. Publish in dependency order.
 4. Apply the normal triage label from `docs/agents/triage-labels.md`.
 5. Record blockers using real issue numbers once created.
-
-## Status Updates
-
-When work is active, report what changed, what is blocked, what can run in
-parallel, what Danilo should review, and what doc should update next.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,9 @@ Single-context repo: read root `CONTEXT.md` and `docs/adr/` when present. See [`
 
 ### Sketchbook Ridge team roles
 
-When Danilo invokes named helpers such as "Hey Mira", use [`docs/agents/sketchbook-ridge-team.md`](docs/agents/sketchbook-ridge-team.md) for the role contract and activation rules.
+When Danilo invokes helper roles such as "Producer", "Level Designer", or "Audio Designer", use [`docs/agents/sketchbook-ridge-team.md`](docs/agents/sketchbook-ridge-team.md) for the role contract and activation rules.
 
-When Danilo invokes Mira specifically, use [`.agents/skills/mira-producer/SKILL.md`](.agents/skills/mira-producer/SKILL.md) for the repeatable producer workflow.
+When Danilo invokes the Producer specifically, use [`.agents/skills/producer/SKILL.md`](.agents/skills/producer/SKILL.md) for the repeatable producer workflow.
 
 ### Sprite asset pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,4 +10,4 @@ For named Sketchbook Ridge helpers such as "Hey Mira", read:
 
 For Mira's repeatable producer workflow, read:
 
-- [`.agents/skills/mira-producer/SKILL.md`](.agents/skills/mira-producer/SKILL.md)
+- [`.agents/skills/producer/SKILL.md`](.agents/skills/producer/SKILL.md)

--- a/docs/agents/sketchbook-ridge-team.md
+++ b/docs/agents/sketchbook-ridge-team.md
@@ -3,12 +3,12 @@
 This document defines lightweight role cards for the Sketchbook Ridge Summit
 planning and implementation team.
 
-Use these roles when Danilo invokes a team member by name, for example:
+Use these roles when Danilo invokes a helper by responsibility, for example:
 
-- "Hey Mira"
-- "Ask Zoran"
-- "What does Milena think?"
-- "Bring in Django"
+- "Ask the Producer"
+- "Ask the Architect"
+- "What does the Character Designer think?"
+- "Bring in the Audio Designer"
 
 These are not separate code owners in git. They are conversational operating
 modes that help agents load the right context, protect the right constraints,
@@ -32,25 +32,25 @@ Role-specific docs:
 
 ## Activation Rule
 
-When Danilo says **"Hey Mira"**, **"Mira"**, or asks for the coordinator,
-respond as **Mira, Producer / Agent Coordinator**.
+When Danilo asks for the **Producer** or coordinator, respond as **Producer /
+Agent Coordinator**.
 
-When Danilo names another team member, respond in that role if the request is
-about that role's responsibility. If the request needs coordination across
-roles, Mira should answer and explicitly bring in the named specialist.
+When Danilo names another specialist role, respond in that role if the request
+is about that role's responsibility. If the request needs coordination across
+roles, the Producer should answer and explicitly bring in the named specialist.
 
-If an agent is unsure whether a named role applies, default to Mira and state
+If an agent is unsure whether a named role applies, default to Producer and state
 which specialist view is being used.
 
-## Mira: Producer / Agent Coordinator
+## Producer / Agent Coordinator
 
 Purpose: keep the work moving without losing the vision.
 
-Mira also has a repeatable workflow skill:
+The Producer also has a repeatable workflow skill:
 
-- [`.agents/skills/mira-producer/SKILL.md`](../../.agents/skills/mira-producer/SKILL.md)
+- [`.agents/skills/producer/SKILL.md`](../../.agents/skills/producer/SKILL.md)
 
-Mira owns:
+The Producer owns:
 
 - current milestone status
 - next issue selection
@@ -60,11 +60,11 @@ Mira owns:
 - making sure shipped behavior updates `player-manual.md`
 - deciding whether to bring in more specialists
 
-Mira must protect:
+The Producer must protect:
 
 - `sketchbook-ridge-summit.md` as the product goal
 - `sketchbook-ridge-milestone-plan.md` as the work map
-- Zoran's rule: parallelize scene internals, serialize shared seams
+- the Architect's rule: parallelize scene internals, serialize shared seams
 - Danilo's time and taste
 
 Default response shape:
@@ -75,18 +75,18 @@ Default response shape:
 4. Shared-file conflict risks
 5. Decisions needed from Danilo
 
-Mira should not:
+The Producer should not:
 
 - invent a large new roadmap without checking the milestone plan
 - spawn or suggest many agents before shared seams are stable
 - treat archived competition docs as active design source of truth
 - ask Danilo to decide implementation details that agents can safely infer
 
-## Zoran: Architect
+## Architect
 
 Purpose: prevent merge-conflict mountains and architecture drift.
 
-Zoran owns:
+The Architect owns:
 
 - shared seam sequencing
 - branch strategy
@@ -94,7 +94,7 @@ Zoran owns:
 - dependency order
 - deciding what cannot be parallelized
 
-Zoran must protect:
+The Architect must protect:
 
 - `src/game/bridge/store.ts`
 - `src/game/scenes/sceneIds.ts`
@@ -104,15 +104,19 @@ Zoran must protect:
 - `src/game/sceneLifecycle/contexts/createSceneContexts.ts`
 - `src/game/sharedSceneRuntime/**`
 
-Default question for Zoran:
+Default question for the Architect:
 
 > Can this be parallelized safely, or does it touch shared seams?
 
-## Aleksa: Lead Level Designer
+## Level Designer
 
 Purpose: make the Ridge fun as a place.
 
-Aleksa owns:
+The Level Designer also has a repeatable workflow skill:
+
+- [`.agents/skills/level-design-reviewer/SKILL.md`](../../.agents/skills/level-design-reviewer/SKILL.md)
+
+The Level Designer owns:
 
 - route shape
 - pacing
@@ -121,18 +125,18 @@ Aleksa owns:
 - first-minute experience
 - return-to-Ridge feel
 
-Aleksa must protect:
+The Level Designer must protect:
 
 - Relay Spire visible early
 - compact one-ridge scope
 - no precision platforming on the main path
 - rewards that make backtracking faster or more interesting
 
-## Iva: Emotional / Story Feel
+## Story / Tone Designer
 
 Purpose: keep the game warm, personal, and weird in the right way.
 
-Iva owns:
+The Story / Tone Designer owns:
 
 - emotional arc
 - NPC tone
@@ -140,18 +144,18 @@ Iva owns:
 - understated dialogue
 - "ship something alive" ending feel
 
-Iva must protect:
+The Story / Tone Designer must protect:
 
 - Danilo as primary audience
 - sincerity under the joke
 - no generic portfolio sales pitch
 - small moments over lore dumps
 
-## Vuk: Systems / Production Designer
+## Systems / Production Designer
 
 Purpose: keep the fun loops feasible.
 
-Vuk owns:
+The Systems / Production Designer owns:
 
 - mini-game scope
 - mobile feasibility
@@ -159,18 +163,18 @@ Vuk owns:
 - reward shape
 - first-slice definitions
 
-Vuk must protect:
+The Systems / Production Designer must protect:
 
 - one verb per mini-game
 - Potassium owns ricochet
 - no premature generic mini-game framework
 - bridge stores durable rewards, not session internals
 
-## Milena: Character Designer
+## Character Designer
 
 Purpose: make the Ridge inhabited without turning it into an RPG.
 
-Milena owns:
+The Character Designer owns:
 
 - NPC silhouettes
 - Cicka presence
@@ -178,37 +182,37 @@ Milena owns:
 - readable character function
 - tiny cast discipline
 
-Milena must protect:
+The Character Designer must protect:
 
 - every NPC readable by silhouette first
 - Cicka feels like a real resident, not a pasted-on mascot
 - no NPC schedules until static characters feel alive
 - no dialogue trees in v1
 
-## Rade: Character / Environment Artist
+## Visual Direction Artist
 
 Purpose: give implementation enough visual direction without demanding final
 art too early.
 
-Rade owns:
+The Visual Direction Artist owns:
 
 - NPC silhouette sheet
 - Cicka mini kit spec
 - landmark thumbnail board
 - sticker / ink-memory vocabulary
 
-Rade must protect:
+The Visual Direction Artist must protect:
 
 - rough but readable ink silhouettes
 - no full NPC animation sets before the loop works
 - manga composition without manga production cost
 - modular sticker overlays instead of bespoke redraws
 
-## Aleksandra: Overlay / Visual Readability Artist
+## Overlay Readability Designer
 
 Purpose: make UI readable, mobile-friendly, and sketchbook-native.
 
-Aleksandra owns:
+The Overlay Readability Designer owns:
 
 - Trail Card composition
 - Manual Page composition
@@ -216,7 +220,7 @@ Aleksandra owns:
 - monochrome reward language
 - paper-cut component rules
 
-Aleksandra must protect:
+The Overlay Readability Designer must protect:
 
 - mobile-first overlays
 - no nested cards
@@ -224,11 +228,11 @@ Aleksandra must protect:
 - handwriting for flavor, not dense reading
 - black/white readability without color dependence
 
-## Django: Music / Sound Designer
+## Audio Designer
 
 Purpose: make the Ridge emotionally sticky and mini-games audibly legible.
 
-Django owns:
+The Audio Designer owns:
 
 - Ridge audio palette
 - Cicka SFX language
@@ -236,7 +240,7 @@ Django owns:
 - Stampede Sketch prototype audio
 - Telegraph Terrace timing cue research
 
-Django must protect:
+The Audio Designer must protect:
 
 - quiet handmade overworld tone
 - no full dynamic score engine in v1
@@ -246,7 +250,7 @@ Django must protect:
 
 ## Hiring More Team Members
 
-Mira may propose hiring another specialist only when there is a real gap, such
+The Producer may propose hiring another specialist only when there is a real gap, such
 as:
 
 - a testing lead for mobile playtest passes

--- a/docs/game-design/README.md
+++ b/docs/game-design/README.md
@@ -18,9 +18,9 @@ This directory separates shipped player-facing behavior from future design conce
 - **[Ridge Blockout Source](./ridge.blockout.txt)**: First full text skeleton for the seamless Ridge world, written in the Ridge Map Language.
 - **[Ridge Blockout Fun Review](./ridge-blockout-fun-review.md)**: Design-quality review of the first blockout skeleton against 2D map design, Lucky Luna, and Nine Sols research.
 - **[Sketchbook Ridge Long-Term Topology Ideas](./sketchbook-ridge-long-term-topology-ideas.md)**: Exploratory long-term map, shortcut, and secret-direction companion for Ridge after the current milestone is proven.
-- **[Sketchbook Ridge M3 Visual Pack](./sketchbook-ridge-m3-visual-pack.md)**: Rade/Milena visual direction for Cicka, NPCs, landmarks, stickers, and M4 placeholders.
-- **[Sketchbook Ridge M3 Overlay Pack](./sketchbook-ridge-m3-overlay-pack.md)**: Aleksandra's Trail Card, Manual Page, mobile readability, and monochrome reward-state spec.
-- **[Sketchbook Ridge M3 Audio Pack](./sketchbook-ridge-m3-audio-pack.md)**: Django's Ridge, Cicka, Potassium acknowledgement, Stampede, and Telegraph audio direction.
+- **[Sketchbook Ridge M3 Visual Pack](./sketchbook-ridge-m3-visual-pack.md)**: Visual Direction Artist and Character Designer direction for Cicka, NPCs, landmarks, stickers, and M4 placeholders.
+- **[Sketchbook Ridge M3 Overlay Pack](./sketchbook-ridge-m3-overlay-pack.md)**: Overlay Readability Designer's Trail Card, Manual Page, mobile readability, and monochrome reward-state spec.
+- **[Sketchbook Ridge M3 Audio Pack](./sketchbook-ridge-m3-audio-pack.md)**: Audio Designer's Ridge, Cicka, Potassium acknowledgement, Stampede, and Telegraph audio direction.
 - **[AI Game Design Competition Archive](./ai-competition/README.md)**: Closed provenance for the competition that produced the current Ridge Summit direction.
 
 ## Document Status

--- a/docs/game-design/asset-readiness-triage.md
+++ b/docs/game-design/asset-readiness-triage.md
@@ -72,11 +72,11 @@ question."
 
 ## Recommended Specialist Read
 
-- Mira: keep this bounded to readiness, not production art overhaul.
-- Rade: review silhouettes and style fit before each adoption slice.
-- Vuk: check whether each asset supports the current gameplay loop.
-- Zoran: own duplicate cleanup and manifest safety.
-- Milena: review Cicka and NPC assets before Ridge character adoption.
+- Producer: keep this bounded to readiness, not production art overhaul.
+- Visual Direction Artist: review silhouettes and style fit before each adoption slice.
+- Systems / Production Designer: check whether each asset supports the current gameplay loop.
+- Architect: own duplicate cleanup and manifest safety.
+- Character Designer: review Cicka and NPC assets before Ridge character adoption.
 
 Do not bring in the whole team at once. Four specialist reads are enough for
 this phase.

--- a/docs/game-design/sketchbook-ridge-asset-staging-plan.md
+++ b/docs/game-design/sketchbook-ridge-asset-staging-plan.md
@@ -31,9 +31,9 @@ it becomes easy to confuse:
 This document keeps the Summit milestone moving while giving the newer POC
 assets a clear home.
 
-## Mira Summary
+## Producer Summary
 
-Mira's producer read is:
+Producer read:
 
 - the **long-term Ridge topology ideas do not mess up the current plan**
   if they stay planning-only

--- a/docs/game-design/sketchbook-ridge-m3-audio-pack.md
+++ b/docs/game-design/sketchbook-ridge-m3-audio-pack.md
@@ -1,6 +1,6 @@
 # Sketchbook Ridge M3 Audio Direction Pack
 
-Owner mode: Django, Music / Sound Designer.
+Owner mode: Audio Designer.
 
 Purpose: implementation-facing audio research for the Ridge, Cicka, Potassium
 acknowledgements, Stampede Sketch, and Telegraph Terrace. This is a spec pack,

--- a/docs/game-design/sketchbook-ridge-m3-overlay-pack.md
+++ b/docs/game-design/sketchbook-ridge-m3-overlay-pack.md
@@ -1,6 +1,6 @@
 # Sketchbook Ridge M3 Overlay Pack
 
-> Aleksandra's overlay and manual-page visual readability pack for M3.
+> Overlay Readability Designer's overlay and manual-page visual readability pack for M3.
 > This is a practical spec for Trail Cards, Manual Pages, and monochrome
 > reward/locked language. It should guide implementation without creating final
 > art pressure.

--- a/docs/game-design/sketchbook-ridge-m3-visual-pack.md
+++ b/docs/game-design/sketchbook-ridge-m3-visual-pack.md
@@ -1,8 +1,8 @@
 # Sketchbook Ridge M3 Visual Pack
 
-Rade visual direction with Milena character input. This pack is implementation
-guidance, not a final art bible. M4 should be able to ship rough placeholders
-from these specs without waiting for polished drawings.
+Visual Direction Artist guidance with Character Designer input. This pack is
+implementation guidance, not a final art bible. M4 should be able to ship rough
+placeholders from these specs without waiting for polished drawings.
 
 Active sources: `sketchbook-ridge-summit.md`, `sketchbook-ridge-milestone-plan.md`,
 `docs/design/style-guide.md`, current runtime docs, scoped agent rules, and

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -71,14 +71,14 @@ Anything beyond that is future scope unless a slice explicitly pulls it in.
 Role contracts and activation phrases live in
 [`docs/agents/sketchbook-ridge-team.md`](../agents/sketchbook-ridge-team.md).
 
-- **Aleksa**: level design and milestone shape.
-- **Iva**: emotional/story tone.
-- **Vuk**: systems and production constraints.
-- **Milena**: NPC/character design.
-- **Zoran**: architecture and branch conflict control.
-- **Rade**: character and environment art research.
-- **Aleksandra**: overlay, manual, and mobile visual readability.
-- **Django**: music and sound design research.
+- **Level Designer**: level design and milestone shape.
+- **Story / Tone Designer**: emotional/story tone.
+- **Systems / Production Designer**: systems and production constraints.
+- **Character Designer**: NPC/character design.
+- **Architect**: architecture and branch conflict control.
+- **Visual Direction Artist**: character and environment art research.
+- **Overlay Readability Designer**: overlay, manual, and mobile visual readability.
+- **Audio Designer**: music and sound design research.
 
 ## Reference Stack
 
@@ -97,7 +97,7 @@ Use [`potassium-slip.md`](./potassium-slip.md) for Potassium-specific behavior.
 
 ## Conflict Strategy
 
-Zoran's rule:
+Architect's rule:
 
 > Parallelize scene internals. Serialize shared seams.
 
@@ -205,7 +205,7 @@ Registry wiring should be serialized through the integration branch.
 
 Goal: unblock implementation without creating final-asset pressure.
 
-Owners: Rade, Aleksandra, Django.
+Owners: Visual Direction Artist, Overlay Readability Designer, Audio Designer.
 
 Outputs:
 

--- a/docs/game-design/sketchbook-ridge-summit.md
+++ b/docs/game-design/sketchbook-ridge-summit.md
@@ -6,10 +6,10 @@
 
 ## Team Frame
 
-- **Aleksa, lead level designer**: owns the playable world, pacing, and scope.
-- **Iva, emotional/world design**: protects warmth, manga sketchbook tone, and the feeling that the world remembers Danilo.
-- **Vuk, systems/production design**: protects input simplicity, Phaser/React boundaries, and build order.
-- **Milena, character designer**: protects NPC silhouettes, interaction charm, and the feeling that the ridge is inhabited.
+- **Level Designer**: owns the playable world, pacing, and scope.
+- **Story / Tone Designer**: protects warmth, manga sketchbook tone, and the feeling that the world remembers Danilo.
+- **Systems / Production Designer**: protects input simplicity, Phaser/React boundaries, and build order.
+- **Character Designer**: protects NPC silhouettes, interaction charm, and the feeling that the ridge is inhabited.
 
 The competition winner remains **Sketchbook Ridge**. The production direction is:
 
@@ -462,7 +462,7 @@ This should be small and slightly spicy. It should never block the main ending.
 
 The tone is **warm weirdos with tiny stakes delivered like destiny**.
 
-Milena's character-design rule: every NPC should be readable by silhouette first, voice second, and function third. If an NPC exists only to explain a menu, it should be a sign instead.
+Character Designer rule: every NPC should be readable by silhouette first, voice second, and function third. If an NPC exists only to explain a menu, it should be a sign instead.
 
 Examples:
 
@@ -764,7 +764,7 @@ These are the choices to iterate on next:
 - **Cicka timing**: default to first perch in Slice 1, translator/daydream after Ridge Memory proves return play.
 - **World scale**: default to one ridge before any new area.
 
-## Aleksa Verdict
+## Level Designer Verdict
 
 Build the smallest version that already feels like the real game:
 

--- a/docs/research/Level Design Resources for Indie 2D Games.md
+++ b/docs/research/Level Design Resources for Indie 2D Games.md
@@ -1,0 +1,261 @@
+# **Technical Standards and Spatial Narratives: A Comprehensive Framework for 2D Level Design**
+
+The discipline of level design within the contemporary interactive landscape resides at the critical intersection of spatial architecture, cognitive psychology, and systemic engineering. For the professional designer, particularly those operating within the indie development sphere and focused on 2D environments, the task is not merely the construction of digital geography but the curation of a guided player experience that harmonizes mechanics with narrative intent.1 This report serves as an exhaustive technical compendium and theoretical framework, intended for reference by specialized design agents and developers. It synthesizes decades of industry wisdom, from the foundational rules of early pioneers to the sophisticated pedagogical techniques of modern masterpieces like *Celeste* and *Hollow Knight*.1
+
+## **The Ontology of the Level Designer**
+
+In the formal industrial context, a clear distinction must be maintained between the roles of the level designer and the environment artist. While the latter focuses on the aesthetic fidelity, lighting, and set dressing of a space, the level designer is primarily concerned with shaping player behavior.2 This involves the drafting of layouts, the creation of functional blockouts, and the balancing of mechanical encounters to ensure a coherent flow.2 The level designer operates as an architect of movement, utilizing geometry as a tool to elicit specific psychological responses and to guide the player through the game's systemic "verbs".6
+
+### **The Vocabulary of Interaction**
+
+The conceptual foundation of level design is rooted in a fundamental language of verbs and objects. As established by theorists such as Anna Anthropy and Naomi Clark, verbs represent the primary actions available to the player character—running, jumping, shooting, or dashing—while objects are the environmental elements that interact with or resist those actions.6 The successful level designer does not merely place these elements in a vacuum but organizes them into "scenes" or "beats" that collectively form the narrative arc of the gameplay.7  
+This vocabulary extends to the concept of "context," where the visual and auditory aesthetics of a level provide the necessary framework for interpreting the mechanics.7 Without context, a jump is merely a displacement in coordinate space; with context, it becomes a desperate leap across a volcanic chasm, imbuing the mechanical act with emotional weight.8 Professional design requires a disciplined understanding of how these relationships are established and maintained throughout a project’s lifecycle.6
+
+### **Room Design versus World Design**
+
+The scale of design dictates the methodology employed. In directed or scripted experiences, such as linear platformers, the designer may spend weeks perfecting a single room or screen to ensure that every jump and encounter is precisely tuned to the player’s moveset.2 This is analogous to the work of an architect focusing on the ergonomics of a single building. Conversely, in open-world or massive multiplayer environments, the designer adopts the role of an urban planner, focusing on biomes, neighborhoods, and "wayfinding" systems that allow for systemic, player-driven emergence.2  
+In 2D indie development, this distinction is often blurred as designers navigate the complexities of interconnected maps, such as those found in the Metroidvania subgenre.9 Here, the design must function at both the granular level of individual challenges and the macro level of world progression, ensuring that the acquisition of new mechanics re-contextualizes previously explored spaces.9
+
+| Design Scale | Primary Focus | Analogy | Key Output |
+| :---- | :---- | :---- | :---- |
+| Room/Screen Design | Precision mechanics, scripted events, micro-pacing. | Architect | Perfected "beats".2 |
+| Area/Zone Design | Thematic consistency, enemy variety, sub-goals. | Interior Designer | Narrative vignettes.11 |
+| World/Level Design | Interconnectedness, gating, macro-flow, wayfinding. | Urban Planner | Critical path mapping.2 |
+
+## **Navigational Guidance and Spatial Communication**
+
+One of the most profound challenges in 2D level design is guiding the player through an environment without relying on intrusive UI elements. Professional designers utilize "spatial communication," a set of techniques designed to intuitively nudge the player toward objectives while maintaining the illusion of agency.5
+
+### **Sightlines and Clear Objectives**
+
+The commencement of any design process should involve the placement of a clear, distant objective—a technique often used to combat "blank canvas syndrome".5 By establishing a visual goal, such as a lighthouse or a distant mountain peak, the designer provides the player with a constant sense of direction.5 Even in a 2D side-scroller, the use of "parallaxing"—layering geometry at different depths—helps the player perceive distance and orient themselves within the world.5  
+Effective navigation also relies on the manipulation of sightlines. Blocking a player's view with foreground geometry can motivate movement, as the player is naturally driven to uncover hidden information and "mentally map" the space.5 Once a player reaches a vantage point, they are granted a "privileged perspective," allowing them to survey upcoming challenges from a position of safety before committing to action.5
+
+### **The Use of Contrast and Affordances**
+
+Lighting and sound are primary tools for attracting player attention. High-contrast areas, localized sound sources, or moving objects (such as spinning fans) act as beacons that draw the player toward intended routes.4 This is reinforced by "affordances"—visual shapes that communicate their function.1 For example, an archway intuitively suggests passage, while a series of stepped platforms suggests vertical ascent.5 Professional design requires that these affordances remain consistent; if a red door is interactive in the first level, every red door in the game must share that property unless a clear narrative reason is provided for the change.11
+
+### **Pinch Points and One-Way Valves**
+
+To maintain control over the experience without taking control away from the player, designers utilize "pinch points." These are narrow passages that force the player into a specific position, allowing the designer to frame a "hero shot" or introduce a critical narrative element.5 Complementary to this are "one-way valves"—drops or barriers that prevent the player from backtracking.5 These valves serve several purposes: they prevent the player from getting lost in complex areas, they nudge the player toward the next objective, and in technical terms, they can facilitate the unloading of previous map sections to optimize performance.5
+
+## **Technical Metrics and Physics in 2D Environments**
+
+The "feel" of a 2D game is determined by the precise calibration of its physics and the metrics of its environment. A level designed for a character with a high-speed dash will be fundamentally different from one designed for a slow, momentum-based character.15
+
+### **Movement Models: Snappy versus Weighted**
+
+The industry generally categorizes 2D character movement into "snappy" and "weighted" models. Snappy controls, utilized in titles like *Super Meat Boy* or *Hollow Knight*, feature near-instant acceleration and deceleration, allowing for extreme precision and rapid reaction times.15 Weighted controls, such as those in the *Super Mario* series, rely on momentum and acceleration curves, requiring the player to account for inertia when jumping or stopping.15  
+Designing for these models requires strict adherence to environmental metrics. Designers must establish a "Bible of Obstacles" that defines the exact height and length of a character’s jump.15 For instance, if a character’s maximum jump height is 5 units, a platform placed at 5.5 units becomes an insurmountable barrier.16
+
+| Metric Category | Variable | Technical Impact |
+| :---- | :---- | :---- |
+| Vertical Traversal | Max Jump Height (![][image1]) | Determines platform verticality.16 |
+| Horizontal Traversal | Max Jump Length (![][image2]) | Determines pit width.16 |
+| Acceleration | ![][image3] | Influences "snappiness" of movement.15 |
+| Gravity | ![][image4] | Dictates the "weight" of falling and jumping.1 |
+| Dash Distance | ![][image5] | Defines the spacing of mid-air recharge points.1 |
+
+The physics of a jump can be modeled using standard kinematic equations. The peak height of a jump is calculated as ![][image6], where ![][image7] is the initial vertical velocity and ![][image4] is the gravity constant. Professional 2D design often incorporates "variable jump input," where the height of the jump is determined by the duration of the button press; releasing the button essentially applies a vertical "brake" to the character's velocity.15
+
+### **Checkpoints and Difficulty Scaling**
+
+The placement of checkpoints is a critical metric for managing player frustration and maintaining "flow".15 In high-difficulty titles like *Super Meat Boy*, frequent checkpoints (often one per screen) allow for a high failure rate without significant time loss, keeping the player in a state of constant engagement.15 In contrast, games with more exploration, such as *Hollow Knight* or *Silksong*, utilize more distant checkpoints to increase the tension of exploration and require a higher level of mastery over the character's moveset.15
+
+## **Pedagogical Design: The Invisible Tutorial**
+
+One of the hallmarks of expert level design is the ability to teach the player new mechanics without the use of explicit text or intrusive tutorials.1 This pedagogical approach relies on the player's natural curiosity and the structured sequencing of challenges.
+
+### **The Four-Step Introduction Pattern**
+
+Modern 2D masterpieces often follow a four-step pattern when introducing a new mechanic or hazard 1:
+
+1. **Safety:** The mechanic is introduced in an area where failure has no consequence (e.g., no pits or enemies).1  
+2. **Combination:** The player must combine the new mechanic with a previously learned skill (e.g., jumping while dashing).1  
+3. **Risk:** The mechanic must be used to overcome a genuine hazard, establishing the stakes of the new skill.1  
+4. **Mastery:** The player is required to use the mechanic in a complex, timed sequence to proceed, confirming their proficiency.16
+
+*Celeste* provides a definitive example of this pattern through its use of "green diamonds" (dash crystals).1 The player first encounters a crystal in a safe area, where they intuitively dash into it and realize it recharges their ability.1 The game then places crystals over spikes, forcing the player to plan a route that involves mid-air recharges to reach safety.1 This "self-teaching" method fosters a sense of accomplishment and respects the player's intelligence.1
+
+### **Problem-Solution Ordering**
+
+A fundamental psychological rule in level design is that the player should encounter a problem before finding the solution.5 If a player finds a "red key" before they have ever seen a "red door," the key feels like a meaningless collectible.5 However, if they struggle to open a red door first, the subsequent discovery of the red key provides a satisfying "Aha\!" moment and a clear sense of progress.5 This ordering ensures that every item and ability has immediate utility and narrative value.
+
+## **Structural Theory in Metroidvanias and Megadungeons**
+
+The Metroidvania subgenre represents one of the most complex challenges in level design, requiring a delicate balance between non-linear exploration and controlled progression.10 The core of this design is the relationship between "locks" and "keys," where the keys are often mechanical upgrades rather than literal items.10
+
+### **Subtractive Design and Gating Logic**
+
+The development of a Metroidvania often follows a "subtractive design" philosophy.16 The designer first defines the character's ultimate moveset—everything they will be able to do by the end of the game.16 The world is then constructed with barriers that can only be bypassed by specific abilities.10 Progression is managed by stripping the player of these abilities at the start of the game and then scattering them throughout the world.10
+
+| Gate Type | Mechanical Requirement | Function |
+| :---- | :---- | :---- |
+| Spatial Gate | Double Jump / Wall Jump | Re-contextualizes vertical space.19 |
+| Physical Gate | Bomb / Heavy Strike | Destroys barriers, opening shortcuts.16 |
+| Environmental Gate | Heat Shield / Gas Mask | Allows passage through hazardous biomes.16 |
+| Combat Gate | Specific Weapon Element | Requires mastery of a new combat style.14 |
+
+### **The Foreshadowing Loop and Spiral Map Design**
+
+To keep the player motivated during long periods of exploration, designers utilize "Foreshadowing Loops".19 This involves showing the player a path or a reward they cannot yet reach, creating a "mental bookmark".19 When the player later acquires the necessary upgrade, they are encouraged to backtrack to the foreshadowed area, reinforcing their mastery over the world.9  
+Spiral map design is a technique where the world is arranged in an almost counter-clockwise pattern around a central hub.9 This prevents the world from feeling like a linear corridor and ensures that the player is frequently circling back to known areas, which are then re-evaluated in the context of their new abilities.4
+
+## **Environmental Storytelling and Narrative Traces**
+
+Level design is a powerful narrative tool that allows for the embedding of story directly into the physical space.11 This "indexical storytelling" engages the player as an active participant in uncovering the game's history.13
+
+### **The Theme Park Influence: Don Carson’s Secrets**
+
+Much of modern environmental storytelling in games draws from the theme park industry, specifically the work of Disney "Imagineers" like Don Carson.11 The environment must answer the player's first question—"Where am I?"—within the first 15 seconds.11 This is achieved through "cause-and-effect vignettes"—staged scenes that suggest a previous event.11 A dining table with chairs overturned and a half-eaten meal suggests a sudden, violent interruption, telling a story without a single line of dialogue.11  
+Professional designers also utilize "the familiar" to anchor players in alien environments.11 If the goal is to design a surreal, intestine-like level, periodically placing recognizable objects (like a discarded human shoe or a mechanical lamp) provides the player with a sense of scale and a point of comparison, making the alien elements more impactful.11
+
+### **The Door Problem and Spatial Agency**
+
+Narrative can also be used to lead gameplay through the "Door Problem of Combat Design".22 This involves using environmental cues to draw a player into a room or toward an encounter.23 A partially open door or a flickering light at the end of a corridor piques the player's curiosity, driving them forward.5 This technique ensures that the player is always an "active participant" in the narrative rather than a passive observer.13
+
+## **The id Software Legacy: John Romero’s Rules for Layout**
+
+The foundational principles of 3D level design, as established by John Romero during the development of *Doom* and *Quake*, remain remarkably relevant to 2D environments, particularly regarding layout clarity and technical rigor.4
+
+### **Romero’s Eight Rules of Level Construction**
+
+Romero’s rules focus on maintaining a high level of quality and readability through texture work and spatial contrast.4 For the 2D designer, these can be translated as follows:
+
+1. **Texture and Height Alignment:** Always change the floor height (or ledge position) when changing floor textures.4 This helps the player distinguish between different surfaces and elevations, which is crucial for readability in tile-based 2D games.4  
+2. **Border Textures:** Use border or "support" textures between different wall segments and doorways to create a clean transition.4  
+3. **Strict Alignment:** Be obsessive about texture alignment with the grid.4 In 2D games, misaligned tiles are often the mark of amateur design and can lead to visual noise that distracts from the gameplay.25  
+4. **Contrast:** Use contrast in every element: light and dark areas, cramped and open areas, and high-intensity vs. quiet areas.4 This maintains a "roller-coaster" pace that prevents the player from becoming bored.18  
+5. **Landmarks:** Create easily recognizable landmarks to assist with navigation and prevent the player from getting turned around.4  
+6. **Secret Density:** Include at least four secrets per level to reward thorough exploration.18  
+7. **The Horseshoe Layout:** Design paths that are non-linear, forcing the player to look at every wall of a room, which increases the likelihood of them noticing secrets or environmental story cues.4  
+8. **The Loop:** Ensure that levels flow so that the player revisits areas multiple times, reinforcing their understanding of the spatial layout.4
+
+### **Managing Flow and Revisitability**
+
+The "Loop" is a particularly powerful pattern in 2D design. By guiding the player back to a previously explored area, the designer provides an "illusion of non-linearity" while maintaining a strictly controlled progression path.4 This reinforcement of space allows the player to feel like they are developing a deep understanding of the world, fostering a sense of immersion and expertise.4
+
+## **Professional Workflow: From Blockout to Final Polish**
+
+The production of a level is a highly iterative process that prioritizes gameplay functionality over visual fidelity in its early stages.2
+
+### **The Blockout Phase: Agility and Flexibility**
+
+A "blockout" (or "greybox") is a version of a level built with simple, placeholder geometry.5 The goal is to achieve "maximum information for minimum effort".5 Professional designers use blockouts to quickly test gameplay ideas, pacing, and difficulty before the environment is "handed off" to artists for final set dressing.2  
+During the blockout phase, designers should focus on "temp furniture"—placeholders that help judge the true scale of a space.5 An empty room always feels larger than it will once it is fully decorated with furniture, crates, and debris.5 Placing these items early prevents the need for costly layout changes later in production.5
+
+### **Iteration and "Go Map" Philosophy**
+
+The only way to master the craft is through the constant production and testing of levels.2 This is referred to in the community as the "Go Map" philosophy—an encouragement to stop over-analyzing and start building.2 Professional design involves observing playtests and being willing to "tear down walls" if they don't serve the gameplay.5 A level is never truly finished; it is refined through a continuous cycle of testing and iteration until the intended player experience is achieved.23
+
+| Phase | Goal | Key Tools |
+| :---- | :---- | :---- |
+| Pre-Production | Defining pillars, metrics, and "verbs." | GDD, Prototypes.16 |
+| Blockout/Greybox | Testing flow, pacing, and sightlines. | Simple primitives, grid editors.5 |
+| Iteration/Testing | Observing players, adjusting difficulty. | Playtests, heatmaps.2 |
+| Art Pass | Set dressing, lighting, environmental story. | Final assets, Substance Painter.2 |
+| Final Polish | Bug fixing, performance optimization. | Profilers, automated testing.14 |
+
+## **Documentation and Project Management for Level Design**
+
+In a professional setting, the level designer is responsible for maintaining clear, up-to-date documentation that ensures the entire team is aligned with the project's vision.27
+
+### **The Modern Game Design Document (GDD)**
+
+The GDD serves as the single source of truth for the project.30 For level designers, a modern GDD should be "minimal" and "living"—updated constantly as the game evolves.27 Key sections include 27:
+
+* **Design Pillars:** The 3-5 core principles that guide every design decision (e.g., "Exploration over Combat," "Precise Movement," "Atmospheric Horror").27  
+* **The Core Loop:** A concise summary of the player's moment-to-moment experience (e.g., Explore → Fight → Loot → Upgrade → Repeat).27  
+* **Technical Metrics:** A "Bible of Obstacles" specifying the exact jump heights, run speeds, and collision rules.15  
+* **Level Maps and Flowcharts:** Visual representations of how the levels are interconnected and the order in which mechanics are introduced.16
+
+### **Technical Design and Living Documents**
+
+For complex projects, a Technical Design Document (TDD) may be necessary to explain implementation details, such as how the game handles dynamic map loading or AI pathfinding in 2D environments.14 Some teams utilize specialized tools like Codecks or wiki-style databases to integrate design documentation directly into their project management workflow, ensuring that task execution is always grounded in the design intent.31
+
+## **Curated Resource Compendium for Professional Referencing**
+
+To maintain a competitive edge, designers must engage with a wide range of academic and professional resources. The following collection represents the highest quality sources available for 2D level design.12
+
+### **Essential Literature**
+
+* **"An Architectural Approach to Level Design" by Christopher W. Totten:** Provides a comprehensive breakdown of architectural techniques and spatial design principles applicable to both 2D and 3D environments.35  
+* **"A Game Design Vocabulary" by Anna Anthropy and Naomi Clark:** Establishes the fundamental language of verbs, objects, and scenes.6  
+* **"Level Up\! The Guide to Great Video Game Design" by Scott Rogers:** A practical, visually-driven guide to designing mechanics and levels from a veteran of titles like *Pac-Man World*.34  
+* **"The Art of Game Design: A Book of Lenses" by Jesse Schell:** A "bible" of the industry that provides 100+ mental frameworks for evaluating player experience.34  
+* **"Level Design: Concept, Theory, and Practice" by Rudolf Kremers:** A comprehensive textbook focusing on the theoretical reasons behind design choices, including pacing and immersion.8
+
+### **Digital Databases and Educational Communities**
+
+* **Level-Design.org:** A massive knowledge database and reference collection for level designers, including thousands of tagged screenshots for analysis.12  
+* **GDC Vault:** The primary archive for industry talks, featuring masterclasses on environmental storytelling, pacing, and 2D platformer design.20  
+* **Level Design Lobby (Podcast/Blog):** Hosted by Max Pears, this resource provides interviews with industry professionals and deep dives into specific LD concepts.12  
+* **Steve Lee’s YouTube Channel:** A lead level designer (formerly of Arkane) who provides walkthroughs of professional level design processes, blockout tips, and portfolio advice.12  
+* **Game Maker's Toolkit (GMTK):** Mark Brown’s channel provides exceptional case studies on level design, such as "Why Nathan Drake Doesn't Need a Compass" and "The Best 2D Platformer?".12
+
+## **Synthesis: Actionable Patterns for Design Agents**
+
+The integration of these principles into a cohesive design workflow requires the adoption of specific, actionable patterns. For a design agent operating in the 2D indie space, the following strategic takeaways should be considered mandatory:
+
+1. **Prioritize Movement Fidelity:** Before any levels are built, the character's movement must be "perfect." This involves refining the "buffer windows" (allowing for inputs to be registered slightly before they can be executed) and "coyote time" (allowing a player to jump for a few frames after leaving a platform) to ensure the game feel is forgiving and responsive.1  
+2. **Standardize Environmental Feedback:** Use consistent visual languages for interactables. For example, all destructible walls should share a specific texture or "crumbly" appearance.1 This reduces cognitive load on the player and allows them to focus on the mechanical challenge.1  
+3. **Implement One-Way Valves Strategicially:** Use valves not just for navigation but for technical optimization and to ensure that the player is always moving toward a goal.5  
+4. **Adopt a "Problem-First" Philosophy:** Always present the lock before the key. This ensures that the acquisition of new abilities is meaningful and rewarding.5  
+5. **Focus on "Action Blocks" in Pre-Production:** Develop small, self-contained mechanical challenges (action blocks) and test them in isolation before attempting to string them together into a full level.16  
+6. **Utilize Safety Nets to Maintain Flow:** Avoid instant-death traps unless the game is explicitly a "masocore" title. Instead, use lower platforms or water pits that require the player to backtrack a short distance rather than restarting the entire screen.5  
+7. **Maintain Living Documentation:** Ensure that the GDD is a functional tool that is updated as playtest data reveals flaws in the original design.27
+
+The convergence of these techniques—from Romero’s grid-based rigor to modern pedagogical scaffolding—provides a robust framework for creating engaging, professional-grade 2D levels.1 As the indie development scene continues to push the boundaries of the medium, the successful level designer will be the one who best balances technical excellence with a deep, intuitive understanding of the player's psychological journey through the digital space.1
+
+#### **Works cited**
+
+1. The Award-Winning Level Design in Celeste | by Joseph Diamond ..., accessed May 15, 2026, [https://medium.com/@josephdiamond115/the-award-winning-level-design-in-celeste-c2acb315bf79](https://medium.com/@josephdiamond115/the-award-winning-level-design-in-celeste-c2acb315bf79)  
+2. What is level design | The Level Design Book, accessed May 15, 2026, [https://book.leveldesignbook.com/introduction](https://book.leveldesignbook.com/introduction)  
+3. Can anyone give me an example of a 2D action platformer game with very solid level design ?, i need inspiration \- Reddit, accessed May 15, 2026, [https://www.reddit.com/r/gamedesign/comments/npv6pf/can\_anyone\_give\_me\_an\_example\_of\_a\_2d\_action/](https://www.reddit.com/r/gamedesign/comments/npv6pf/can_anyone_give_me_an_example_of_a_2d_action/)  
+4. John Romero's Level Design Tips \- Helldorado Team, accessed May 15, 2026, [https://www.helldoradoteam.com/2018/12/19/john-romeros-level-design-tips/](https://www.helldoradoteam.com/2018/12/19/john-romeros-level-design-tips/)  
+5. Spatial Communication in Level Design, accessed May 15, 2026, [https://www.youtube.com/watch?v=AKeUZVikPV8\&list=PL7drPFPQSY36C2L9N88cQ9VoEvxicnyI0](https://www.youtube.com/watch?v=AKeUZVikPV8&list=PL7drPFPQSY36C2L9N88cQ9VoEvxicnyI0)  
+6. Game Design Vocabulary, A by Anna Anthropy & Naomi Clark on Apple Books, accessed May 15, 2026, [https://books.apple.com/us/book/game-design-vocabulary-a/id825597940](https://books.apple.com/us/book/game-design-vocabulary-a/id825597940)  
+7. A Game Design Vocabulary \- Pearsoncmg.com, accessed May 15, 2026, [https://ptgmedia.pearsoncmg.com/images/9780321886927/samplepages/0321886925.pdf](https://ptgmedia.pearsoncmg.com/images/9780321886927/samplepages/0321886925.pdf)  
+8. Level Design: Concept, Theory, and Practice \- 1st Edition \- Rudolf Kre \- Routledge, accessed May 15, 2026, [https://www.routledge.com/Level-Design-Concept-Theory-and-Practice/Kremers/p/book/9781568813387](https://www.routledge.com/Level-Design-Concept-Theory-and-Practice/Kremers/p/book/9781568813387)  
+9. What are some tips on making Metroidvania Level Layouts and Gating Mechanism? : r/gamedesign \- Reddit, accessed May 15, 2026, [https://www.reddit.com/r/gamedesign/comments/fs9vbf/metroidvania\_what\_are\_some\_tips\_on\_making/](https://www.reddit.com/r/gamedesign/comments/fs9vbf/metroidvania_what_are_some_tips_on_making/)  
+10. Making Sense of Metroidvania Game Design \- Game Developer, accessed May 15, 2026, [https://www.gamedeveloper.com/design/making-sense-of-metroidvania-game-design](https://www.gamedeveloper.com/design/making-sense-of-metroidvania-game-design)  
+11. Environmental Storytelling: Creating Immersive 3D Worlds Using Lessons Learned from the Theme Park Industry \- Game Developer, accessed May 15, 2026, [https://www.gamedeveloper.com/design/environmental-storytelling-creating-immersive-3d-worlds-using-lessons-learned-from-the-theme-park-industry](https://www.gamedeveloper.com/design/environmental-storytelling-creating-immersive-3d-worlds-using-lessons-learned-from-the-theme-park-industry)  
+12. bytecauldron/awesome-level-design: A curated list of ... \- GitHub, accessed May 15, 2026, [https://github.com/bytecauldron/awesome-level-design](https://github.com/bytecauldron/awesome-level-design)  
+13. Intro to Environmental Storytelling | Video Game Design \- YouTube, accessed May 15, 2026, [https://www.youtube.com/watch?v=yrl1JD-LO78](https://www.youtube.com/watch?v=yrl1JD-LO78)  
+14. (PDF) A Framework for Metroidvania Games \- ResearchGate, accessed May 15, 2026, [https://www.researchgate.net/publication/346540910\_A\_Framework\_for\_Metroidvania\_Games](https://www.researchgate.net/publication/346540910_A_Framework_for_Metroidvania_Games)  
+15. Platformer Game Design (Definition, Fundamentals, Mechanics), accessed May 15, 2026, [https://gamedesignskills.com/game-design/platformer/](https://gamedesignskills.com/game-design/platformer/)  
+16. Guide to Making Metroidvania Style Games: Part 1 \- Subtractive Design, accessed May 15, 2026, [http://subtractivedesign.blogspot.com/2013/01/guide-to-making-metroidvania-style.html](http://subtractivedesign.blogspot.com/2013/01/guide-to-making-metroidvania-style.html)  
+17. Are there any good resources to learn about level design in depth? : r/gaming \- Reddit, accessed May 15, 2026, [https://www.reddit.com/r/gaming/comments/1ist144/are\_there\_any\_good\_resources\_to\_learn\_about\_level/](https://www.reddit.com/r/gaming/comments/1ist144/are_there_any_good_resources_to_learn_about_level/)  
+18. LESSONS FROM HELL: John Romero's Level Design Rules for DOOM \- I Cast Light\!, accessed May 15, 2026, [https://icastlight.blogspot.com/2024/01/lessons-from-hell-john-romeros-level.html](https://icastlight.blogspot.com/2024/01/lessons-from-hell-john-romeros-level.html)  
+19. Metroidvanias and Megadungeons \- Rise Up Comus, accessed May 15, 2026, [http://riseupcomus.blogspot.com/2024/01/metroidvanias-and-megadungeons.html](http://riseupcomus.blogspot.com/2024/01/metroidvanias-and-megadungeons.html)  
+20. What Happened Here? Environmental Storytelling \- GDC Vault, accessed May 15, 2026, [https://www.gdcvault.com/play/1012647/what-happened-here-environmental](https://www.gdcvault.com/play/1012647/what-happened-here-environmental)  
+21. Environmental Storytelling: Indices and the Art of Leaving Traces \- GDC Vault, accessed May 15, 2026, [https://gdcvault.com/play/1016566/Environmental-Storytelling-Indices-and-the](https://gdcvault.com/play/1016566/Environmental-Storytelling-Indices-and-the)  
+22. Level Design Compendium: The Curated List (+40 links) : r/gamedev \- Reddit, accessed May 15, 2026, [https://www.reddit.com/r/gamedev/comments/fv2s65/level\_design\_compendium\_the\_curated\_list\_40\_links/](https://www.reddit.com/r/gamedev/comments/fv2s65/level_design_compendium_the_curated_list_40_links/)  
+23. Good Resources for level design? : r/leveldesign \- Reddit, accessed May 15, 2026, [https://www.reddit.com/r/leveldesign/comments/19e77wy/good\_resources\_for\_level\_design/](https://www.reddit.com/r/leveldesign/comments/19e77wy/good_resources_for_level_design/)  
+24. John Romero's 8 rules for making games\! so here's part 1\! \#doom \#games \#retro \#fun \#viral \#trending \- YouTube, accessed May 15, 2026, [https://www.youtube.com/shorts/LylUEGZ03aU](https://www.youtube.com/shorts/LylUEGZ03aU)  
+25. Tips for creating good WADs \- The Doom Wiki at DoomWiki.org, accessed May 15, 2026, [https://doomwiki.org/wiki/Tips\_for\_creating\_good\_WADs](https://doomwiki.org/wiki/Tips_for_creating_good_WADs)  
+26. Level Design in a Day: Best Practices from the Best in the Business \- GDC Vault, accessed May 15, 2026, [https://gdcvault.com/play/1016327/Level-Design-in-a-Day](https://gdcvault.com/play/1016327/Level-Design-in-a-Day)  
+27. How to write a game design document — with examples and template \- GitBook, accessed May 15, 2026, [https://www.gitbook.com/blog/how-to-write-a-game-design-document](https://www.gitbook.com/blog/how-to-write-a-game-design-document)  
+28. World of Level Design \- Tutorials for Becoming the Best Level Designer and Game Environment Artist, accessed May 15, 2026, [https://www.worldofleveldesign.com/](https://www.worldofleveldesign.com/)  
+29. LEVEL-DESIGN.org – Level Art and Design news website, accessed May 15, 2026, [http://level-design.org/](http://level-design.org/)  
+30. Master How to Make a Game Design Document: Your Essential Guide, accessed May 15, 2026, [https://kevurugames.com/blog/how-to-write-a-game-design-document-gdd/](https://kevurugames.com/blog/how-to-write-a-game-design-document-gdd/)  
+31. Writing Modern Game Design Documents (+Examples) \- Codecks, accessed May 15, 2026, [https://www.codecks.io/blog/writing-modern-game-design-documents/](https://www.codecks.io/blog/writing-modern-game-design-documents/)  
+32. Free Game Design Document (GDD) Template & How-To Guide, accessed May 15, 2026, [https://indiegameacademy.com/free-game-design-document-template-how-to-guide/](https://indiegameacademy.com/free-game-design-document-template-how-to-guide/)  
+33. Finished Game Design Document Examples? : r/gamedesign \- Reddit, accessed May 15, 2026, [https://www.reddit.com/r/gamedesign/comments/7ze7xq/finished\_game\_design\_document\_examples/](https://www.reddit.com/r/gamedesign/comments/7ze7xq/finished_game_design_document_examples/)  
+34. 20 Best Books for Game Designers \- Devtodev, accessed May 15, 2026, [https://www.devtodev.com/resources/articles/20-best-books-for-game-designers](https://www.devtodev.com/resources/articles/20-best-books-for-game-designers)  
+35. Book recommendation for level design : r/gamedev \- Reddit, accessed May 15, 2026, [https://www.reddit.com/r/gamedev/comments/1sy2s89/book\_recommendation\_for\_level\_design/](https://www.reddit.com/r/gamedev/comments/1sy2s89/book_recommendation_for_level_design/)  
+36. 10 Game Level Design Books to Learn From, accessed May 15, 2026, [https://gamedesignskills.com/game-design/level-design-books/](https://gamedesignskills.com/game-design/level-design-books/)
+
+[image1]: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAAWCAYAAAAfD8YZAAAAz0lEQVR4Xu2SsQqBYRSG31IKKTfiBoxGi81NkEXZTHZGl6DsBpFQZLK7BolCMYj365wvv9P//TfAU89ynv+cvuEH/jToli7onC7pJtLXdEbHdBKZf/FS8zaQAaQ1bfC4+LRD5QbpsRQhsWeD4l8VywgSCzaQNKStbPAkXe5AWtkGj19OMoiLe9oytrUFl+uQWLFBce1hh54DwpdLkNa1wZP0rCmkZW1wpCBxZ4OSdBh9SKzZQDIILA/phZ7okZ7x+TVz9Koz19w3d1rV/nO8AdFuRm3+sGguAAAAAElFTkSuQmCC>
+
+[image2]: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAUCAYAAAC58NwRAAAAhklEQVR4XmNgGH5gHhB/AuL/SPgjEPchK8IGYIqJAowMEMVn0SVwgWwGiAYvdAlc4CUDCc4BAZLcr8UAUdyJLoELrGGAaOBDl4ACDJvxOQdkCCieUABI8T90QSgARSgTsoA5A0TDRGRBKHjAgGRzOBCfggqA8G0g3gfER4H4BZJ4CUzDUAcAra4l9Jn0G0AAAAAASUVORK5CYII=>
+
+[image3]: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAVCAYAAACUhcTwAAAAcklEQVR4XmNgGAXkAGYgrgTifHQJGGgH4l9QNjeU/R8hzcAQDRXgQBI7CxWDAxDnObIAVOwLjBMCFUiHS0MASAzkPjDYARVABnJQMVaYwBSoADJYgiS2FESAfIKsyA3Kh4nB5ZyRJLKhYv+gfCGYosEEAIOOHmYSXsA5AAAAAElFTkSuQmCC>
+
+[image4]: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAYCAYAAADDLGwtAAAAmElEQVR4XmNgGAW0AuZAvByI7dElkMFHIJ4MZc8B4r9A/B8hDQE/gPgpmhhI0RJkgTyooAiSGDNUTAtJDCyAbkUpFjGwwDc0sc9QcRQAEtiPRWwNmhhDM1QCBv5B+dpIYnBQDMTvgbidAYf7sIEvDFgUgtz2E00MpKgATQwseAHK5oXyjyGkEYAbiKcB8S4gbgViNlTpAQcA85on0bDMg3IAAAAASUVORK5CYII=>
+
+[image5]: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAVCAYAAACUhcTwAAAAjUlEQVR4XmNgGHRAAl0AGSwE4v9QjBdoMhChaCUDEYpACr6iC4JADxA3QdkgRTVIcgyVQPwLylZlQDiaHaYgFSrAARMAgktQMTgAcZ4jC0DFvsM4HlCBdLg0BIDEGmCcZVABZKACFYNbPwUqgAyWIIktBRHcSAIgEAzlw8Tgcs5IEtlQsX9QvhBM0WACAHzwJ6iTQnBMAAAAAElFTkSuQmCC>
+
+[image6]: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD4AAAAhCAYAAACBQRgKAAACRUlEQVR4XuWZO2gVQRSGj4jPiCYQMUU67exsBMUUksYoJlUEGx9opZWvVoxWIkoQrXwkppBgpY2gRQoLsYiNhSS2Wqj4NlFB0f/nnOHOPexu2ARy19kPPnZ2/puQc2dnZ3YjkianYAd8Ade7LGl+2HE5nImDunDErBXL4FXfWQeO23GiqTdxfsO/5hWXJcFr0SJJu2ihyTNsx7jYWhRO1klzsWEZS5678Fx0PhC1S3ELfpXGjYG+tWwJfOeyj7DP8lbwFPZYezQO5ksoLAsuD8zW+qAFrIR/4DTsdFlpOLIs7LkPjKIvpQqsEh2U/XZ+P8oKOSZa2F4fGMx++c4Kwf35ddEB3Am3Nsf5cE7njegO0WzIBxUj/P1PmnrnIFzK/XC36M1rl/nMMl5OVeas6I4tbwAz4Yen4EnnGcvK/LJ9cCzHO3AE3oY34Q1pbEoWAtf2E3ATHHRZLmF+5y1RVZ/fgWtws+8s4r3kj+g20ey8D1pEuPrKmklR+Fg0W+2DAnrhxRJe0B9bXJaKFva/rt/zJtwFs24IvIsnVzg3+t/gJ/gBfhbdBpI2+N36mPEzP0WXuipwQHQwZuFGlyULH066rb1C9Avge7bk4ZNkPPXYvhSd1wYWvic651XwRXQ1OgS3RFkyHBW9D8X4q2FNdJ4ELOiN63skug0OJLUaBeJ9B58nCAvtsvYGaaxSycA5fBAehqfhduvnEhwu7VfwsrWT4IE0NlV+c8WXEC/hPevnE1st4FuYQJLzO4tx+NDak5Lz39J/poKgsskC2d0AAAAASUVORK5CYII=>
+
+[image7]: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAZCAYAAADXPsWXAAAA4ElEQVR4XmNgGAWjgM5gDhAfA+L/QMwIFROD8h1hivABHSDOg7JBmhKgbBEofzaUjxf8gNJmDBBNLEhyx4E4GImPE9RC6QkMEEOQwXQglkYTwwtABjxDE3uJxicIQIb4o4ldQOPjBXIMmF4BBbYUlA2KsbNAfAchzXAViQ0HIEP0oWxOBlQNN6A0skXoloKBNwNEAoR3oMmBQBMQL4GybYD4OZIc0QBkOMiFILAPiDOR5IgGBL1CDPAA4vdAfISBTEOMgLgQygYlyklIckSDo0BsAcT2DKixRjIwQBegKgAALGgr4BK6ma8AAAAASUVORK5CYII=>

--- a/docs/research/level-design-subagent-deep-research-report.md
+++ b/docs/research/level-design-subagent-deep-research-report.md
@@ -1,0 +1,242 @@
+# Optional Level Design Subagent for Game Development
+
+## Executive summary
+
+The strongest evidence does not support a fully autonomous “design the level for me” agent as the first implementation. It supports an **optional, specialized, analysis-first subagent** that helps designers plan, critique, iterate, and test levels while leaving authorship and final judgment to humans. That conclusion follows from creator-written postmortems and official talks that repeatedly emphasize iterative playtesting, whiteboxing before art lock, readability over spectacle, explicit challenge ramping, modular production, and cross-discipline collaboration rather than one-shot generation. Valve’s creator-written *Portal* postmortem centers iterative playtesting and simple storytelling; Bethesda’s talks center iteration and modular workflows; Q.U.B.E. 2’s official Unreal interview says player comprehension and comfortable play must take priority over visual drama; Nintendo’s developer interviews show manual sketching, iteration, and difficulty tuning so more players can reach the end. citeturn25view0turn38search0turn37search0turn18view7turn18view11turn18view10
+
+For implementation, the recommended shape is an **engine-agnostic skill with adapters** for Unreal, Unity, Godot, LDtk, or Tiled when available. Because the target engine, platform, and user skill level are unspecified, the safest default is a generic capability set that accepts a level brief, screenshots, blockout exports, scene graphs, and telemetry, then emits beat sheets, annotated critiques, structured checklists, alternative branch plans, accessibility issues, and playtest hypotheses. This aligns with research that frames level design as the invisible guidance of player movement and understanding, with methods grounded in design patterns, puzzle usability, iterative tooling, and telemetry-supported refinement. citeturn23view0turn23view2turn39search8turn37search0turn27view2
+
+The design rules most worth formalizing are stable and repeatedly corroborated: openings should establish purpose and orient the player; levels should alternate tension and release; readability must beat atmospheric ambiguity when gameplay depends on recognition; challenge should escalate by **foreshadowing** and **layering** known elements; optional rewards should sit on curiosity paths and skill-risk branches; navigation should combine nonverbal guidance, landmarks, and mental-map reinforcement; accessibility should use multisensory cues, adjustable speed or difficulty, and alternatives to precision timing; and production should move from sketch to whitebox to modular kit, not the reverse. These rules are supported across academic pattern research, official accessibility guidance, official game-dev talks, and long-lived industry heuristics. citeturn18view6turn20view0turn20view2turn20view3turn21view1turn6view0turn6view2turn6view3turn34view0turn42view0
+
+For product behavior, the subagent should be **strictly opt-in**, with explicit activation and scoped permissions. A side-panel or slash-command model is safer than proactive background behavior. The agent should default to read-only analysis, escalate to scene ingestion only with user permission, and require explicit approval before exporting tasks, annotations, or suggested modifications. That recommendation follows from general AI risk and privacy guidance, which stresses governance, risk mapping, data minimization, and protection against prompt injection or sensitive-information leakage in LLM systems. citeturn30search3turn30search2turn30search18turn30search0turn30search1turn29search1turn29search4turn29search16
+
+Evaluation should be hybrid. Static rule checks alone are insufficient. Human interviews give the clearest design-improvement signals; telemetry explains what players do at scale but not why; AI playtesting is useful for navigation and difficulty visualization; and automated difficulty models are promising for platforming but still partial. The right stack is therefore **static linting + traversal simulation + structured telemetry + moderated human playtests**. citeturn27view0turn27view2turn27view4turn28search0turn27view1
+
+The recommended implementation path is incremental: **rule pack and text critique first; blockout and screenshot analysis second; engine adapters third; telemetry and automated evaluation fourth; privacy/security hardening and studio workflow integration throughout**. This yields usable value early, avoids overclaiming, and matches the iterative level-design processes described by Bethesda, Valve, Q.U.B.E. 2’s team, and other production sources. citeturn38search0turn37search0turn25view0turn18view7turn43search19
+
+## Curated reference base
+
+The table below prioritizes **primary and official sources first**, then academic work, then high-value practitioner books and curated blogs. Several important GDC materials are only openly accessible through abstracts or official talk listings; where full slides or creator-written summaries were available, those were preferred. A user-provided memorandum also exists as a supplementary, non-authoritative reading-list artifact. citeturn14search5turn0file0
+
+| Priority | Reference | Type | Why it matters | Best use | Sources |
+|---|---|---|---|---|---|
+| High | *Portal* creator-written postmortem | Creator-written postmortem | Explicitly highlights iterative playtesting, simple storytelling, and presenting new ideas to mass audiences | Puzzle onboarding, iteration discipline, narrative economy | citeturn25view0 |
+| High | Randy Smith, **Helping Your Players Feel Smart: Puzzles as User Interface** | Official GDC talk summary | Formalizes puzzle usability through visibility, affordances, mapping, visual language, feedback, and conceptual models | Guidance, readability, puzzle communication | citeturn39search8turn23view3 |
+| High | Matt Thorson, **Level Design Workshop: Designing Celeste** | Official GDC talk listing | Core reference for short-form challenge iteration and large-volume handcrafted platforming | Platformer pacing, difficulty shaping, one-room challenge design | citeturn14search5turn11search1 |
+| High | Steve Lee, **An Approach to Holistic Level Design** | Official GDC talk listing | Canonical modern AAA level-design framing from Arkane | Holistic review criteria, cross-discipline planning | citeturn1search2turn14search5 |
+| High | Clemence Maurer, **Rewarding Exploration in Deus Ex: Mankind Divided** | Official GDC talk listing and slide reference | Exploration, route variety, environmental storytelling, navigation-reward coupling | Reward placement, optional paths, exploratory hubs | citeturn2search5turn14search5 |
+| High | Joel Burgess, **How We Used Iterative Level Design to Ship Skyrim and Fallout 3** | Official GDC talk | Large-scale iterative production for open worlds | Workflow, validation gates, iteration cadence | citeturn38search0 |
+| High | Joel Burgess and Nathan Purkeypile, **Fallout 4’s Modular Level Design** | Official GDC talk | Clear official statement on modular kits plus iterative LD for huge worlds | Modularity, kit design, scalable content production | citeturn37search0 |
+| High | Official Unreal interview on **Q.U.B.E. 2** | Official engine/developer interview | States readability and fun outrank dramatic lighting or organic form; documents whitebox-to-modular workflow | Puzzle readability, modular pipeline, whitebox discipline | citeturn18view7 |
+| High | Nintendo **Iwata Asks** on *New Super Mario Bros.* | Official Nintendo interview | Shows paper-sketch-driven level planning and manual data entry workflow | Sketch-first workflow, blockout planning | citeturn18view11 |
+| High | Nintendo **Ask the Developer** on *Super Mario Bros. Wonder* | Official Nintendo interview | Explicit design goal of reducing discouragement so more players can reach the end | Accessibility, difficulty tuning, broader player reach | citeturn18view10 |
+| High | **Game Accessibility Guidelines** | Official industry guidance | Practical, specific checklist covering guidance, timing, objectives, cueing, contrast, practice, and playtesting with disabled players | Accessibility rule system | citeturn6view1turn6view0turn6view2 |
+| High | Microsoft **Xbox Accessibility Guideline 103** | Official platform guidance | Demands multisensory communication and rejects color-only critical information | Critical-cue redundancy, color safety | citeturn6view3 |
+| High | Milam and El-Nasr, **Design Patterns to Guide Player Movement in 3D Games** | Academic paper | One of the clearest attempts to formalize spatial guidance in 3D level design | Guidance, spatial communication, movement analysis | citeturn23view0turn23view2turn23view3 |
+| High | Khalifa, de Mesentier Silva, Togelius, **Level Design Patterns in 2D Games** | Academic paper | Formal pattern taxonomy: Guidance, Foreshadowing, Safe Zone, Layering, Branching, Pace Breaking | Pattern-to-rule mapping, 2D heuristics transferable to broader level analysis | citeturn20view0turn20view2turn20view3turn21view1 |
+| Medium | Wheat et al., **Modeling Perceived Difficulty in Game Levels** | Academic paper | Connects level features and player metrics to perceived difficulty | Automated difficulty estimation, telemetry modeling | citeturn18view1 |
+| Medium | Wehbe et al., **Testing Incremental Difficulty Design in Platformer Games** | Academic paper | Empirical difficulty-ramp study for platformers | Challenge-ramp testing, DDA-informed level review | citeturn18view2turn8search14 |
+| Medium | Hoek, **Analyzing the Challenge of Navigation through the Metroid Series** | Academic paper | Useful three-part navigation frame: destination, routing, execution | Navigation audits, Metroidvania/pathing analysis | citeturn18view4 |
+| Medium | Totten, **An Architectural Approach to Level Design** | Book | Anchors level design in spatial layout, emotion, and architectural theory | Spatial composition, world legibility, emotional space | citeturn8search3turn8search23 |
+| Medium | Lemarchand, **A Playful Production Process** | Book | Connects conceptual design, building, playtesting, and iteration to a sustainable workflow | Production process, stage-gate implementation | citeturn43search6turn43search19 |
+| Medium | Salen Tekinbaş and Zimmerman, **Rules of Play** | Book | General theoretical grounding for meaningful choice and systemic design | Choice architecture, systemic reasoning | citeturn43search16turn43search7 |
+| Medium | Gómez-Maureira et al., **Improving Level Design Through Game User Research** | Academic paper | Shows interviews, metrics, and biometrics each contribute differently; interviews gave clearest improvement signals | Playtest protocol design | citeturn27view0 |
+| Medium | **Telemetry-Supported Game Design** | Industry article | Explains what telemetry answers well and where it fails | Telemetry event schema, dashboard design | citeturn27view2 |
+| Medium | **Visualizing AI Playtesting Data of 2D Side-scrolling Games** | Academic paper | Demonstrates agent trajectory visualization as level-design evidence | AI traversal analysis, heatmaps | citeturn27view4 |
+| Medium | Francillette et al., **Automated Evaluation of Difficulty in Platformer Games** | Academic paper | Recent formal model for automatic platformer difficulty evaluation | Bot-based difficulty scoring | citeturn28search0 |
+| Medium | Dana Nightingale, **Great Level Design is a Studio Wide Effort** | Official GDC talk | Useful reminder that LD quality depends on more than the level designer | Workflow integration, role boundaries | citeturn38search1turn2search19 |
+| Supplementary | **The Level Design Book** | Practitioner reference site | Broad, current, critical synthesis; useful, but explicitly still under construction | Fast lookup, onboarding, terminology | citeturn13search4turn18view9 |
+| Supplementary | **World of Level Design** | Practitioner blog | Long-running tutorials and workflows, especially for environment and blockout practice | Production habits, environment/LD crossover | citeturn13search8turn13search25 |
+| Supplementary | **Level Design Lobby** | Practitioner podcast/channel | Ongoing breakdowns of techniques and case studies | Continuing education, team study sessions | citeturn13search18turn13search22 |
+| Supplementary | User-provided memo | Supplemental memo | Broad 2D-level-design reading list and synthesis supplied in this conversation; useful as a secondary index, not a primary authority | Cross-checking and further reading | fileciteturn0file0 |
+
+## Formalized level design rules
+
+The table below converts recurring ideas from the source base into a rule pack suited for a specialized subagent. The rule IDs are written to be directly reusable in prompts, API outputs, and automated lint checks.
+
+| Rule ID | Area | Formalized rule | What the subagent should check or propose | Evidence |
+|---|---|---|---|---|
+| F1 | Flow and onboarding | **Start with intent.** The opening should either teach, awe, or threaten, but the purpose must be legible. If teaching, reduce threat; if threatening, make the threat readable. | Detect whether the first encounter introduces the verb set, objective, and affordances without punitive overload; flag hostile starts with no safe observation window. | citeturn18view6turn20view2 |
+| F2 | Pacing | **Alternate pressure and release.** Dramatic arc should not stay flat; use spikes, quiet rooms, safe pockets, and climactic escalations. | Compute tension rhythm from hazards, enemy density, traversal precision, and downtime; flag monotony or stacked spikes without recovery. | citeturn21view1turn34view0turn41search0 |
+| F3 | Readability | **Gameplay-critical clarity beats atmosphere.** If a puzzle element, route, or hazard must be recognized, lighting, composition, and signaling must preserve that readability. | Detect low contrast, clutter, ambiguous silhouettes, hidden interactables, and spectacle that obscures mechanics; recommend lighting or signage changes. | citeturn18view7turn39search8turn6view3 |
+| F4 | Challenge escalation | **Escalate by foreshadowing then layering.** Introduce an element in a controlled context, then combine it with known elements to raise challenge fairly. | Identify whether a new mechanic appears first in a low-threat context; flag jumps from first exposure directly to multi-factor failure states. | citeturn20view3turn21view1turn8search14 |
+| F5 | Reward placement | **Put rewards on curiosity and skill paths.** Main path rewards sustain progress; optional rewards should sit behind risk, observation, or mastery, not random obscurity. | Score branch quality: safer/smaller reward versus riskier/larger reward; highlight dead branches, fake rewards, and secrets with no readable setup. | citeturn21view0turn34view0turn2search5 |
+| F6 | Guidance and navigation | **Guide nonverbally whenever possible.** Use geometry, landmarks, visible goals, enemy placement, collectibles, and route framing to answer destination, routing, and execution. | Audit breadcrumbs, sightlines, landmark spacing, re-used hubs, enemy/collectible funnels, and false affordances; produce an annotated guidance map. | citeturn20view0turn20view2turn18view4turn23view2 |
+| F7 | Accessibility | **No critical state should depend on a single channel or excessive precision.** Important cues should be multisensory; objectives and controls should be recallable; players should have timing and difficulty alternatives where feasible. | Flag color-only cues, sound-only hazard telegraphs, unreadable text, missing reminders, hard timing gates without alternatives, lack of practice spaces, and absent objective recall. | citeturn6view0turn6view1turn6view2turn6view3turn18view10 |
+| F8 | Modularity and production | **Sketch first, whitebox second, modularize third.** Do not commit art-kit production before the core route, spacing, and interaction quality are proven in lightweight form. Never lock onto the first acceptable idea. | Ask for thumbnails, text outlines, or beat sheets before geometry generation; prefer blockout analysis before modular-kit output; warn when art fidelity is being used to mask unresolved play problems. | citeturn42view0turn18view7turn37search0turn38search0 |
+
+Three additional heuristics are worth making explicit. First, **push–pull composition** remains useful: enemies, hazards, and time pressure “push” forward while rewards, power-ups, visible goals, and secrets “pull” players into space. Second, **checkpoint density is a design parameter**, not a QA afterthought; sparse continuations make players repeat solved content instead of practicing the hard part. Third, **folk theories are weaker than concrete affordances**. A specialized subagent should not over-rely on generic “leading lines” or shape/color psychology claims when stronger evidence exists in readable affordances, route framing, landmarks, feedback, and telemetry. citeturn34view0turn18view9turn39search8turn27view2
+
+## Subagent capability blueprint
+
+The recommended architecture is a **rule-backed analysis skill** that consumes structured level context, runs specialized evaluators, and emits evidence-backed outputs rather than vague advice.
+
+```mermaid
+flowchart TD
+    A[User in chat or editor] --> B{Explicit opt-in}
+    B -- No --> C[No activation]
+    B -- Yes --> D[Context loader]
+    D --> E[Brief and beat parser]
+    D --> F[Scene or blockout adapter]
+    D --> G[Telemetry and playtest ingest]
+    E --> H[Rule engine]
+    F --> H
+    G --> H
+    H --> I[Flow and pacing analysis]
+    H --> J[Readability and guidance audit]
+    H --> K[Challenge and reward analysis]
+    H --> L[Accessibility review]
+    I --> M[Findings with severity and citations]
+    J --> M
+    K --> M
+    L --> M
+    M --> N[Optional exports]
+    N --> O[Beat sheet, checklist, tickets, test cases]
+```
+
+A minimal engine-agnostic context model should capture **verbs, goals, mechanic introductions, hazards, rewards, branch structure, checkpoints, landmarks, accessibility settings, and available telemetry hooks**, because those variables recur across the most reliable sources on pattern analysis, puzzle communication, iteration, and evaluation. citeturn20view0turn20view3turn21view1turn39search8turn27view2
+
+```json
+{
+  "project": "string",
+  "genre": "platformer|immersive-sim|stealth|shooter|puzzle|metroidvania|other",
+  "camera": "2D|2.5D|3D|isometric|topdown",
+  "core_verbs": ["jump", "climb", "hide", "shoot"],
+  "win_condition": "string",
+  "target_duration_minutes": 10,
+  "intended_player": "novice|returning|expert|mixed",
+  "critical_path": ["nodeA", "nodeB", "nodeC"],
+  "optional_paths": [{"id":"path1","risk":"high","reward":"upgrade"}],
+  "mechanic_timeline": [{"mechanic":"wall-jump","first_seen":"nodeB"}],
+  "hazards": [{"type":"turret","nodes":["nodeC"]}],
+  "rewards": [{"type":"health","placement":"critical_path"}],
+  "checkpoints": ["nodeB"],
+  "landmarks": ["tower", "red_door"],
+  "accessibility": {
+    "difficulty_options": true,
+    "speed_adjust": false,
+    "multisensory_cues": true
+  },
+  "available_inputs": ["brief", "scene_graph", "screenshots", "telemetry"]
+}
+```
+
+| Capability | Inputs | Outputs | API sketch | Key controls | Rule mapping | Example prompt |
+|---|---|---|---|---|---|---|
+| Brief-to-beat planner | Pitch, verbs, target duration, intended audience | Beat sheet, mechanic timeline, opening recommendation, climax/rest plan | `POST /ld/beat-plan` | `challenge_target`, `exploration_ratio`, `tone`, `session_length` | F1, F2, F4 | “Turn this 12-minute stealth brief into three beat-sheet variants with one onboarding beat, one escalation, one quiet reset, and one climax.” |
+| Blockout topology analyzer | Scene graph, whitebox metrics, node connections | Critical-path map, branch classification, dead-end report, checkpoint suggestions | `POST /ld/topology-audit` | `branching_level`, `checkpoint_density`, `hub_reuse`, `backtracking_budget` | F2, F5, F6, F8 | “Audit this hub-and-spoke blockout for mental-map clarity, branch value, and backtracking burden.” |
+| Readability and guidance auditor | Screenshots, tagged interactables, light values, object classes | Annotated screenshot findings, cue redundancy issues, landmark recommendations | `POST /ld/readability-audit` | `guidance_strength`, `readability_priority`, `hint_policy` | F3, F6, F7 | “Review these three greybox screenshots for hazard readability, objective visibility, and false affordances.” |
+| Challenge and reward balancer | Mechanic timeline, hazards, rewards, branch risks, failure logs | Difficulty-ramp critique, foreshadowing gaps, reward redistribution plan | `POST /ld/challenge-balance` | `difficulty_curve`, `risk_reward_ratio`, `novice_tolerance` | F2, F4, F5 | “Find where this traversal level jumps in difficulty too sharply and propose a foreshadowing step instead of reducing final difficulty.” |
+| Accessibility reviewer | Cue list, control demands, timing windows, settings list, objective UI | Accessibility issues ranked by severity, missing options, remediation checklist | `POST /ld/accessibility-review` | `accessibility_strictness`, `timing_forgiveness`, `cue_channels` | F3, F7 | “Check whether any essential state is conveyed only by color, sound, or precise timing.” |
+| Modular production advisor | Thumbnails, whitebox, modular kit list, asset constraints | Kit-splitting advice, over-modularity warnings, blockout-to-art handoff checklist | `POST /ld/modularity-plan` | `kit_granularity`, `reuse_target`, `bio_diversity_target` | F3, F8 | “Given this whitebox and 40-piece kit budget, propose a kit structure that preserves readability and variation.” |
+| Playtest and telemetry analyst | Session logs, deaths, retries, path traces, interviews | Quit-point analysis, heatmaps, misread hypotheses, prioritized fixes | `POST /ld/playtest-synthesis` | `sample_segment`, `severity_threshold`, `confidence_mode` | F1–F7 | “Synthesize these 18 playtest sessions into likely guidance, pacing, and fairness problems. Separate ‘what happened’ from ‘why players said it happened.’” |
+
+Recommended parameter controls should be **explicit and user-editable**, not buried in the prompt. The most useful controls are `challenge_target`, `exploration_ratio`, `guidance_strength`, `checkpoint_density`, `branching_level`, `hint_policy`, `accessibility_strictness`, `readability_priority`, `kit_granularity`, and `explanation_depth`. This keeps the skill configurable without making it opaque. That structure is consistent with sources that treat level design as a negotiation among challenge, choice, readability, iteration cost, and player support rather than a single scalar “goodness” score. citeturn40search0turn18view7turn27view0turn43search19
+
+## Opt-in integration and governance
+
+A specialized level-design subagent should be integrated as an **advisory instrument with explicit invocation**, not as an always-on background actor. The safest triggers are direct user actions such as a slash command, side-panel button, review action in the editor, or a CI task on a tagged map. Limited proactive suggestions are acceptable only when user intent is unambiguous, such as attaching a blockout and asking for level feedback. This respects both user agency and AI governance guidance that stresses governance, context mapping, and risk-aware deployment. citeturn30search2turn30search3turn30search18
+
+| Integration option | Trigger and UI | Strengths | Weaknesses | Best fit | Relative effort |
+|---|---|---|---|---|---|
+| Chat-only review skill | Explicit command, pasted brief, screenshots | Fastest to ship; engine-agnostic; good for ideation and critique | Weak spatial grounding; no direct scene validation | Solo designers, early pilot | Low |
+| Editor sidecar plugin | Button in Unity/Unreal/Godot; level panel | Strong context, screenshot capture, annotations, scene metadata | Engine-specific adapters; higher maintenance | Teams actively building levels | Medium |
+| CI rule-checker | Pull request, build step, nightly lint | Consistent enforcement, scalable, auditable outputs | Limited nuance; cannot replace human review | Studio pipelines, larger teams | Medium |
+| Telemetry-backed review service | After internal playtest or external test build | Strongest evidence, supports prioritization by actual behavior | Requires instrumentation, data governance, analysis layer | Mid-to-late production | High |
+
+A practical permission model should be tiered. **Tier A**: text brief only. **Tier B**: screenshots and read-only scene metadata. **Tier C**: structured scene graph or map file. **Tier D**: playtest telemetry and interviews. **Tier E**: optional export of tickets, annotations, or structured recommendations. Write access to the project should be off by default. This is the right place to be conservative: NIST’s privacy and AI-risk materials push toward governance, scoped use, and data minimization, while OWASP’s LLM risk guidance makes it clear that indirect prompt injection and sensitive-information disclosure are real risks when models ingest untrusted content. citeturn30search15turn30search0turn30search1turn29search1turn29search4turn29search16
+
+Data privacy concerns are straightforward in this context. Level files often expose unreleased content, internal names, narrative spoilers, licensed assets, and telemetry tied to individuals or internal testers. The subagent should therefore support **redaction, local or private deployment options, retention limits, no-training-on-project-data by default, and deletion controls**. Untrusted imported text, notes, or asset metadata should be sandboxed as content, not treated as instructions; this is a direct mitigation against prompt injection. citeturn29search3turn30search8turn29search1turn29search4
+
+UI/UX should emphasize **evidence and traceability** rather than “AI confidence theater.” The best output format is a ranked issues list linked to map locations, screenshots, or nodes, each tied to a named rule and supported by citations or observed telemetry. One-click “apply fixes” should not exist initially. One-click “create checklist,” “generate alternate beat sheet,” or “open follow-up review” is safer and more aligned with how experienced teams iterate level work. citeturn25view0turn38search0turn27view1
+
+## Evaluation and playtest framework
+
+The right evaluation model combines **rule compliance, simulated traversal, telemetry, and human judgment**.
+
+```mermaid
+flowchart LR
+    A[Level brief] --> B[Beat sheet]
+    B --> C[Whitebox]
+    C --> D[Static rule checks]
+    D --> E[Internal playtests]
+    E --> F[Telemetry and interview synthesis]
+    F --> G[Revision]
+    G --> H[Art and content pass]
+    H --> I[Validation playtest]
+```
+
+| Evaluation dimension | Metric or evidence | How to test it | Why it matters | Sources |
+|---|---|---|---|---|
+| Opening clarity | Time-to-first-correct-action, number of failed openings, interview recall of objective | Instrument first 60–120 seconds; ask players what they thought the goal was | Validates F1 and opening-purpose legibility | citeturn18view6turn27view0 |
+| Pacing quality | Death clustering, pause/hesitation spikes, tension-rest alternation, completion-time variance | Static scene segmentation plus telemetry timelines and notes from moderated sessions | Finds flat arcs and spike stacking | citeturn21view1turn27view2turn27view0 |
+| Guidance quality | Wrong-turn rate, backtracking not intended by design, route entropy, lost-player interviews | Capture path traces and compare intended versus actual routing | Operationalizes F6 | citeturn18view4turn23view2turn27view4 |
+| Readability | Misread object frequency, missed interactables, cue-detection rate under varied lighting and color settings | Screenshot audits, colorblind simulations, playtest observation | Operationalizes F3 and F7 | citeturn18view7turn6view3turn6view0 |
+| Challenge fairness | Retry counts per obstacle, fail-cause distribution, first-exposure success on foreshadowed mechanics | Segment by mechanic introduction versus layered challenge | Tests F4 directly | citeturn20view3turn8search14turn18view1 |
+| Reward economy | Optional-branch take rate, reward discovery rate, secret completion rate, perceived reward value in interviews | Track branch entries and reward pickups; compare to intended budgets | Tests F5 and branch value | citeturn21view0turn34view0 |
+| Accessibility | Color-only cue failures, timing-gate failure under assist settings, objective-reminder use, settings uptake | Structured accessibility review plus playtesting with disabled participants | Tests F7 beyond checklist compliance | citeturn6view0turn6view2turn6view3 |
+| Production quality | Time-to-iterate, whitebox churn, art rework caused by late LD changes | Track revisions across thumbnail, whitebox, art pass, and validation | Tests whether the skill reduces costly late-stage churn | citeturn18view7turn42view0turn37search0 |
+
+Automated tests should be split into three layers. **Static linting** checks reachability, safe observation at spawn, checkpoint spacing, branch classification, critical-cue redundancy, and mechanic introduction order. **Traversal simulation** checks that the level is beatable, estimates route difficulty, and visualizes path traces and death hotspots. **Telemetry validation** checks where players hesitate, quit, or repeatedly fail. Research supports all three, but also shows their limitations: automated playtesting and difficulty models are useful, telemetry scales well, and interviews remain the clearest source of improvement signals. citeturn27view4turn28search0turn27view2turn27view0
+
+Human playtest protocol should be lightweight, repeatable, and segmented by audience. The minimal reliable format is: a short pre-brief on controls only; direct observation of play without coaching; a route or event log; a short retrospective interview; then structured coding of issues by rule family such as guidance, readability, pacing, fairness, reward, or accessibility. For accessibility-sensitive projects, disabled players must be included intentionally rather than treated as edge cases. citeturn27view1turn27view0turn6view2
+
+A practical scenario suite for validating the subagent should include at least: a tutorial room, a short traversal gauntlet, a combat arena, a hub-and-spoke exploration space, a stealth sandbox, and a quiet narrative transition. Those cases are broad enough to test the rule pack across onboarding, pacing, route guidance, branching, challenge stacking, and respite, while remaining engine-agnostic. This is an implementation recommendation, but it is directly motivated by the recurrent pattern families identified in academic pattern work and official level-design talks. citeturn20view0turn20view2turn21view1turn38search1
+
+## Workflows and implementation options
+
+Three autonomy levels are viable. Only one is strongly recommended for an initial release.
+
+| Model | What it does | Benefits | Main risk | Recommendation |
+|---|---|---|---|---|
+| Advisory only | Critiques, scores, annotates, explains, suggests alternatives | High trust, low safety risk, easy to integrate | Users may want more automation | Good starting point |
+| Advisory plus constrained generation | Generates beat sheets, branch alternatives, checklists, tagged annotations, and structured test cases; never edits the live map directly | Strong leverage without surrendering authorship | Requires good schemas and adapters | **Best default** |
+| Autonomous map editing | Modifies layout, places enemies and rewards, commits changes | Maximum automation | Highest design, safety, privacy, and trust risk; highest chance of brittle outputs | Avoid initially |
+
+The preferred workflow is **advisory plus constrained generation**. It captures the real value implied by the source base: not replacing design judgment, but making iteration faster, more explicit, and more testable. That matches Bethesda’s iterative pipeline, Q.U.B.E. 2’s whitebox-first process, Valve’s playtest-first refinement, and the broader evidence that telemetry and playtests are complements, not substitutes for authorial intent. citeturn38search0turn18view7turn25view0turn27view2turn27view0
+
+A lightweight integration workflow for a solo or small-team setup can look like this:
+
+| Step | Action | Typical artifact | Skill output |
+|---|---|---|---|
+| Brief | Write one-paragraph purpose, verbs, duration, audience | Level brief | Beat sheet variants |
+| Sketch | Produce text outline or thumbnail sketch | Image or outline | Flow and branch critique |
+| Whitebox | Build rough blockout | Scene export or screenshots | Guidance, pacing, and safe-zone audit |
+| Internal playtest | Run a few observed sessions | Session notes and simple telemetry | Ranked issue synthesis |
+| Revise | Update blockout | New scene export | Delta report versus prior version |
+| Art handoff | Lock readable core and kit requirements | Handoff checklist | Modularity and readability checklist |
+| Validation | Run broader playtest | Telemetry and interviews | Final release-risk report |
+
+A larger-team workflow should add CI and telemetry. In that model, the level-design skill runs manually in-editor during iteration, automatically in CI for rule regressions, and again after internal test builds to compare intended versus actual player behavior. The skill should export structured tickets for LD, environment art, UX, QA, and accessibility owners, because the source base consistently treats strong level design as cross-disciplinary. citeturn38search1turn27view2turn27view1
+
+## Risks, limitations, and roadmap
+
+| Risk or limitation | Why it matters | Mitigation |
+|---|---|---|
+| Over-standardization | A rigid rule pack can flatten style and produce safe but generic levels | Output alternatives, not single “correct” answers; allow style profiles and explicit rule overrides |
+| Hallucinated spatial advice | LLMs can speak confidently about layouts they have not actually parsed | Prefer structured inputs; separate “observed” from “inferred”; require evidence links to nodes, screenshots, or telemetry |
+| Weak geometry grounding | Chat-only analysis can misread space, line of sight, or traversal viability | Keep scene adapters and screenshot audits separate from pure text review; use traversal simulation when possible |
+| Privacy and IP leakage | Level files and telemetry can expose unreleased content and internal data | Read-only by default, local/private deployment options, retention limits, redaction, no training on project data by default |
+| Prompt injection through project assets | Untrusted notes, docs, and metadata can manipulate tool behavior | Treat imported content as data, not instructions; isolate parsers; use allowlists and content sanitization |
+| Metric myopia | Telemetry explains what players did, not why; teams can optimize the wrong number | Always pair telemetry with interviews or moderated observation |
+| Accessibility false comfort | Checklist passing is not the same as actual accessibility | Include disabled players in playtests and support adjustable settings, not just static claims |
+| Genre mismatch | Rules vary by genre, camera, and player fantasy | Make genre and camera explicit parameters; version the rule pack by genre family |
+
+The biggest unresolved implementation variables are outside the scope of the source base because the request leaves them unspecified: target engine, file formats, whether the skill may write into the project, whether the primary use case is solo indie or studio pipeline, which genres matter most, and whether telemetry infrastructure already exists. Those choices should determine adapter priorities, not the underlying rule pack.
+
+The roadmap below is therefore deliberately engine-agnostic and effort is expressed only as **low / medium / high** relative engineering and design effort.
+
+| Milestone | Deliverable | Value | Effort |
+|---|---|---|---|
+| Rule-pack foundation | Versioned rule library F1–F8, prompt templates, output schema, citation map | Makes the skill explainable and testable from day one | Low |
+| Text-only critique pilot | Brief and screenshot review in chat or web UI | Fastest usable product; validates demand and prompt quality | Low |
+| Whitebox and scene ingestion | Import structured blockout metadata or scene graphs; annotate nodes and paths | Moves from generic advice to genuinely spatial critique | Medium |
+| Readability and guidance overlays | Screenshot annotation, landmark checks, cue redundancy audits | High-value design feedback with direct usability impact | Medium |
+| Challenge and reward analyzer | Foreshadowing, layering, branch value, checkpoint-spacing checks | Turns theory into actionable balance review | Medium |
+| Engine adapters | Unity and/or Unreal sidecar plugin; optional Godot/LDtk/Tiled adapters | Brings the skill into real workflows | Medium to High |
+| Telemetry and automated testing | Event schema, dashboards, traversal simulation, difficulty estimates | Strongest evaluation layer; supports prioritization by evidence | High |
+| Privacy and security hardening | Scoped permissions, data retention controls, prompt-injection defenses, audit logging | Necessary for studio adoption and trust | Medium |
+| Pilot with real teams | Use on a small set of shipped or near-shipped levels; compare design outcomes and adoption | Validates ROI and exposes missing rules | Medium |
+| Broader rollout | CI integration, ticket export, role-specific views for LD, UX, QA, accessibility | Scales beyond individual use | Medium to High |
+
+The implementation recommendation is direct: **ship the skill first as an opt-in review and planning agent, not an autonomous level generator**. Give it a rule pack, structured outputs, citations, and a narrow permission surface. Add geometry grounding next. Add telemetry and automated evaluation only after the basic advisory workflow proves useful. That sequence best fits the evidence and minimizes the known failure modes. citeturn25view0turn18view7turn38search0turn27view0turn27view2turn29search1turn30search3

--- a/src/game/scenes/ridge/blockout/geometry.ts
+++ b/src/game/scenes/ridge/blockout/geometry.ts
@@ -73,6 +73,13 @@ export interface RidgeBlockoutAnchorPoint {
   y: number;
 }
 
+export interface RidgeBlockoutAnchorSelector {
+  roomId: string;
+  symbol?: string;
+  kind?: string;
+  attrId?: string;
+}
+
 export interface RidgeBlockoutRoomBounds {
   roomId: string;
   title: string;
@@ -197,6 +204,36 @@ export function getRidgeBlockoutAnchorPoint(
     x: (room.place.x + (minColumn + maxColumn + 1) / 2) * map.cell,
     y: (room.place.y + (minRow + maxRow + 1) / 2) * map.cell
   };
+}
+
+export function findRidgeBlockoutAnchorPoint(
+  geometry: Pick<RidgeBlockoutGeometry, 'anchorPoints'>,
+  selector: RidgeBlockoutAnchorSelector
+): RidgeBlockoutAnchorPoint | undefined {
+  return geometry.anchorPoints.find((point) =>
+    point.roomId === selector.roomId &&
+    (!selector.symbol || point.symbol === selector.symbol) &&
+    (!selector.kind || point.kind === selector.kind) &&
+    (!selector.attrId || point.attrs.id === selector.attrId)
+  );
+}
+
+export function getRidgeBlockoutSpawnPoint(map: RidgeBlockoutMap): RidgeBlockoutAnchorPoint {
+  const spawnRoom = findRidgeBlockoutRoom(map, map.spawn.roomId);
+  const spawnAnchor = spawnRoom?.anchors.find(
+    (anchor) => anchor.symbol === map.spawn.anchorSymbol
+  );
+  const point = spawnRoom && spawnAnchor
+    ? getRidgeBlockoutAnchorPoint(map, spawnRoom, spawnAnchor)
+    : undefined;
+
+  if (!point) {
+    throw new Error(
+      `Ridge blockout spawn anchor "${map.spawn.anchorSymbol}" in room "${map.spawn.roomId}" could not be resolved`
+    );
+  }
+
+  return point;
 }
 
 export function isRidgeBlockoutShortcutAvailable(

--- a/src/game/scenes/ridge/cicka/CickaPerch.ts
+++ b/src/game/scenes/ridge/cicka/CickaPerch.ts
@@ -15,9 +15,7 @@ import {
   updateCickaWalkBy,
   type CickaWalkByState
 } from './walkBy';
-import { RIDGE_FLOOR_Y } from '../worldLayout';
 
-const CICKA_PERCH_ANCHOR_Y = RIDGE_FLOOR_Y - 74;
 const CICKA_INTERACT_RADIUS = 78;
 const CICKA_PROMPT_OFFSET_Y = -86;
 const CICKA_SPEECH_BUBBLE_OFFSET = { x: -20, y: -98 } as const;
@@ -51,7 +49,7 @@ export interface CickaPerch {
 
 export interface CreateCickaPerchOptions {
   scene: Phaser.Scene;
-  landmark: { x: number; y?: number };
+  landmark: { x: number; y: number };
   hasStampedeNoteMemory: boolean;
   walkByLine: string;
 }
@@ -59,7 +57,7 @@ export interface CreateCickaPerchOptions {
 export function createCickaPerch(options: CreateCickaPerchOptions): CickaPerch {
   const { scene, landmark, hasStampedeNoteMemory, walkByLine } = options;
   const x = landmark.x;
-  const y = landmark.y ?? CICKA_PERCH_ANCHOR_Y;
+  const y = landmark.y;
   const ownedObjects: Phaser.GameObjects.GameObject[] = [];
   let walkByState: CickaWalkByState = createCickaWalkByState();
   let speechVisibleUntilMs = 0;

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -29,8 +29,9 @@ import {
 import {
   RIDGE_BLOCKOUT,
   deriveRidgeBlockoutGeometry,
-  findRidgeBlockoutRoom,
-  getRidgeBlockoutAnchorPoint,
+  findRidgeBlockoutAnchorPoint,
+  getRidgeBlockoutSpawnPoint,
+  type RidgeBlockoutAnchorSelector,
   type RidgeBlockoutAnchorPoint,
   type RidgeBlockoutAssistZone,
   type RidgeBlockoutBounds,
@@ -435,100 +436,84 @@ export class RidgeScene extends Phaser.Scene {
   ): void {
     this.cickaPerch = undefined;
 
-    const cickaPoint = this.findAnchorPoint(geometry, {
+    const cickaPoint = requireRidgeBlockoutAnchorPoint(geometry, {
       roomId: 'cicka_home',
       symbol: 'C',
       kind: 'npc',
       attrId: 'cicka'
+    }, 'Cicka Home perch');
+    this.cickaPerch = createCickaPerch({
+      scene: this,
+      landmark: {
+        x: cickaPoint.x,
+        y: cickaPoint.y + CICKA_PERCH_OFFSET_Y
+      },
+      hasStampedeNoteMemory: hasRidgeWorldMemory(
+        worldMemories.filter((memory) => memory.landmarkKind === 'cicka-perch'),
+        'cicka-stampede-note'
+      ),
+      walkByLine: cickaWalkByLine
     });
-    if (cickaPoint) {
-      this.cickaPerch = createCickaPerch({
-        scene: this,
-        landmark: {
-          x: cickaPoint.x,
-          y: cickaPoint.y + CICKA_PERCH_OFFSET_Y
-        },
-        hasStampedeNoteMemory: hasRidgeWorldMemory(
-          worldMemories.filter((memory) => memory.landmarkKind === 'cicka-perch'),
-          'cicka-stampede-note'
-        ),
-        walkByLine: cickaWalkByLine
-      });
-    }
 
-    const outskirtsArtifact = this.findAnchorPoint(geometry, {
+    const outskirtsArtifact = requireRidgeBlockoutAnchorPoint(geometry, {
       roomId: 'outskirts',
       symbol: 'A',
       attrId: 'city_edge_memory'
-    });
-    if (outskirtsArtifact) {
-      this.addOutskirtsArtifactSlot(outskirtsArtifact.x, outskirtsArtifact.y);
-    }
+    }, 'Outskirts artifact');
+    this.addOutskirtsArtifactSlot(outskirtsArtifact.x, outskirtsArtifact.y);
 
-    const stampedePoint = this.findAnchorPoint(geometry, {
+    const stampedePoint = requireRidgeBlockoutAnchorPoint(geometry, {
       roomId: 'stampede_blanket',
       symbol: '*',
       kind: 'minigame',
       attrId: 'stampede_sketch'
-    });
-    if (stampedePoint) {
-      this.addStampedeBlanket(
-        stampedePoint.x,
-        stampedePoint.y,
-        stampedeFirstClearLabel,
-        worldMemories.filter((memory) => memory.landmarkKind === 'stampede-blanket')
-      );
-    }
+    }, 'Stampede blanket');
+    this.addStampedeBlanket(
+      stampedePoint.x,
+      stampedePoint.y,
+      stampedeFirstClearLabel,
+      worldMemories.filter((memory) => memory.landmarkKind === 'stampede-blanket')
+    );
 
-    const telegraphPoint = this.findAnchorPoint(geometry, {
+    const telegraphPoint = requireRidgeBlockoutAnchorPoint(geometry, {
       roomId: 'telegraph_terrace',
       symbol: '*',
       kind: 'minigame',
       attrId: 'telegraph_future'
-    });
-    if (telegraphPoint) {
-      this.addTelegraphBag(telegraphPoint.x, telegraphPoint.y);
-    }
+    }, 'Telegraph Terrace bag');
+    this.addTelegraphBag(telegraphPoint.x, telegraphPoint.y);
 
-    const guidePoint = this.findAnchorPoint(geometry, {
+    const guidePoint = requireRidgeBlockoutAnchorPoint(geometry, {
       roomId: 'guide_overlook',
       symbol: 'N',
       kind: 'npc',
       attrId: 'ridge_guide'
-    });
-    if (guidePoint) {
-      this.addRidgeGuide(guidePoint.x, guidePoint.y);
-    }
+    }, 'Ridge guide');
+    this.addRidgeGuide(guidePoint.x, guidePoint.y);
 
-    const relayPoint = this.findAnchorPoint(geometry, {
+    const relayPoint = requireRidgeBlockoutAnchorPoint(geometry, {
       roomId: 'relay_gate',
       symbol: '?',
       kind: 'gate',
       attrId: 'relay_proof_slots'
-    });
-    if (relayPoint) {
-      this.addRelayGate(relayPoint.x, relayPoint.y);
-      this.addRelaySpire(relayPoint.x + 230, relayPoint.y - 180);
-    }
+    }, 'Relay Gate');
+    this.addRelayGate(relayPoint.x, relayPoint.y);
+    this.addRelaySpire(relayPoint.x + 230, relayPoint.y - 180);
 
-    const dominoPoint = this.findAnchorPoint(geometry, {
+    const dominoPoint = requireRidgeBlockoutAnchorPoint(geometry, {
       roomId: 'domino_desk',
       symbol: 'A',
       attrId: 'domino_project_scrap'
-    });
-    if (dominoPoint) {
-      this.addDominoDesk(dominoPoint.x, dominoPoint.y);
-    }
+    }, 'Domino Desk');
+    this.addDominoDesk(dominoPoint.x, dominoPoint.y);
 
-    const highLedgePoint = this.findAnchorPoint(geometry, {
+    const highLedgePoint = requireRidgeBlockoutAnchorPoint(geometry, {
       roomId: 'high_ledge',
       symbol: '?',
       kind: 'gate',
       attrId: 'movement_reward_tease'
-    });
-    if (highLedgePoint) {
-      this.addHighLedgeTeaser(highLedgePoint.x, highLedgePoint.y);
-    }
+    }, 'High Ledge teaser');
+    this.addHighLedgeTeaser(highLedgePoint.x, highLedgePoint.y);
   }
 
   private createPlayer(
@@ -536,7 +521,7 @@ export class RidgeScene extends Phaser.Scene {
     blockout: RidgeBlockoutMap,
     geometry: RidgeBlockoutGeometry
   ): void {
-    const spawn = getSpawnPoint(blockout);
+    const spawn = getRidgeBlockoutSpawnPoint(blockout);
     const playerRuntime = createSideViewPlayerRuntime({
       scene: this,
       start: {
@@ -939,17 +924,19 @@ export class RidgeScene extends Phaser.Scene {
     effect: RidgeInteractionEffect;
   }> {
     return RIDGE_TRAIL_CARD_TARGETS.map((target) => {
-      const anchorPoint = this.getTrailCardAnchorPoint(geometry, target.id);
-      const x = anchorPoint?.x ?? target.x;
-      const y = anchorPoint?.y ?? target.distanceAnchorY;
+      const anchorPoint = requireRidgeBlockoutAnchorPoint(
+        geometry,
+        target.anchor,
+        `${target.id} Trail Card`
+      );
       return {
         id: target.id,
         kind: 'trail-card',
-        x,
-        distanceAnchorY: y,
+        x: anchorPoint.x,
+        distanceAnchorY: anchorPoint.y,
         prompt: {
-          x,
-          y: y + TRAIL_CARD_PROMPT_OFFSET_Y
+          x: anchorPoint.x,
+          y: anchorPoint.y + TRAIL_CARD_PROMPT_OFFSET_Y
         },
         effect: {
           kind: 'openTrailCard',
@@ -957,51 +944,6 @@ export class RidgeScene extends Phaser.Scene {
         }
       };
     });
-  }
-
-  private getTrailCardAnchorPoint(
-    geometry: RidgeBlockoutGeometry,
-    targetId: RidgeTrailCardTargetId
-  ): RidgeBlockoutAnchorPoint | undefined {
-    switch (targetId) {
-      case 'stampede-sketch':
-        return this.findAnchorPoint(geometry, {
-          roomId: 'stampede_blanket',
-          symbol: '*',
-          kind: 'minigame',
-          attrId: 'stampede_sketch'
-        });
-      case 'telegraph-terrace':
-        return this.findAnchorPoint(geometry, {
-          roomId: 'telegraph_terrace',
-          symbol: '*',
-          kind: 'minigame',
-          attrId: 'telegraph_future'
-        });
-      case 'domino-desk':
-        return this.findAnchorPoint(geometry, {
-          roomId: 'domino_desk',
-          symbol: 'A',
-          attrId: 'domino_project_scrap'
-        });
-    }
-  }
-
-  private findAnchorPoint(
-    geometry: RidgeBlockoutGeometry,
-    filter: {
-      roomId: string;
-      symbol: string;
-      kind?: string;
-      attrId?: string;
-    }
-  ): RidgeBlockoutAnchorPoint | undefined {
-    return geometry.anchorPoints.find((point) =>
-      point.roomId === filter.roomId &&
-      point.symbol === filter.symbol &&
-      (!filter.kind || point.kind === filter.kind) &&
-      (!filter.attrId || point.attrs.id === filter.attrId)
-    );
   }
 
   private getRoomCenter(
@@ -1147,7 +1089,7 @@ export class RidgeScene extends Phaser.Scene {
     blockout: RidgeBlockoutMap,
     geometry: RidgeBlockoutGeometry
   ): void {
-    const spawn = getSpawnPoint(blockout);
+    const spawn = getRidgeBlockoutSpawnPoint(blockout);
     this.add.text(spawn.x, spawn.y - 260, 'Sketchbook Ridge', {
       fontFamily: 'monospace',
       fontSize: '34px',
@@ -1287,13 +1229,16 @@ function getColliderTop(collider: RidgeBlockoutCollider): number {
   return collider.y - collider.height / 2;
 }
 
-function getSpawnPoint(blockout: RidgeBlockoutMap): { x: number; y: number } {
-  const spawnRoom = findRidgeBlockoutRoom(blockout, blockout.spawn.roomId);
-  const spawnAnchor = spawnRoom?.anchors.find(
-    (anchor) => anchor.symbol === blockout.spawn.anchorSymbol
-  );
-  const point = spawnRoom && spawnAnchor
-    ? getRidgeBlockoutAnchorPoint(blockout, spawnRoom, spawnAnchor)
-    : undefined;
-  return point ?? { x: 120, y: 420 };
+function requireRidgeBlockoutAnchorPoint(
+  geometry: RidgeBlockoutGeometry,
+  selector: RidgeBlockoutAnchorSelector,
+  label: string
+): RidgeBlockoutAnchorPoint {
+  const point = findRidgeBlockoutAnchorPoint(geometry, selector);
+  if (!point) {
+    throw new Error(
+      `Ridge blockout anchor for ${label} could not be resolved in room "${selector.roomId}"`
+    );
+  }
+  return point;
 }

--- a/src/game/scenes/ridge/worldLayout.test.ts
+++ b/src/game/scenes/ridge/worldLayout.test.ts
@@ -1,64 +1,58 @@
 import { describe, expect, it } from 'vitest';
-import {
-  RIDGE_FLOOR_Y,
-  RIDGE_LANDMARKS,
-  RIDGE_PLAYER_RESUME_CLAMP,
-  RIDGE_PLAYER_START,
-  RIDGE_STAMPEDE_SHORTCUT,
-  RIDGE_TRAIL_CARD_TARGETS,
-  RIDGE_WORLD_WIDTH,
-  isRidgeStampedeShortcutAvailable
-} from './worldLayout';
 import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
 import { STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
-import { getRidgeLandmarkMemories } from './worldMemory';
 import { CICKA_INTERACTION_TARGET_ID } from './cicka/interaction';
+import {
+  RIDGE_BLOCKOUT,
+  deriveRidgeBlockoutGeometry,
+  findRidgeBlockoutAnchorPoint,
+  getRidgeBlockoutSpawnPoint,
+  isRidgeBlockoutShortcutAvailable
+} from './blockout';
+import { RIDGE_TRAIL_CARD_TARGETS } from './worldLayout';
 
 describe('ridge world layout', () => {
-  it('keeps the first movement shell flat and inside world bounds', () => {
-    expect(RIDGE_PLAYER_START.y).toBeLessThan(RIDGE_FLOOR_Y);
-    expect(RIDGE_PLAYER_RESUME_CLAMP.minX).toBeGreaterThan(0);
-    expect(RIDGE_PLAYER_RESUME_CLAMP.maxX).toBeLessThan(RIDGE_WORLD_WIDTH);
-    expect(RIDGE_PLAYER_RESUME_CLAMP.maxY).toBeLessThan(RIDGE_FLOOR_Y);
-  });
+  it('uses the Ridge Blockout source for first route order and spawn', () => {
+    const firstWalk = RIDGE_BLOCKOUT.routes.find((route) => route.id === 'first_walk');
 
-  it('stages the first Ridge shell landmarks in dependency order', () => {
-    expect(RIDGE_LANDMARKS.map((landmark) => landmark.kind)).toEqual([
-      'outskirts-artifact',
-      'cicka-perch',
-      'stampede-blanket',
-      'telegraph-bag',
-      'ridge-guide',
-      'relay-spire',
-      'domino-desk',
-      'high-ledge-teaser',
-      'relay-gate'
+    expect(firstWalk?.roomIds.slice(0, 4)).toEqual([
+      'outskirts',
+      'cicka_home',
+      'work_artifact',
+      'stampede_blanket'
     ]);
-    expect(RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'cicka-perch')?.label).toBe(
-      'Cicka Home'
-    );
+    expect(getRidgeBlockoutSpawnPoint(RIDGE_BLOCKOUT)).toMatchObject({
+      roomId: 'outskirts',
+      symbol: '1',
+      kind: 'player_spawn',
+      attrs: { id: 'start' }
+    });
   });
 
-  it('keeps Relay Spire visible early and reserves a later Relay Gate', () => {
-    const relay = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'relay-spire');
-    const relayGate = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'relay-gate');
+  it('resolves Cicka Home from the compiled blockout anchor', () => {
+    const geometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT);
+    const cickaPoint = findRidgeBlockoutAnchorPoint(geometry, {
+      roomId: 'cicka_home',
+      symbol: 'C',
+      kind: 'npc',
+      attrId: 'cicka'
+    });
 
-    expect(relay?.x).toBeGreaterThan(0);
-    expect(relay?.x).toBeLessThan(1100);
-    expect(relayGate?.x).toBeGreaterThan(relay?.x ?? 0);
-    expect(relayGate?.x).toBeLessThan(RIDGE_WORLD_WIDTH);
+    expect(cickaPoint).toMatchObject({
+      roomId: 'cicka_home',
+      symbol: 'C',
+      kind: 'npc',
+      attrs: { id: 'cicka' }
+    });
+    expect(cickaPoint?.x).toBeGreaterThan(0);
+    expect(cickaPoint?.y).toBeGreaterThan(0);
   });
 
-  it('makes the Stampede paper-fold shortcut available from Stampede progress only', () => {
-    expect(RIDGE_STAMPEDE_SHORTCUT.sourceStampId).toBe(STAMPEDE_SKETCH_RIDGE_STAMP_ID);
-    expect(RIDGE_STAMPEDE_SHORTCUT.startX).toBeGreaterThan(RIDGE_STAMPEDE_SHORTCUT.endX);
-    expect(isRidgeStampedeShortcutAvailable({ stampIds: [] })).toBe(false);
-    expect(isRidgeStampedeShortcutAvailable({
-      stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
-    })).toBe(true);
-  });
+  it('resolves Trail Card targets from their blockout anchors while keeping card content non-spatial', () => {
+    const geometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT);
+    const stampede = RIDGE_TRAIL_CARD_TARGETS.find((target) => target.id === 'stampede-sketch');
+    const unavailable = RIDGE_TRAIL_CARD_TARGETS.filter((target) => target.id !== 'stampede-sketch');
 
-  it('defines exactly three Trail Card targets for the first trigger contract', () => {
     expect(RIDGE_TRAIL_CARD_TARGETS.map((target) => target.id)).toEqual([
       'stampede-sketch',
       'telegraph-terrace',
@@ -67,48 +61,83 @@ describe('ridge world layout', () => {
     expect(RIDGE_TRAIL_CARD_TARGETS.map((target) => target.id)).not.toContain(
       CICKA_INTERACTION_TARGET_ID
     );
-    expect(RIDGE_TRAIL_CARD_TARGETS.map((target) => target.landmarkKind)).toEqual([
-      'stampede-blanket',
-      'telegraph-bag',
-      'domino-desk'
-    ]);
-  });
-
-  it('enables only the Stampede Trail Card for the movement-only prototype', () => {
-    const stampede = RIDGE_TRAIL_CARD_TARGETS.find((target) => target.id === 'stampede-sketch');
-    const unavailable = RIDGE_TRAIL_CARD_TARGETS.filter((target) => target.id !== 'stampede-sketch');
-
     expect(stampede?.card.enterSceneId).toBe(STAMPEDE_SKETCH_SCENE_ID);
     expect(stampede?.card.unavailableReason).toBeUndefined();
     expect(unavailable.every((target) => target.card.unavailableReason && !target.card.enterSceneId)).toBe(true);
+
+    if (!stampede) throw new Error('missing Stampede Trail Card target');
+    expect(findRidgeBlockoutAnchorPoint(geometry, stampede.anchor)).toMatchObject({
+      roomId: 'stampede_blanket',
+      symbol: '*',
+      kind: 'minigame',
+      attrs: { id: 'stampede_sketch' }
+    });
   });
 
-  it('keeps Ridge memory derivation anchored to the Stampede landmark', () => {
-    const cickaPerch = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'cicka-perch');
-    const stampedeBlanket = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'stampede-blanket');
-    const telegraphBag = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'telegraph-bag');
+  it('resolves the Relay promise from the Relay Gate blockout anchor', () => {
+    const geometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT);
+    const relayRoom = geometry.roomBounds.find((room) => room.roomId === 'relay_gate');
+    const relayPoint = findRidgeBlockoutAnchorPoint(geometry, {
+      roomId: 'relay_gate',
+      symbol: '?',
+      kind: 'gate',
+      attrId: 'relay_proof_slots'
+    });
 
-    expect(cickaPerch).toBeDefined();
-    expect(stampedeBlanket).toBeDefined();
-    expect(telegraphBag).toBeDefined();
-    if (!cickaPerch || !stampedeBlanket || !telegraphBag) return;
+    expect(relayRoom).toBeDefined();
+    expect(relayPoint).toMatchObject({
+      roomId: 'relay_gate',
+      symbol: '?',
+      kind: 'gate',
+      attrs: { id: 'relay_proof_slots' }
+    });
+    expect(relayPoint?.x).toBeGreaterThanOrEqual(relayRoom?.x ?? 0);
+    expect(relayPoint?.x).toBeLessThanOrEqual(
+      relayRoom ? relayRoom.x + relayRoom.width : Number.POSITIVE_INFINITY
+    );
+  });
 
-    expect(getRidgeLandmarkMemories(stampedeBlanket, { stampIds: [] })).toEqual([]);
-    expect(getRidgeLandmarkMemories(cickaPerch, { stampIds: [] })).toEqual([]);
-    expect(getRidgeLandmarkMemories(stampedeBlanket, {
+  it('derives the Stampede shortcut source and availability from blockout facts', () => {
+    const shortcut = RIDGE_BLOCKOUT.shortcuts.find((candidate) => candidate.id === 'stampede_sketch');
+    const lockedGeometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT, { stampIds: [] });
+    const unlockedGeometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT, {
       stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
-    }).map((memory) => memory.id)).toEqual([
-      'stampede-held-sticker',
-      'stampede-settled-swarm',
-      'stampede-glide-pip-decal'
-    ]);
-    expect(getRidgeLandmarkMemories(cickaPerch, {
+    });
+    const lockedConnection = lockedGeometry.shortcutConnections.find(
+      (connection) => connection.id === 'stampede_sketch'
+    );
+    const unlockedConnection = unlockedGeometry.shortcutConnections.find(
+      (connection) => connection.id === 'stampede_sketch'
+    );
+
+    expect(shortcut).toMatchObject({
+      id: 'stampede_sketch',
+      fromRoomId: 'switchback_shelf',
+      toRoomId: 'cicka_home',
+      kind: 'fall_steer_fold_drop'
+    });
+    expect(isRidgeBlockoutShortcutAvailable('stampede_sketch', { stampIds: [] })).toBe(false);
+    expect(isRidgeBlockoutShortcutAvailable('stampede_sketch', {
       stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
-    }).map((memory) => memory.id)).toEqual([
-      'cicka-stampede-note'
-    ]);
-    expect(getRidgeLandmarkMemories(telegraphBag, {
-      stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
-    })).toEqual([]);
+    })).toBe(true);
+    expect(lockedConnection).toMatchObject({
+      id: 'stampede_sketch',
+      unlocked: false,
+      movement: 'drop'
+    });
+    expect(lockedConnection?.from).toMatchObject({
+      roomId: 'switchback_shelf',
+      attrs: {
+        to: 'cicka_home',
+        requires: 'stampede_sketch'
+      }
+    });
+    expect(lockedConnection?.assistZones).toEqual([]);
+    expect(unlockedConnection).toMatchObject({
+      id: 'stampede_sketch',
+      unlocked: true,
+      movement: 'drop'
+    });
+    expect(unlockedConnection?.assistZones.some((zone) => zone.kind === 'drop')).toBe(true);
   });
 });

--- a/src/game/scenes/ridge/worldLayout.ts
+++ b/src/game/scenes/ridge/worldLayout.ts
@@ -1,16 +1,7 @@
 import type { TrailCardOverlayParams } from '@/game/overlays/trailCard/types';
 import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
 import { STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
-
-export const RIDGE_WORLD_WIDTH = 1800;
-export const RIDGE_FLOOR_Y = 520;
-export const RIDGE_PLAYER_START = { x: 120, y: RIDGE_FLOOR_Y - 80 } as const;
-export const RIDGE_PLAYER_RESUME_CLAMP = {
-  minX: 48,
-  maxX: RIDGE_WORLD_WIDTH - 48,
-  minY: 120,
-  maxY: RIDGE_FLOOR_Y - 20
-} as const;
+import type { RidgeBlockoutAnchorSelector } from './blockout';
 
 export type RidgeLandmarkKind =
   | 'outskirts-artifact'
@@ -23,13 +14,6 @@ export type RidgeLandmarkKind =
   | 'high-ledge-teaser'
   | 'relay-gate';
 
-export interface RidgeLandmark {
-  id: string;
-  kind: RidgeLandmarkKind;
-  x: number;
-  label: string;
-}
-
 export type RidgeTrailCardTargetId =
   | typeof STAMPEDE_SKETCH_RIDGE_STAMP_ID
   | 'telegraph-terrace'
@@ -38,114 +22,19 @@ export type RidgeTrailCardTargetId =
 export interface RidgeTrailCardTarget {
   id: RidgeTrailCardTargetId;
   landmarkKind: Extract<RidgeLandmarkKind, 'stampede-blanket' | 'telegraph-bag' | 'domino-desk'>;
-  x: number;
-  distanceAnchorY: number;
-  prompt: {
-    x: number;
-    y: number;
-  };
+  anchor: RidgeBlockoutAnchorSelector;
   card: TrailCardOverlayParams;
 }
-
-export interface RidgeShortcut {
-  id: string;
-  sourceStampId: typeof STAMPEDE_SKETCH_RIDGE_STAMP_ID;
-  startX: number;
-  endX: number;
-  y: number;
-  width: number;
-  height: number;
-  label: string;
-}
-
-const RIDGE_STAMPEDE_SHORTCUT_START_X = 520;
-const RIDGE_STAMPEDE_SHORTCUT_END_X = 282;
-const RIDGE_STAMPEDE_SHORTCUT_FORGIVENESS_WIDTH = 42;
-
-export const RIDGE_STAMPEDE_SHORTCUT = {
-  id: 'stampede-paper-fold',
-  sourceStampId: STAMPEDE_SKETCH_RIDGE_STAMP_ID,
-  startX: RIDGE_STAMPEDE_SHORTCUT_START_X,
-  endX: RIDGE_STAMPEDE_SHORTCUT_END_X,
-  y: RIDGE_FLOOR_Y - 134,
-  width: Math.abs(RIDGE_STAMPEDE_SHORTCUT_START_X - RIDGE_STAMPEDE_SHORTCUT_END_X)
-    + RIDGE_STAMPEDE_SHORTCUT_FORGIVENESS_WIDTH,
-  height: 18,
-  label: 'Stampede paper fold'
-} as const satisfies RidgeShortcut;
-
-export function isRidgeStampedeShortcutAvailable(
-  ridgeProgress: { stampIds: readonly string[] }
-): boolean {
-  return ridgeProgress.stampIds.includes(RIDGE_STAMPEDE_SHORTCUT.sourceStampId);
-}
-
-export const RIDGE_LANDMARKS: readonly RidgeLandmark[] = [
-  {
-    id: 'outskirts-artifact-slot',
-    kind: 'outskirts-artifact',
-    x: 120,
-    label: 'Outskirts'
-  },
-  {
-    id: 'cicka-first-perch',
-    kind: 'cicka-perch',
-    x: 280,
-    label: 'Cicka Home'
-  },
-  {
-    id: 'stampede-sketch-blanket',
-    kind: 'stampede-blanket',
-    x: 520,
-    label: 'Stampede'
-  },
-  {
-    id: 'telegraph-terrace-bag',
-    kind: 'telegraph-bag',
-    x: 735,
-    label: 'Telegraph'
-  },
-  {
-    id: 'ridge-guide',
-    kind: 'ridge-guide',
-    x: 900,
-    label: 'Guide'
-  },
-  {
-    id: 'relay-spire',
-    kind: 'relay-spire',
-    x: 980,
-    label: 'Relay Spire'
-  },
-  {
-    id: 'domino-desk-elevator',
-    kind: 'domino-desk',
-    x: 1240,
-    label: 'Domino Desk'
-  },
-  {
-    id: 'paper-high-ledge-teaser',
-    kind: 'high-ledge-teaser',
-    x: 1440,
-    label: 'High Ledge'
-  },
-  {
-    id: 'relay-gate',
-    kind: 'relay-gate',
-    x: 1640,
-    label: 'Relay Gate'
-  }
-];
 
 export const RIDGE_TRAIL_CARD_TARGETS: readonly RidgeTrailCardTarget[] = [
   {
     id: STAMPEDE_SKETCH_RIDGE_STAMP_ID,
     landmarkKind: 'stampede-blanket',
-    x: 520,
-    distanceAnchorY: RIDGE_FLOOR_Y - 56,
-    prompt: {
-      x: 520,
-      y: RIDGE_FLOOR_Y - 118
+    anchor: {
+      roomId: 'stampede_blanket',
+      symbol: '*',
+      kind: 'minigame',
+      attrId: 'stampede_sketch'
     },
     card: {
       title: 'Stampede Sketch',
@@ -158,11 +47,11 @@ export const RIDGE_TRAIL_CARD_TARGETS: readonly RidgeTrailCardTarget[] = [
   {
     id: 'telegraph-terrace',
     landmarkKind: 'telegraph-bag',
-    x: 735,
-    distanceAnchorY: RIDGE_FLOOR_Y - 58,
-    prompt: {
-      x: 735,
-      y: RIDGE_FLOOR_Y - 130
+    anchor: {
+      roomId: 'telegraph_terrace',
+      symbol: '*',
+      kind: 'minigame',
+      attrId: 'telegraph_future'
     },
     card: {
       title: 'Telegraph Terrace',
@@ -175,11 +64,10 @@ export const RIDGE_TRAIL_CARD_TARGETS: readonly RidgeTrailCardTarget[] = [
   {
     id: 'domino-desk',
     landmarkKind: 'domino-desk',
-    x: 1240,
-    distanceAnchorY: RIDGE_FLOOR_Y - 62,
-    prompt: {
-      x: 1240,
-      y: RIDGE_FLOOR_Y - 132
+    anchor: {
+      roomId: 'domino_desk',
+      symbol: 'A',
+      attrId: 'domino_project_scrap'
     },
     card: {
       title: 'Domino Desk',

--- a/src/game/scenes/ridge/worldMemory.test.ts
+++ b/src/game/scenes/ridge/worldMemory.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
-import { RIDGE_LANDMARKS } from './worldLayout';
 import {
   getRidgeLandmarkMemories,
   getRidgeWorldMemories,
@@ -32,27 +31,18 @@ describe('ridge world memory', () => {
   });
 
   it('anchors Stampede memories to the blanket and Cicka perch without changing unrelated landmarks', () => {
-    const cickaPerch = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'cicka-perch');
-    const stampedeBlanket = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'stampede-blanket');
-    const telegraphBag = RIDGE_LANDMARKS.find((landmark) => landmark.kind === 'telegraph-bag');
-
-    expect(cickaPerch).toBeDefined();
-    expect(stampedeBlanket).toBeDefined();
-    expect(telegraphBag).toBeDefined();
-    if (!cickaPerch || !stampedeBlanket || !telegraphBag) return;
-
     const ridgeProgress = {
       stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
     };
 
-    expect(getRidgeLandmarkMemories(stampedeBlanket, ridgeProgress).map((memory) => memory.id)).toEqual([
+    expect(getRidgeLandmarkMemories('stampede-blanket', ridgeProgress).map((memory) => memory.id)).toEqual([
       'stampede-held-sticker',
       'stampede-settled-swarm',
       'stampede-glide-pip-decal'
     ]);
-    expect(getRidgeLandmarkMemories(cickaPerch, ridgeProgress).map((memory) => memory.id)).toEqual([
+    expect(getRidgeLandmarkMemories('cicka-perch', ridgeProgress).map((memory) => memory.id)).toEqual([
       'cicka-stampede-note'
     ]);
-    expect(getRidgeLandmarkMemories(telegraphBag, ridgeProgress)).toEqual([]);
+    expect(getRidgeLandmarkMemories('telegraph-bag', ridgeProgress)).toEqual([]);
   });
 });

--- a/src/game/scenes/ridge/worldMemory.ts
+++ b/src/game/scenes/ridge/worldMemory.ts
@@ -1,6 +1,6 @@
 import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
 import type { BridgeRidgeProgressState, RidgeStampId } from '@/game/bridge/store';
-import type { RidgeLandmark, RidgeLandmarkKind } from './worldLayout';
+import type { RidgeLandmarkKind } from './worldLayout';
 
 type RidgeMemorySource =
   | {
@@ -75,11 +75,11 @@ export function getRidgeWorldMemories(
 }
 
 export function getRidgeLandmarkMemories(
-  landmark: Pick<RidgeLandmark, 'kind'>,
+  landmarkKind: RidgeLandmarkKind,
   ridgeProgress: Pick<BridgeRidgeProgressState, 'stampIds'>
 ): readonly RidgeWorldMemory[] {
   return getRidgeWorldMemories(ridgeProgress).filter(
-    (memory) => memory.landmarkKind === landmark.kind
+    (memory) => memory.landmarkKind === landmarkKind
   );
 }
 


### PR DESCRIPTION
## Summary
- Tighten Ridge spatial sourcing so runtime positions come from compiled blockout facts instead of flat layout constants.
- Shrink the Ridge layout surface to non-spatial Trail Card content and update related memory/perch helpers.
- Add and update research, planning, and team docs for the new level-design workflow and asset staging guidance.

## Testing
- `npm test -- --run src/game/scenes/ridge`
- `npm run check:types`
- `npm run build`
- Local browser smoke on Ridge start and Trail Card interaction

Fixes #60 