### PR TITLE
Add compiled Ridge Blockout facts and migrate Ridge consumers

### DIFF
--- a/src/game/scenes/ridge/blockout/facts.test.ts
+++ b/src/game/scenes/ridge/blockout/facts.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+import { RIDGE_BLOCKOUT } from './ridgeBlockout';
+import {
+  compileRidgeBlockoutFacts,
+  findRidgeBlockoutFactAnchor
+} from './facts';
+
+describe('ridge blockout facts', () => {
+  it('compiles the first route order and route links', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const firstWalk = facts.routes.find((route) => route.id === 'first_walk');
+
+    expect(firstWalk?.roomIds.slice(0, 4)).toEqual([
+      'outskirts',
+      'cicka_home',
+      'work_artifact',
+      'stampede_blanket'
+    ]);
+    expect(firstWalk?.links.slice(0, 3)).toEqual([
+      { fromRoomId: 'outskirts', toRoomId: 'cicka_home' },
+      { fromRoomId: 'cicka_home', toRoomId: 'work_artifact' },
+      { fromRoomId: 'work_artifact', toRoomId: 'stampede_blanket' }
+    ]);
+  });
+
+  it('resolves spawn and Cicka Home anchors as typed facts', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const cicka = findRidgeBlockoutFactAnchor(facts, {
+      roomId: 'cicka_home',
+      symbol: 'C',
+      kind: 'npc',
+      attrId: 'cicka'
+    });
+
+    expect(facts.spawn).toMatchObject({
+      roomId: 'outskirts',
+      symbol: '1',
+      kind: 'player_spawn',
+      id: 'start'
+    });
+    expect(cicka).toMatchObject({
+      roomId: 'cicka_home',
+      symbol: 'C',
+      kind: 'npc',
+      id: 'cicka'
+    });
+    expect(cicka?.x).toBeGreaterThan(0);
+    expect(cicka?.y).toBeGreaterThan(0);
+  });
+
+  it('exposes Trail Card and Relay anchors without raw attr reads', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const stampede = findRidgeBlockoutFactAnchor(facts, {
+      roomId: 'stampede_blanket',
+      symbol: '*',
+      kind: 'minigame',
+      attrId: 'stampede_sketch'
+    });
+    const relay = findRidgeBlockoutFactAnchor(facts, {
+      roomId: 'relay_gate',
+      symbol: '?',
+      kind: 'gate',
+      attrId: 'relay_proof_slots'
+    });
+    const relayRoom = facts.rooms.find((room) => room.id === 'relay_gate');
+
+    expect(stampede).toMatchObject({
+      roomId: 'stampede_blanket',
+      id: 'stampede_sketch'
+    });
+    expect(relay).toMatchObject({
+      roomId: 'relay_gate',
+      id: 'relay_proof_slots'
+    });
+    expect(relay?.x).toBeGreaterThanOrEqual(relayRoom?.bounds.x ?? 0);
+    expect(relay?.x).toBeLessThanOrEqual(
+      relayRoom ? relayRoom.bounds.x + relayRoom.bounds.width : Number.POSITIVE_INFINITY
+    );
+  });
+
+  it('resolves future-route promises as typed route facts', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const underpath = facts.futureRoutes.find((route) => route.id === 'cicka_underpath');
+    const highLedge = facts.futureRoutes.find((route) => route.id === 'high_ledge');
+
+    expect(underpath).toMatchObject({
+      kind: 'future_route',
+      roomIds: ['outskirts', 'underpath', 'cicka_home']
+    });
+    expect(underpath?.links).toContainEqual({
+      fromRoomId: 'underpath',
+      toRoomId: 'cicka_home'
+    });
+    expect(highLedge?.links).toEqual([
+      { fromRoomId: 'domino_desk', toRoomId: 'high_ledge' }
+    ]);
+  });
+
+  it('resolves Stampede shortcut source, gate, and availability from progress', () => {
+    const lockedFacts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT, { stampIds: [] });
+    const unlockedFacts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT, {
+      stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
+    });
+    const lockedShortcut = lockedFacts.shortcuts.find((shortcut) => shortcut.id === 'stampede_sketch');
+    const unlockedShortcut = unlockedFacts.shortcuts.find((shortcut) => shortcut.id === 'stampede_sketch');
+
+    expect(lockedShortcut).toMatchObject({
+      id: 'stampede_sketch',
+      fromRoomId: 'switchback_shelf',
+      toRoomId: 'cicka_home',
+      kind: 'fall_steer_fold_drop',
+      movement: 'drop',
+      requiredStampId: STAMPEDE_SKETCH_RIDGE_STAMP_ID,
+      available: false
+    });
+    expect(lockedShortcut?.from).toMatchObject({
+      roomId: 'switchback_shelf',
+      targetRoomId: 'cicka_home',
+      requires: 'stampede_sketch',
+      movement: 'drop'
+    });
+    expect(unlockedShortcut).toMatchObject({
+      id: 'stampede_sketch',
+      movement: 'drop',
+      available: true
+    });
+  });
+
+  it('exposes Cicka Home mutation declarations as typed facts', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+
+    expect(facts.homeMutations).toContainEqual(expect.objectContaining({
+      id: 'stampede_sketch',
+      adds: 'stampede_note',
+      opens: 'fold_drop_landing'
+    }));
+    expect(facts.homeMutations).toContainEqual(expect.objectContaining({
+      id: 'work_artifact',
+      adds: 'work_display'
+    }));
+  });
+});

--- a/src/game/scenes/ridge/blockout/facts.ts
+++ b/src/game/scenes/ridge/blockout/facts.ts
@@ -1,0 +1,229 @@
+import {
+  RIDGE_BLOCKOUT_TRAVERSAL_MOVEMENTS,
+  type RidgeBlockoutMap,
+  type RidgeBlockoutTraversalMovement
+} from './parser';
+import {
+  deriveRidgeBlockoutGeometry,
+  type RidgeBlockoutAnchorPoint,
+  type RidgeBlockoutAnchorSelector,
+  type RidgeBlockoutBounds,
+  type RidgeBlockoutGeometry,
+  type RidgeBlockoutRoomBounds
+} from './geometry';
+import {
+  getRidgeBlockoutShortcutRequiredStampId,
+  isRidgeBlockoutShortcutAvailable
+} from './progress';
+
+export type RidgeBlockoutRouteKind = 'route' | 'future_route';
+
+export interface RidgeRouteLinkFact {
+  fromRoomId: string;
+  toRoomId: string;
+}
+
+export interface RidgeAnchorFact extends RidgeBlockoutAnchorPoint {
+  id?: string;
+  label?: string;
+  targetRoomId?: string;
+  requires?: string;
+  movement?: RidgeBlockoutTraversalMovement;
+  reward?: string;
+}
+
+export interface RidgeRoomBeatFact {
+  id: string;
+  title: string;
+  theme?: string;
+  mood?: string;
+  links: readonly string[];
+  props: readonly string[];
+  declarations: readonly string[];
+  bounds: RidgeBlockoutRoomBounds;
+  anchors: readonly RidgeAnchorFact[];
+}
+
+export interface RidgeRouteFact {
+  id: string;
+  kind: RidgeBlockoutRouteKind;
+  roomIds: readonly string[];
+  links: readonly RidgeRouteLinkFact[];
+}
+
+export interface RidgeShortcutFact {
+  id: string;
+  fromRoomId: string;
+  toRoomId: string;
+  kind?: string;
+  movement: RidgeBlockoutTraversalMovement;
+  requiredStampId?: string;
+  available: boolean;
+  from?: RidgeAnchorFact;
+  to: {
+    x: number;
+    y: number;
+  };
+}
+
+export interface RidgeHomeMutationFact {
+  id: string;
+  adds?: string;
+  opens?: string;
+  attrs: Readonly<Record<string, string>>;
+}
+
+export interface RidgeBlockoutFacts {
+  worldId: string;
+  title: string;
+  cell: number;
+  bounds: RidgeBlockoutBounds;
+  spawn: RidgeAnchorFact;
+  rooms: readonly RidgeRoomBeatFact[];
+  anchors: readonly RidgeAnchorFact[];
+  routes: readonly RidgeRouteFact[];
+  futureRoutes: readonly RidgeRouteFact[];
+  shortcuts: readonly RidgeShortcutFact[];
+  homeMutations: readonly RidgeHomeMutationFact[];
+}
+
+export interface RidgeBlockoutFactsOptions {
+  stampIds?: readonly string[];
+  geometry?: RidgeBlockoutGeometry;
+}
+
+export function compileRidgeBlockoutFacts(
+  map: RidgeBlockoutMap,
+  options: RidgeBlockoutFactsOptions = {}
+): RidgeBlockoutFacts {
+  const geometry = options.geometry ?? deriveRidgeBlockoutGeometry(map, {
+    stampIds: options.stampIds
+  });
+  const anchors = geometry.anchorPoints.map(toAnchorFact);
+  const rooms = map.rooms.map((room) => {
+    const bounds = geometry.roomBounds.find((candidate) => candidate.roomId === room.id);
+    if (!bounds) {
+      throw new Error(`Ridge blockout room "${room.id}" could not be compiled into facts`);
+    }
+    return {
+      id: room.id,
+      title: room.title,
+      theme: room.theme,
+      mood: room.mood,
+      links: room.links,
+      props: room.props,
+      declarations: room.declarations,
+      bounds,
+      anchors: anchors.filter((anchor) => anchor.roomId === room.id)
+    };
+  });
+  const spawn = findRidgeBlockoutFactAnchor({ anchors }, {
+    roomId: map.spawn.roomId,
+    symbol: map.spawn.anchorSymbol
+  });
+  if (!spawn) {
+    throw new Error(
+      `Ridge blockout spawn anchor "${map.spawn.anchorSymbol}" in room "${map.spawn.roomId}" could not be compiled into facts`
+    );
+  }
+
+  return {
+    worldId: map.worldId,
+    title: map.title,
+    cell: map.cell,
+    bounds: geometry.bounds,
+    spawn,
+    rooms,
+    anchors,
+    routes: map.routes.map((route) => toRouteFact(route, 'route')),
+    futureRoutes: map.futureRoutes.map((route) => toRouteFact(route, 'future_route')),
+    shortcuts: map.shortcuts.map((shortcut) => {
+      const connection = geometry.shortcutConnections.find((candidate) => candidate.id === shortcut.id);
+      const source = anchors.find((anchor) =>
+        anchor.roomId === shortcut.fromRoomId &&
+        anchor.targetRoomId === shortcut.toRoomId &&
+        anchor.requires === shortcut.id
+      );
+      const available = options.geometry && options.stampIds === undefined
+        ? connection?.unlocked ?? false
+        : isRidgeBlockoutShortcutAvailable(shortcut.id, {
+          stampIds: options.stampIds ?? []
+        });
+      return {
+        id: shortcut.id,
+        fromRoomId: shortcut.fromRoomId,
+        toRoomId: shortcut.toRoomId,
+        kind: shortcut.kind,
+        movement: connection?.movement ?? 'ramp',
+        requiredStampId: getRidgeBlockoutShortcutRequiredStampId(shortcut.id),
+        available,
+        from: source,
+        to: connection?.to ?? getRoomCenter(geometry, shortcut.toRoomId) ?? { x: 0, y: 0 }
+      };
+    }),
+    homeMutations: map.homeMutations.map((mutation) => ({
+      id: mutation.id,
+      adds: mutation.attrs.adds,
+      opens: mutation.attrs.opens,
+      attrs: mutation.attrs
+    }))
+  };
+}
+
+export function findRidgeBlockoutFactAnchor(
+  facts: Pick<RidgeBlockoutFacts, 'anchors'>,
+  selector: RidgeBlockoutAnchorSelector
+): RidgeAnchorFact | undefined {
+  return facts.anchors.find((point) =>
+    point.roomId === selector.roomId &&
+    (!selector.symbol || point.symbol === selector.symbol) &&
+    (!selector.kind || point.kind === selector.kind) &&
+    (!selector.attrId || point.id === selector.attrId)
+  );
+}
+
+function toAnchorFact(point: RidgeBlockoutAnchorPoint): RidgeAnchorFact {
+  return {
+    ...point,
+    id: point.attrs.id,
+    label: point.attrs.label,
+    targetRoomId: point.attrs.to,
+    requires: point.attrs.requires,
+    movement: parseTraversalMovement(point.attrs.movement),
+    reward: point.attrs.reward
+  };
+}
+
+function toRouteFact(
+  route: { id: string; roomIds: readonly string[] },
+  kind: RidgeBlockoutRouteKind
+): RidgeRouteFact {
+  return {
+    id: route.id,
+    kind,
+    roomIds: route.roomIds,
+    links: route.roomIds.slice(0, -1).map((roomId, index) => ({
+      fromRoomId: roomId,
+      toRoomId: route.roomIds[index + 1] ?? ''
+    }))
+  };
+}
+
+function parseTraversalMovement(value: string | undefined): RidgeBlockoutTraversalMovement | undefined {
+  return value && RIDGE_BLOCKOUT_TRAVERSAL_MOVEMENTS.has(value)
+    ? value as RidgeBlockoutTraversalMovement
+    : undefined;
+}
+
+function getRoomCenter(
+  geometry: Pick<RidgeBlockoutGeometry, 'roomBounds'>,
+  roomId: string
+): { x: number; y: number } | undefined {
+  const room = geometry.roomBounds.find((candidate) => candidate.roomId === roomId);
+  return room
+    ? {
+      x: room.x + room.width / 2,
+      y: room.y + room.height / 2
+    }
+    : undefined;
+}

--- a/src/game/scenes/ridge/blockout/geometry.ts
+++ b/src/game/scenes/ridge/blockout/geometry.ts
@@ -1,4 +1,3 @@
-import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
 import {
   RIDGE_BLOCKOUT_LADDER_SYMBOL,
   RIDGE_BLOCKOUT_TRAVERSAL_MOVEMENTS,
@@ -10,6 +9,8 @@ import {
   type RidgeBlockoutRect,
   type RidgeBlockoutRoom
 } from './parser';
+export { isRidgeBlockoutShortcutAvailable } from './progress';
+import { isRidgeBlockoutShortcutAvailable } from './progress';
 
 export type RidgeBlockoutColliderKind =
   | 'solid'
@@ -130,10 +131,6 @@ export interface RidgeBlockoutGeometryOptions {
 }
 
 const COLLIDER_SYMBOLS = new Set(['#', '_']);
-const SHORTCUT_STAMP_IDS: Readonly<Record<string, string>> = {
-  stampede_sketch: STAMPEDE_SKETCH_RIDGE_STAMP_ID
-};
-
 export function deriveRidgeBlockoutGeometry(
   map: RidgeBlockoutMap,
   options: RidgeBlockoutGeometryOptions = {}
@@ -234,14 +231,6 @@ export function getRidgeBlockoutSpawnPoint(map: RidgeBlockoutMap): RidgeBlockout
   }
 
   return point;
-}
-
-export function isRidgeBlockoutShortcutAvailable(
-  shortcutId: string,
-  progress: { stampIds: readonly string[] }
-): boolean {
-  const stampId = SHORTCUT_STAMP_IDS[shortcutId];
-  return stampId ? progress.stampIds.includes(stampId) : false;
 }
 
 function deriveRoomBounds(map: RidgeBlockoutMap): readonly RidgeBlockoutRoomBounds[] {

--- a/src/game/scenes/ridge/blockout/index.ts
+++ b/src/game/scenes/ridge/blockout/index.ts
@@ -1,3 +1,5 @@
+export * from './facts';
 export * from './geometry';
 export * from './parser';
+export * from './progress';
 export * from './ridgeBlockout';

--- a/src/game/scenes/ridge/blockout/progress.ts
+++ b/src/game/scenes/ridge/blockout/progress.ts
@@ -1,0 +1,17 @@
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+
+const SHORTCUT_STAMP_IDS: Readonly<Record<string, string>> = {
+  stampede_sketch: STAMPEDE_SKETCH_RIDGE_STAMP_ID
+};
+
+export function getRidgeBlockoutShortcutRequiredStampId(shortcutId: string): string | undefined {
+  return SHORTCUT_STAMP_IDS[shortcutId];
+}
+
+export function isRidgeBlockoutShortcutAvailable(
+  shortcutId: string,
+  progress: { stampIds: readonly string[] }
+): boolean {
+  const stampId = getRidgeBlockoutShortcutRequiredStampId(shortcutId);
+  return stampId ? progress.stampIds.includes(stampId) : false;
+}

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -28,17 +28,17 @@ import {
 } from '@/game/sharedSceneRuntime/interactions/InteriorInteractionRuntime';
 import {
   RIDGE_BLOCKOUT,
+  compileRidgeBlockoutFacts,
   deriveRidgeBlockoutGeometry,
-  findRidgeBlockoutAnchorPoint,
-  getRidgeBlockoutSpawnPoint,
-  type RidgeBlockoutAnchorSelector,
   type RidgeBlockoutAnchorPoint,
   type RidgeBlockoutAssistZone,
   type RidgeBlockoutBounds,
   type RidgeBlockoutCollider,
   type RidgeBlockoutGeometry,
-  type RidgeBlockoutMap,
-  type RidgeBlockoutRoomBounds
+  type RidgeBlockoutFacts,
+  type RidgeBlockoutRoomBounds,
+  type RidgeAnchorFact,
+  findRidgeBlockoutFactAnchor
 } from '../blockout';
 import {
   RIDGE_TRAIL_CARD_TARGETS,
@@ -172,6 +172,10 @@ export class RidgeScene extends Phaser.Scene {
     const geometry = deriveRidgeBlockoutGeometry(blockout, {
       stampIds: ridgeProgress.stampIds
     });
+    const facts = compileRidgeBlockoutFacts(blockout, {
+      stampIds: ridgeProgress.stampIds,
+      geometry
+    });
     this.ridgeGeometry = geometry;
     this.ridgeSolidBlockers = geometry.gridColliders.filter(isSolidCollider);
     this.ridgeMantleTargets = geometry.colliders.filter(isMantleTargetCollider);
@@ -190,23 +194,23 @@ export class RidgeScene extends Phaser.Scene {
     const worldMemories = getRidgeWorldMemories(ridgeProgress);
     this.addBackdrop(geometry.bounds);
     this.addRoomBounds(geometry.roomBounds);
-    this.addFutureRoutePromises(blockout, geometry);
+    this.addFutureRoutePromises(facts);
     this.addTraversalConnectorVisuals(geometry);
     const platforms = this.addBlockoutColliders(geometry);
-    this.addShortcutPromises(geometry);
+    this.addShortcutPromises(facts);
     this.addAnchorMarkers(geometry);
     this.addLandmarksFromBlockout(
-      geometry,
+      facts,
       messages.scenes.ridge.memory.stampedeFirstClearLabel,
       messages.scenes.ridge.memory.cickaWalkByBark,
       worldMemories
     );
-    this.addPlaceholderCopy(blockout, geometry);
-    this.createPlayer(platforms, blockout, geometry);
+    this.addPlaceholderCopy(facts);
+    this.createPlayer(platforms, facts, geometry);
     this.createRidgeInteractions(
       messages.navigation.interact,
       messages.scenes.ridge.cicka.interaction,
-      geometry
+      facts
     );
     this.setPaused(this.isPaused);
     this.playerRuntime?.syncAppearance();
@@ -312,17 +316,14 @@ export class RidgeScene extends Phaser.Scene {
     });
   }
 
-  private addFutureRoutePromises(
-    blockout: RidgeBlockoutMap,
-    geometry: RidgeBlockoutGeometry
-  ): void {
+  private addFutureRoutePromises(facts: RidgeBlockoutFacts): void {
     const graphics = this.add.graphics().setDepth(-8);
     graphics.lineStyle(3, 0x596f8f, 0.18);
 
-    blockout.futureRoutes.forEach((route) => {
-      route.roomIds.slice(0, -1).forEach((roomId, index) => {
-        const from = this.getRoomCenter(geometry, roomId);
-        const to = this.getRoomCenter(geometry, route.roomIds[index + 1] ?? '');
+    facts.futureRoutes.forEach((route) => {
+      route.links.forEach((link) => {
+        const from = this.getRoomCenter(facts, link.fromRoomId);
+        const to = this.getRoomCenter(facts, link.toRoomId);
         if (!from || !to) return;
         graphics.strokeLineShape(new Phaser.Geom.Line(from.x, from.y, to.x, to.y));
       });
@@ -390,10 +391,11 @@ export class RidgeScene extends Phaser.Scene {
       .setDepth(style.depth);
   }
 
-  private addShortcutPromises(geometry: RidgeBlockoutGeometry): void {
-    geometry.shortcutConnections.forEach((connection) => {
+  private addShortcutPromises(facts: RidgeBlockoutFacts): void {
+    facts.shortcuts.forEach((connection) => {
+      if (!connection.from) return;
       const graphics = this.add.graphics().setDepth(6);
-      graphics.lineStyle(4, connection.unlocked ? 0xf0d35f : 0x1f1f1d, connection.unlocked ? 0.34 : 0.16);
+      graphics.lineStyle(4, connection.available ? 0xf0d35f : 0x1f1f1d, connection.available ? 0.34 : 0.16);
       graphics.strokeLineShape(new Phaser.Geom.Line(
         connection.from.x,
         connection.from.y,
@@ -401,7 +403,7 @@ export class RidgeScene extends Phaser.Scene {
         connection.to.y
       ));
 
-      if (!connection.unlocked) {
+      if (!connection.available) {
         const centerX = (connection.from.x + connection.to.x) / 2;
         const centerY = (connection.from.y + connection.to.y) / 2;
         this.add.rectangle(centerX, centerY, 96, 18, 0xf7f1df, 0.24)
@@ -429,14 +431,14 @@ export class RidgeScene extends Phaser.Scene {
   }
 
   private addLandmarksFromBlockout(
-    geometry: RidgeBlockoutGeometry,
+    facts: RidgeBlockoutFacts,
     stampedeFirstClearLabel: string,
     cickaWalkByLine: string,
     worldMemories: readonly RidgeWorldMemory[]
   ): void {
     this.cickaPerch = undefined;
 
-    const cickaPoint = requireRidgeBlockoutAnchorPoint(geometry, {
+    const cickaPoint = requireRidgeBlockoutFactAnchor(facts, {
       roomId: 'cicka_home',
       symbol: 'C',
       kind: 'npc',
@@ -455,14 +457,14 @@ export class RidgeScene extends Phaser.Scene {
       walkByLine: cickaWalkByLine
     });
 
-    const outskirtsArtifact = requireRidgeBlockoutAnchorPoint(geometry, {
+    const outskirtsArtifact = requireRidgeBlockoutFactAnchor(facts, {
       roomId: 'outskirts',
       symbol: 'A',
       attrId: 'city_edge_memory'
     }, 'Outskirts artifact');
     this.addOutskirtsArtifactSlot(outskirtsArtifact.x, outskirtsArtifact.y);
 
-    const stampedePoint = requireRidgeBlockoutAnchorPoint(geometry, {
+    const stampedePoint = requireRidgeBlockoutFactAnchor(facts, {
       roomId: 'stampede_blanket',
       symbol: '*',
       kind: 'minigame',
@@ -475,7 +477,7 @@ export class RidgeScene extends Phaser.Scene {
       worldMemories.filter((memory) => memory.landmarkKind === 'stampede-blanket')
     );
 
-    const telegraphPoint = requireRidgeBlockoutAnchorPoint(geometry, {
+    const telegraphPoint = requireRidgeBlockoutFactAnchor(facts, {
       roomId: 'telegraph_terrace',
       symbol: '*',
       kind: 'minigame',
@@ -483,7 +485,7 @@ export class RidgeScene extends Phaser.Scene {
     }, 'Telegraph Terrace bag');
     this.addTelegraphBag(telegraphPoint.x, telegraphPoint.y);
 
-    const guidePoint = requireRidgeBlockoutAnchorPoint(geometry, {
+    const guidePoint = requireRidgeBlockoutFactAnchor(facts, {
       roomId: 'guide_overlook',
       symbol: 'N',
       kind: 'npc',
@@ -491,7 +493,7 @@ export class RidgeScene extends Phaser.Scene {
     }, 'Ridge guide');
     this.addRidgeGuide(guidePoint.x, guidePoint.y);
 
-    const relayPoint = requireRidgeBlockoutAnchorPoint(geometry, {
+    const relayPoint = requireRidgeBlockoutFactAnchor(facts, {
       roomId: 'relay_gate',
       symbol: '?',
       kind: 'gate',
@@ -500,14 +502,14 @@ export class RidgeScene extends Phaser.Scene {
     this.addRelayGate(relayPoint.x, relayPoint.y);
     this.addRelaySpire(relayPoint.x + 230, relayPoint.y - 180);
 
-    const dominoPoint = requireRidgeBlockoutAnchorPoint(geometry, {
+    const dominoPoint = requireRidgeBlockoutFactAnchor(facts, {
       roomId: 'domino_desk',
       symbol: 'A',
       attrId: 'domino_project_scrap'
     }, 'Domino Desk');
     this.addDominoDesk(dominoPoint.x, dominoPoint.y);
 
-    const highLedgePoint = requireRidgeBlockoutAnchorPoint(geometry, {
+    const highLedgePoint = requireRidgeBlockoutFactAnchor(facts, {
       roomId: 'high_ledge',
       symbol: '?',
       kind: 'gate',
@@ -518,10 +520,10 @@ export class RidgeScene extends Phaser.Scene {
 
   private createPlayer(
     platforms: readonly Phaser.GameObjects.Zone[],
-    blockout: RidgeBlockoutMap,
+    facts: RidgeBlockoutFacts,
     geometry: RidgeBlockoutGeometry
   ): void {
-    const spawn = getRidgeBlockoutSpawnPoint(blockout);
+    const spawn = facts.spawn;
     const playerRuntime = createSideViewPlayerRuntime({
       scene: this,
       start: {
@@ -880,7 +882,7 @@ export class RidgeScene extends Phaser.Scene {
   private createRidgeInteractions(
     promptText: string,
     cickaInteractionCopy: CickaInteractionCopy,
-    geometry: RidgeBlockoutGeometry
+    facts: RidgeBlockoutFacts
   ): void {
     this.interactPrompt?.destroy();
 
@@ -908,13 +910,13 @@ export class RidgeScene extends Phaser.Scene {
             )
           })
         }] : []),
-        ...this.createTrailCardTargets(geometry)
+        ...this.createTrailCardTargets(facts)
       ]
     });
   }
 
   private createTrailCardTargets(
-    geometry: RidgeBlockoutGeometry
+    facts: RidgeBlockoutFacts
   ): Array<{
     id: RidgeTrailCardTargetId;
     kind: 'trail-card';
@@ -924,8 +926,8 @@ export class RidgeScene extends Phaser.Scene {
     effect: RidgeInteractionEffect;
   }> {
     return RIDGE_TRAIL_CARD_TARGETS.map((target) => {
-      const anchorPoint = requireRidgeBlockoutAnchorPoint(
-        geometry,
+      const anchorPoint = requireRidgeBlockoutFactAnchor(
+        facts,
         target.anchor,
         `${target.id} Trail Card`
       );
@@ -947,14 +949,14 @@ export class RidgeScene extends Phaser.Scene {
   }
 
   private getRoomCenter(
-    geometry: RidgeBlockoutGeometry,
+    facts: Pick<RidgeBlockoutFacts, 'rooms'>,
     roomId: string
   ): { x: number; y: number } | undefined {
-    const room = geometry.roomBounds.find((candidate) => candidate.roomId === roomId);
+    const room = facts.rooms.find((candidate) => candidate.id === roomId);
     return room
       ? {
-        x: room.x + room.width / 2,
-        y: room.y + room.height / 2
+        x: room.bounds.x + room.bounds.width / 2,
+        y: room.bounds.y + room.bounds.height / 2
       }
       : undefined;
   }
@@ -1085,17 +1087,14 @@ export class RidgeScene extends Phaser.Scene {
     this.add.circle(x + 60, y - 37, 4, 0x1f1f1d, 0.58).setDepth(17);
   }
 
-  private addPlaceholderCopy(
-    blockout: RidgeBlockoutMap,
-    geometry: RidgeBlockoutGeometry
-  ): void {
-    const spawn = getRidgeBlockoutSpawnPoint(blockout);
+  private addPlaceholderCopy(facts: RidgeBlockoutFacts): void {
+    const spawn = facts.spawn;
     this.add.text(spawn.x, spawn.y - 260, 'Sketchbook Ridge', {
       fontFamily: 'monospace',
       fontSize: '34px',
       color: '#1f1f1d'
     }).setOrigin(0.5).setDepth(60);
-    this.add.text(spawn.x, spawn.y - 214, `${blockout.title} - parsed ${geometry.roomBounds.length} room beats`, {
+    this.add.text(spawn.x, spawn.y - 214, `${facts.title} - parsed ${facts.rooms.length} room beats`, {
       fontFamily: 'monospace',
       fontSize: '16px',
       color: '#4b4337'
@@ -1229,12 +1228,17 @@ function getColliderTop(collider: RidgeBlockoutCollider): number {
   return collider.y - collider.height / 2;
 }
 
-function requireRidgeBlockoutAnchorPoint(
-  geometry: RidgeBlockoutGeometry,
-  selector: RidgeBlockoutAnchorSelector,
+function requireRidgeBlockoutFactAnchor(
+  facts: RidgeBlockoutFacts,
+  selector: {
+    roomId: string;
+    symbol?: string;
+    kind?: string;
+    attrId?: string;
+  },
   label: string
-): RidgeBlockoutAnchorPoint {
-  const point = findRidgeBlockoutAnchorPoint(geometry, selector);
+): RidgeAnchorFact {
+  const point = findRidgeBlockoutFactAnchor(facts, selector);
   if (!point) {
     throw new Error(
       `Ridge blockout anchor for ${label} could not be resolved in room "${selector.roomId}"`

--- a/src/game/scenes/ridge/worldLayout.test.ts
+++ b/src/game/scenes/ridge/worldLayout.test.ts
@@ -4,16 +4,15 @@ import { STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
 import { CICKA_INTERACTION_TARGET_ID } from './cicka/interaction';
 import {
   RIDGE_BLOCKOUT,
-  deriveRidgeBlockoutGeometry,
-  findRidgeBlockoutAnchorPoint,
-  getRidgeBlockoutSpawnPoint,
-  isRidgeBlockoutShortcutAvailable
+  compileRidgeBlockoutFacts,
+  findRidgeBlockoutFactAnchor
 } from './blockout';
 import { RIDGE_TRAIL_CARD_TARGETS } from './worldLayout';
 
 describe('ridge world layout', () => {
   it('uses the Ridge Blockout source for first route order and spawn', () => {
-    const firstWalk = RIDGE_BLOCKOUT.routes.find((route) => route.id === 'first_walk');
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const firstWalk = facts.routes.find((route) => route.id === 'first_walk');
 
     expect(firstWalk?.roomIds.slice(0, 4)).toEqual([
       'outskirts',
@@ -21,17 +20,17 @@ describe('ridge world layout', () => {
       'work_artifact',
       'stampede_blanket'
     ]);
-    expect(getRidgeBlockoutSpawnPoint(RIDGE_BLOCKOUT)).toMatchObject({
+    expect(facts.spawn).toMatchObject({
       roomId: 'outskirts',
       symbol: '1',
       kind: 'player_spawn',
-      attrs: { id: 'start' }
+      id: 'start'
     });
   });
 
   it('resolves Cicka Home from the compiled blockout anchor', () => {
-    const geometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT);
-    const cickaPoint = findRidgeBlockoutAnchorPoint(geometry, {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const cickaPoint = findRidgeBlockoutFactAnchor(facts, {
       roomId: 'cicka_home',
       symbol: 'C',
       kind: 'npc',
@@ -42,14 +41,14 @@ describe('ridge world layout', () => {
       roomId: 'cicka_home',
       symbol: 'C',
       kind: 'npc',
-      attrs: { id: 'cicka' }
+      id: 'cicka'
     });
     expect(cickaPoint?.x).toBeGreaterThan(0);
     expect(cickaPoint?.y).toBeGreaterThan(0);
   });
 
   it('resolves Trail Card targets from their blockout anchors while keeping card content non-spatial', () => {
-    const geometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT);
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
     const stampede = RIDGE_TRAIL_CARD_TARGETS.find((target) => target.id === 'stampede-sketch');
     const unavailable = RIDGE_TRAIL_CARD_TARGETS.filter((target) => target.id !== 'stampede-sketch');
 
@@ -66,18 +65,18 @@ describe('ridge world layout', () => {
     expect(unavailable.every((target) => target.card.unavailableReason && !target.card.enterSceneId)).toBe(true);
 
     if (!stampede) throw new Error('missing Stampede Trail Card target');
-    expect(findRidgeBlockoutAnchorPoint(geometry, stampede.anchor)).toMatchObject({
+    expect(findRidgeBlockoutFactAnchor(facts, stampede.anchor)).toMatchObject({
       roomId: 'stampede_blanket',
       symbol: '*',
       kind: 'minigame',
-      attrs: { id: 'stampede_sketch' }
+      id: 'stampede_sketch'
     });
   });
 
   it('resolves the Relay promise from the Relay Gate blockout anchor', () => {
-    const geometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT);
-    const relayRoom = geometry.roomBounds.find((room) => room.roomId === 'relay_gate');
-    const relayPoint = findRidgeBlockoutAnchorPoint(geometry, {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const relayRoom = facts.rooms.find((room) => room.id === 'relay_gate');
+    const relayPoint = findRidgeBlockoutFactAnchor(facts, {
       roomId: 'relay_gate',
       symbol: '?',
       kind: 'gate',
@@ -89,55 +88,39 @@ describe('ridge world layout', () => {
       roomId: 'relay_gate',
       symbol: '?',
       kind: 'gate',
-      attrs: { id: 'relay_proof_slots' }
+      id: 'relay_proof_slots'
     });
-    expect(relayPoint?.x).toBeGreaterThanOrEqual(relayRoom?.x ?? 0);
+    expect(relayPoint?.x).toBeGreaterThanOrEqual(relayRoom?.bounds.x ?? 0);
     expect(relayPoint?.x).toBeLessThanOrEqual(
-      relayRoom ? relayRoom.x + relayRoom.width : Number.POSITIVE_INFINITY
+      relayRoom ? relayRoom.bounds.x + relayRoom.bounds.width : Number.POSITIVE_INFINITY
     );
   });
 
   it('derives the Stampede shortcut source and availability from blockout facts', () => {
-    const shortcut = RIDGE_BLOCKOUT.shortcuts.find((candidate) => candidate.id === 'stampede_sketch');
-    const lockedGeometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT, { stampIds: [] });
-    const unlockedGeometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT, {
+    const lockedFacts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT, { stampIds: [] });
+    const unlockedFacts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT, {
       stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
     });
-    const lockedConnection = lockedGeometry.shortcutConnections.find(
-      (connection) => connection.id === 'stampede_sketch'
-    );
-    const unlockedConnection = unlockedGeometry.shortcutConnections.find(
-      (connection) => connection.id === 'stampede_sketch'
-    );
+    const lockedConnection = lockedFacts.shortcuts.find((shortcut) => shortcut.id === 'stampede_sketch');
+    const unlockedConnection = unlockedFacts.shortcuts.find((shortcut) => shortcut.id === 'stampede_sketch');
 
-    expect(shortcut).toMatchObject({
+    expect(lockedConnection).toMatchObject({
       id: 'stampede_sketch',
       fromRoomId: 'switchback_shelf',
       toRoomId: 'cicka_home',
-      kind: 'fall_steer_fold_drop'
-    });
-    expect(isRidgeBlockoutShortcutAvailable('stampede_sketch', { stampIds: [] })).toBe(false);
-    expect(isRidgeBlockoutShortcutAvailable('stampede_sketch', {
-      stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
-    })).toBe(true);
-    expect(lockedConnection).toMatchObject({
-      id: 'stampede_sketch',
-      unlocked: false,
+      kind: 'fall_steer_fold_drop',
+      available: false,
       movement: 'drop'
     });
     expect(lockedConnection?.from).toMatchObject({
       roomId: 'switchback_shelf',
-      attrs: {
-        to: 'cicka_home',
-        requires: 'stampede_sketch'
-      }
+      targetRoomId: 'cicka_home',
+      requires: 'stampede_sketch'
     });
-    expect(lockedConnection?.assistZones).toEqual([]);
     expect(unlockedConnection).toMatchObject({
       id: 'stampede_sketch',
-      unlocked: true,
+      available: true,
       movement: 'drop'
     });
-    expect(unlockedConnection?.assistZones.some((zone) => zone.kind === 'drop')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Added a typed Ridge Blockout facts layer with compiled room beats, routes, anchors, shortcuts, home mutations, and spawn facts.
- Moved Ridge runtime lookups to the new facts interface for spawn, future-route visuals, shortcut state, landmark anchors, Trail Card anchors, and placeholder copy.
- Split shortcut progress gating into a shared helper so geometry and facts resolve availability from the same source.

## Testing
- Added focused facts coverage for route order, spawn, anchor resolution, future routes, shortcut availability, and home mutation facts.
- Migrated Ridge world-layout assertions to the compiled facts interface.
- `npm run test` passed.
- `npm run build` passed.

Fixes #62 