### PR TITLE
Extract Ridge traversal assists into a dedicated runtime

### DIFF
--- a/src/game/scenes/ridge/blockout/facts.test.ts
+++ b/src/game/scenes/ridge/blockout/facts.test.ts
@@ -127,6 +127,39 @@ describe('ridge blockout facts', () => {
     });
   });
 
+  it('preserves drop shortcut movement when geometry cannot build a connection', () => {
+    const facts = compileRidgeBlockoutFacts({
+      ...RIDGE_BLOCKOUT,
+      shortcuts: [{
+        id: 'missing_anchor_drop',
+        fromRoomId: 'outskirts',
+        toRoomId: 'cicka_home',
+        kind: 'fall_test_drop'
+      }]
+    });
+
+    expect(facts.shortcuts[0]).toMatchObject({
+      id: 'missing_anchor_drop',
+      movement: 'drop',
+      toRoomId: 'cicka_home'
+    });
+    expect(facts.shortcuts[0]?.to).not.toEqual({ x: 0, y: 0 });
+  });
+
+  it('fails loudly when a shortcut target cannot resolve', () => {
+    expect(() => compileRidgeBlockoutFacts({
+      ...RIDGE_BLOCKOUT,
+      shortcuts: [{
+        id: 'missing_target',
+        fromRoomId: 'outskirts',
+        toRoomId: 'missing_room',
+        kind: 'ramp'
+      }]
+    })).toThrow(
+      'Ridge blockout shortcut "missing_target" target room "missing_room" could not be compiled into facts'
+    );
+  });
+
   it('exposes Cicka Home mutation declarations as typed facts', () => {
     const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
 

--- a/src/game/scenes/ridge/blockout/facts.ts
+++ b/src/game/scenes/ridge/blockout/facts.ts
@@ -100,8 +100,15 @@ export function compileRidgeBlockoutFacts(
     stampIds: options.stampIds
   });
   const anchors = geometry.anchorPoints.map(toAnchorFact);
+  const anchorsByRoomId = groupAnchorsByRoomId(anchors);
+  const roomBoundsById = new Map(
+    geometry.roomBounds.map((bounds) => [bounds.roomId, bounds])
+  );
+  const shortcutConnectionsById = new Map(
+    geometry.shortcutConnections.map((connection) => [connection.id, connection])
+  );
   const rooms = map.rooms.map((room) => {
-    const bounds = geometry.roomBounds.find((candidate) => candidate.roomId === room.id);
+    const bounds = roomBoundsById.get(room.id);
     if (!bounds) {
       throw new Error(`Ridge blockout room "${room.id}" could not be compiled into facts`);
     }
@@ -114,7 +121,7 @@ export function compileRidgeBlockoutFacts(
       props: room.props,
       declarations: room.declarations,
       bounds,
-      anchors: anchors.filter((anchor) => anchor.roomId === room.id)
+      anchors: anchorsByRoomId.get(room.id) ?? []
     };
   });
   const spawn = findRidgeBlockoutFactAnchor({ anchors }, {
@@ -138,7 +145,7 @@ export function compileRidgeBlockoutFacts(
     routes: map.routes.map((route) => toRouteFact(route, 'route')),
     futureRoutes: map.futureRoutes.map((route) => toRouteFact(route, 'future_route')),
     shortcuts: map.shortcuts.map((shortcut) => {
-      const connection = geometry.shortcutConnections.find((candidate) => candidate.id === shortcut.id);
+      const connection = shortcutConnectionsById.get(shortcut.id);
       const source = anchors.find((anchor) =>
         anchor.roomId === shortcut.fromRoomId &&
         anchor.targetRoomId === shortcut.toRoomId &&
@@ -154,11 +161,11 @@ export function compileRidgeBlockoutFacts(
         fromRoomId: shortcut.fromRoomId,
         toRoomId: shortcut.toRoomId,
         kind: shortcut.kind,
-        movement: connection?.movement ?? 'ramp',
+        movement: connection?.movement ?? resolveShortcutFallbackMovement(shortcut.kind),
         requiredStampId: getRidgeBlockoutShortcutRequiredStampId(shortcut.id),
         available,
         from: source,
-        to: connection?.to ?? getRoomCenter(geometry, shortcut.toRoomId) ?? { x: 0, y: 0 }
+        to: connection?.to ?? getRequiredRoomCenter(geometry, shortcut.toRoomId, shortcut.id)
       };
     }),
     homeMutations: map.homeMutations.map((mutation) => ({
@@ -204,15 +211,48 @@ function toRouteFact(
     roomIds: route.roomIds,
     links: route.roomIds.slice(0, -1).map((roomId, index) => ({
       fromRoomId: roomId,
-      toRoomId: route.roomIds[index + 1] ?? ''
+      toRoomId: route.roomIds[index + 1]
     }))
   };
+}
+
+function resolveShortcutFallbackMovement(
+  kind: string | undefined
+): RidgeBlockoutTraversalMovement {
+  if (kind?.includes('drop') || kind?.includes('fall')) return 'drop';
+  return parseTraversalMovement(kind) ?? 'ramp';
 }
 
 function parseTraversalMovement(value: string | undefined): RidgeBlockoutTraversalMovement | undefined {
   return value && RIDGE_BLOCKOUT_TRAVERSAL_MOVEMENTS.has(value)
     ? value as RidgeBlockoutTraversalMovement
     : undefined;
+}
+
+function groupAnchorsByRoomId(
+  anchors: readonly RidgeAnchorFact[]
+): Map<string, readonly RidgeAnchorFact[]> {
+  const anchorsByRoomId = new Map<string, RidgeAnchorFact[]>();
+  anchors.forEach((anchor) => {
+    const roomAnchors = anchorsByRoomId.get(anchor.roomId) ?? [];
+    roomAnchors.push(anchor);
+    anchorsByRoomId.set(anchor.roomId, roomAnchors);
+  });
+  return anchorsByRoomId;
+}
+
+function getRequiredRoomCenter(
+  geometry: Pick<RidgeBlockoutGeometry, 'roomBounds'>,
+  roomId: string,
+  shortcutId: string
+): { x: number; y: number } {
+  const center = getRoomCenter(geometry, roomId);
+  if (!center) {
+    throw new Error(
+      `Ridge blockout shortcut "${shortcutId}" target room "${roomId}" could not be compiled into facts`
+    );
+  }
+  return center;
 }
 
 function getRoomCenter(

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -1,6 +1,5 @@
 import * as Phaser from 'phaser';
 import { PHASER_SCENE_KEYS } from '@/game/scenes/sceneIds';
-import type { InputCommandFrame } from '@/game/core/input/commands';
 import {
   bridgeStore,
   isItemEquipped,
@@ -66,20 +65,9 @@ import {
 } from '../cicka/CickaPerch';
 import type { TrailCardOverlayParams } from '@/game/overlays/trailCard/types';
 import {
-  canMantleLedge,
-  canStepUp,
-  chooseFallRecovery,
-  getClimbProgressDelta,
-  getFrameRateIndependentLerpAlpha,
-  getLedgeTop,
-  getPointOnTraversalSegment,
-  isMantleTargetCollider,
-  isPointNearTraversalLine,
-  isTraversalPathOccludedBySolid,
-  projectPointToSegmentT,
-  resolveWalkableRampSurfaceY,
-  shouldMaintainClimbAttachment
-} from './traversalComfort';
+  createRidgeTraversalRuntime,
+  type RidgeTraversalRuntime
+} from './ridgeTraversalRuntime';
 
 interface RidgeSceneStartData {
   onClose?: () => void;
@@ -103,38 +91,19 @@ const TRAIL_CARD_PROMPT_OFFSET_Y = -86;
 const RIDGE_PLAYER_EDGE_PADDING = 48;
 const RIDGE_COYOTE_TIME_MS = 120;
 const RIDGE_JUMP_BUFFER_MS = 120;
-const RIDGE_RAMP_SNAP = {
-  maxSnapDownY: 28,
-  maxSnapUpY: 8
-} as const;
-const RIDGE_CLIMB_ATTACH_DISTANCE = 22;
-const RIDGE_DROP_ATTACH_DISTANCE = 28;
-const RIDGE_MANTLE_HORIZONTAL_DISTANCE = 32;
-const RIDGE_MANTLE_MIN_VERTICAL_DELTA = 24;
-const RIDGE_MANTLE_MAX_VERTICAL_DELTA = 96;
-const RIDGE_MANTLE_MIN_VELOCITY_Y = -20;
-const RIDGE_STEP_UP_MAX_HEIGHT = 18;
-const RIDGE_STEP_UP_HORIZONTAL_DISTANCE = 22;
-const RIDGE_CLIMB_PROGRESS_PER_SECOND = 0.36;
-const RIDGE_DROP_LERP_ALPHA_AT_60FPS = 0.08;
-const RIDGE_FALL_RECOVERY_THRESHOLD_Y = 48;
 
 export class RidgeScene extends Phaser.Scene {
   player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
   interactPrompt?: Phaser.GameObjects.Text;
 
   private playerRuntime?: SideViewPlayerRuntime;
+  private traversalRuntime?: RidgeTraversalRuntime;
   private interactionRuntime?: InteriorInteractionRuntime<RidgeInteractionTargetId, RidgeInteractionEffect>;
   private cickaPerch?: CickaPerch;
   private onClose: () => void = () => {};
   private onOpenOverlay?: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   private isPaused = false;
   private resumePosition?: { x: number; y: number };
-  private ridgeGeometry?: RidgeBlockoutGeometry;
-  private ridgeSolidBlockers: readonly RidgeBlockoutCollider[] = [];
-  private ridgeMantleTargets: readonly RidgeBlockoutCollider[] = [];
-  private lastSafePosition?: { x: number; y: number };
-  private activeClimbZoneId: string | null = null;
 
   constructor() {
     super(PHASER_SCENE_KEYS.ridge);
@@ -176,11 +145,7 @@ export class RidgeScene extends Phaser.Scene {
       stampIds: ridgeProgress.stampIds,
       geometry
     });
-    this.ridgeGeometry = geometry;
-    this.ridgeSolidBlockers = geometry.gridColliders.filter(isSolidCollider);
-    this.ridgeMantleTargets = geometry.colliders.filter(isMantleTargetCollider);
-    this.lastSafePosition = undefined;
-    this.activeClimbZoneId = null;
+    this.traversalRuntime = undefined;
 
     this.cameras.main.setBackgroundColor('#f7f1df');
     this.physics.world.setBounds(
@@ -217,7 +182,9 @@ export class RidgeScene extends Phaser.Scene {
   }
 
   update(_time: number, delta: number): void {
-    this.primeTraversalGrounding();
+    if (this.player) {
+      this.traversalRuntime?.primeGrounding(this.player);
+    }
     const playerUpdate = this.playerRuntime?.update();
     if (!playerUpdate || playerUpdate.paused) return;
 
@@ -226,7 +193,13 @@ export class RidgeScene extends Phaser.Scene {
       return;
     }
 
-    this.applyTraversalComfort(playerUpdate.commands, delta);
+    if (this.player) {
+      this.traversalRuntime?.update({
+        player: this.player,
+        commands: playerUpdate.commands,
+        deltaMs: delta
+      });
+    }
 
     this.cickaPerch?.update({
       playerX: this.player?.x ?? 0,
@@ -576,307 +549,10 @@ export class RidgeScene extends Phaser.Scene {
     platforms.forEach((platform) => {
       this.physics.add.collider(player, platform);
     });
-    this.lastSafePosition = { x: player.x, y: player.y };
-  }
-
-  private primeTraversalGrounding(): void {
-    const player = this.player;
-    const geometry = this.ridgeGeometry;
-    if (!player?.body || !geometry) return;
-
-    const body = player.body;
-    const bottomY = getPlayerBottomY(player);
-    const ramp = resolveWalkableRampSurfaceY(
-      geometry.assistZones,
-      { x: player.x, y: bottomY },
-      RIDGE_RAMP_SNAP
-    );
-    const climb = geometry.assistZones.find((zone) =>
-      zone.kind === 'climb' &&
-      this.isNearTraversalLine(zone, { x: player.x, y: bottomY }, RIDGE_CLIMB_ATTACH_DISTANCE)
-    );
-
-    if (ramp || climb) {
-      markBodyGrounded(body);
-    }
-  }
-
-  private applyTraversalComfort(commands: InputCommandFrame, deltaMs: number): void {
-    const player = this.player;
-    const geometry = this.ridgeGeometry;
-    if (!player?.body || !geometry) return;
-
-    const didClimb = this.applyClimbAssist(commands, geometry.assistZones, deltaMs);
-    if (!didClimb) {
-      this.releaseClimbAttachment();
-      this.applyRampAssist(commands, geometry.assistZones);
-      this.applyDropAssist(geometry.assistZones, deltaMs);
-      this.applyStepUpAssist(commands, geometry.colliders);
-      this.applyMantleAssist(commands);
-    }
-    this.recoverFromWorldBottom(geometry);
-    this.captureLastSafePosition(geometry);
-  }
-
-  private applyRampAssist(
-    commands: InputCommandFrame,
-    zones: readonly RidgeBlockoutAssistZone[]
-  ): boolean {
-    const player = this.player;
-    if (!player?.body || commands.jump) return false;
-
-    const body = player.body;
-    const bottomY = getPlayerBottomY(player);
-    const ramp = resolveWalkableRampSurfaceY(
-      zones,
-      { x: player.x, y: bottomY },
-      RIDGE_RAMP_SNAP
-    );
-    if (!ramp || body.velocity.y < -60) return false;
-
-    const target = { x: player.x, y: ramp.y - body.height / 2 };
-    if (this.isAssistPathOccluded(target)) return false;
-
-    player.y = target.y;
-    player.setVelocityY(0);
-    markBodyGrounded(body);
-    return true;
-  }
-
-  private applyClimbAssist(
-    commands: InputCommandFrame,
-    zones: readonly RidgeBlockoutAssistZone[],
-    deltaMs: number
-  ): boolean {
-    const player = this.player;
-    if (!player?.body) return false;
-
-    const zone = zones.find((candidate) =>
-      candidate.kind === 'climb' &&
-      this.isNearTraversalLine(
-        candidate,
-        { x: player.x, y: getPlayerBottomY(player) },
-        RIDGE_CLIMB_ATTACH_DISTANCE
-      )
-    );
-    const isAttached = this.activeClimbZoneId !== null;
-    if (!zone) return false;
-    if (
-      commands.verticalAxis === 0 &&
-      !shouldMaintainClimbAttachment({
-        attached: isAttached,
-        jump: commands.jump,
-        horizontalAxis: commands.moveAxis,
-        nearClimbLine: true
-      })
-    ) {
-      return false;
-    }
-    if (commands.jump) return false;
-
-    const currentT = projectPointToSegmentT(
-      { x: player.x, y: getPlayerBottomY(player) },
-      zone
-    );
-    const nextT = Phaser.Math.Clamp(
-      currentT + getClimbProgressDelta({
-        verticalAxis: commands.verticalAxis,
-        fromY: zone.from.y,
-        toY: zone.to.y,
-        progressPerSecond: RIDGE_CLIMB_PROGRESS_PER_SECOND,
-        deltaMs
-      }),
-      0,
-      1
-    );
-    const point = getPointOnTraversalSegment(zone, nextT);
-    const target = { x: point.x, y: point.y - player.body.height / 2 };
-    if (this.isAssistPathOccluded(target)) return false;
-
-    this.activeClimbZoneId = zone.id;
-    player.body.setAllowGravity(false);
-    player.x = target.x;
-    player.y = target.y;
-    player.setVelocityX(0);
-    player.setVelocityY(0);
-    markBodyGrounded(player.body);
-    return true;
-  }
-
-  private releaseClimbAttachment(): void {
-    if (!this.activeClimbZoneId) return;
-    this.activeClimbZoneId = null;
-    this.player?.body?.setAllowGravity(true);
-  }
-
-  private applyDropAssist(
-    zones: readonly RidgeBlockoutAssistZone[],
-    deltaMs: number
-  ): boolean {
-    const player = this.player;
-    if (!player?.body || player.body.velocity.y <= 0) return false;
-
-    const zone = zones.find((candidate) =>
-      candidate.kind === 'drop' &&
-      this.isNearTraversalLine(candidate, { x: player.x, y: player.y }, RIDGE_DROP_ATTACH_DISTANCE)
-    );
-    if (!zone) return false;
-
-    const t = projectPointToSegmentT({ x: player.x, y: player.y }, zone);
-    const point = getPointOnTraversalSegment(zone, t);
-    const target = {
-      x: Phaser.Math.Linear(
-        player.x,
-        point.x,
-        getFrameRateIndependentLerpAlpha(RIDGE_DROP_LERP_ALPHA_AT_60FPS, deltaMs)
-      ),
-      y: player.y
-    };
-    if (this.isAssistPathOccluded(target)) return false;
-
-    player.x = target.x;
-    return true;
-  }
-
-  private applyStepUpAssist(
-    commands: InputCommandFrame,
-    colliders: readonly RidgeBlockoutCollider[]
-  ): boolean {
-    const player = this.player;
-    if (!player?.body || commands.moveAxis === 0 || !isBodyGrounded(player.body)) return false;
-
-    const direction = Math.sign(commands.moveAxis);
-    const bottomY = getPlayerBottomY(player);
-    const candidate = findClosestLedge(colliders, player.x, direction, RIDGE_STEP_UP_HORIZONTAL_DISTANCE)
-      ?.collider;
-    if (!candidate) return false;
-
-    const topY = getColliderTop(candidate);
-    if (!canStepUp({
-      playerBottomY: bottomY,
-      obstacleTopY: topY,
-      maxStepHeight: RIDGE_STEP_UP_MAX_HEIGHT
-    })) {
-      return false;
-    }
-
-    const target = {
-      x: player.x + direction * 18,
-      y: topY - player.body.height / 2
-    };
-    if (this.isAssistPathOccluded(target)) return false;
-
-    player.x = target.x;
-    player.y = target.y;
-    player.setVelocityY(0);
-    markBodyGrounded(player.body);
-    return true;
-  }
-
-  private applyMantleAssist(
-    commands: InputCommandFrame
-  ): boolean {
-    const player = this.player;
-    if (!player?.body || commands.moveAxis === 0) return false;
-    if (isBodyGrounded(player.body)) return false;
-    if (player.body.velocity.y < RIDGE_MANTLE_MIN_VELOCITY_Y) return false;
-
-    const direction = Math.sign(commands.moveAxis);
-    const bottomY = getPlayerBottomY(player);
-    const ledges = this.ridgeMantleTargets
-      .map((collider) => ({ collider, distance: getHorizontalLedgeDistance(collider, player.x, direction) }))
-      .filter((candidate) =>
-        candidate.distance >= 0 &&
-        canMantleLedge({
-          playerX: player.x,
-          playerBottomY: bottomY,
-          moveAxis: commands.moveAxis,
-          ledge: candidate.collider,
-          maxHorizontalDistance: RIDGE_MANTLE_HORIZONTAL_DISTANCE,
-          minVerticalDelta: RIDGE_MANTLE_MIN_VERTICAL_DELTA,
-          maxVerticalDelta: RIDGE_MANTLE_MAX_VERTICAL_DELTA
-        })
-      )
-      .sort((a, b) => a.distance - b.distance);
-
-    const target = ledges[0]?.collider;
-    if (!target) return false;
-
-    const topY = getLedgeTop(target);
-    const nextPosition = {
-      x: direction > 0
-        ? target.x - target.width / 2 + player.body.width / 2 + 6
-        : target.x + target.width / 2 - player.body.width / 2 - 6,
-      y: topY - player.body.height / 2
-    };
-    if (this.isAssistPathOccluded(nextPosition)) return false;
-
-    player.x = nextPosition.x;
-    player.y = nextPosition.y;
-    player.setVelocityY(0);
-    markBodyGrounded(player.body);
-    return true;
-  }
-
-  private isNearTraversalLine(
-    zone: RidgeBlockoutAssistZone,
-    point: { x: number; y: number },
-    maxDistance: number
-  ): boolean {
-    return (
-      isPointNearTraversalLine(zone, point, maxDistance)
-    );
-  }
-
-  private isAssistPathOccluded(target: { x: number; y: number }): boolean {
-    const player = this.player;
-    if (!player?.body) return false;
-
-    return isTraversalPathOccludedBySolid({
-      from: { x: player.x, y: player.y },
-      to: target,
-      bodySize: {
-        width: player.body.width,
-        height: player.body.height
-      },
-      solidRects: this.ridgeSolidBlockers
+    this.traversalRuntime = createRidgeTraversalRuntime({
+      geometry,
+      initialSafePosition: { x: player.x, y: player.y }
     });
-  }
-
-  private recoverFromWorldBottom(geometry: RidgeBlockoutGeometry): void {
-    const player = this.player;
-    if (!player?.body) return;
-
-    const recovery = chooseFallRecovery({
-      playerY: player.y,
-      worldBottomY: geometry.bounds.y + geometry.bounds.height,
-      thresholdY: RIDGE_FALL_RECOVERY_THRESHOLD_Y,
-      lastSafePosition: this.lastSafePosition
-    });
-    if (!recovery) return;
-
-    player.x = recovery.x;
-    player.y = recovery.y;
-    player.setVelocityX(0);
-    player.setVelocityY(0);
-  }
-
-  private captureLastSafePosition(geometry: RidgeBlockoutGeometry): void {
-    const player = this.player;
-    if (!player?.body) return;
-
-    const bottomBandY = geometry.bounds.y + geometry.bounds.height - RIDGE_FALL_RECOVERY_THRESHOLD_Y;
-    if (player.y >= bottomBandY) return;
-
-    const bottomY = getPlayerBottomY(player);
-    const ramp = resolveWalkableRampSurfaceY(
-      geometry.assistZones,
-      { x: player.x, y: bottomY },
-      RIDGE_RAMP_SNAP
-    );
-    if (isBodyGrounded(player.body) || ramp) {
-      this.lastSafePosition = { x: player.x, y: player.y };
-    }
   }
 
   private createRidgeInteractions(
@@ -1179,53 +855,6 @@ function drawLadderVisual(
       y
     ));
   }
-}
-
-function isSolidCollider(collider: RidgeBlockoutCollider): boolean {
-  return collider.kind === 'solid';
-}
-
-function getPlayerBottomY(player: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody): number {
-  return player.body.bottom;
-}
-
-function markBodyGrounded(body: Phaser.Physics.Arcade.Body): void {
-  body.touching.down = true;
-  body.blocked.down = true;
-}
-
-function isBodyGrounded(body: Phaser.Physics.Arcade.Body): boolean {
-  return body.touching.down || body.blocked.down;
-}
-
-function findClosestLedge(
-  colliders: readonly RidgeBlockoutCollider[],
-  playerX: number,
-  direction: number,
-  maxDistance: number
-): { collider: RidgeBlockoutCollider; distance: number } | undefined {
-  return colliders
-    .map((collider) => ({
-      collider,
-      distance: getHorizontalLedgeDistance(collider, playerX, direction)
-    }))
-    .filter((candidate) => candidate.distance >= 0 && candidate.distance <= maxDistance)
-    .sort((a, b) => a.distance - b.distance)[0];
-}
-
-function getHorizontalLedgeDistance(
-  collider: RidgeBlockoutCollider,
-  playerX: number,
-  direction: number
-): number {
-  const left = collider.x - collider.width / 2;
-  const right = collider.x + collider.width / 2;
-  if (direction > 0) return left - playerX;
-  return playerX - right;
-}
-
-function getColliderTop(collider: RidgeBlockoutCollider): number {
-  return collider.y - collider.height / 2;
 }
 
 function requireRidgeBlockoutFactAnchor(

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -30,6 +30,7 @@ import {
   compileRidgeBlockoutFacts,
   deriveRidgeBlockoutGeometry,
   type RidgeBlockoutAnchorPoint,
+  type RidgeBlockoutAnchorSelector,
   type RidgeBlockoutAssistZone,
   type RidgeBlockoutBounds,
   type RidgeBlockoutCollider,
@@ -142,7 +143,6 @@ export class RidgeScene extends Phaser.Scene {
       stampIds: ridgeProgress.stampIds
     });
     const facts = compileRidgeBlockoutFacts(blockout, {
-      stampIds: ridgeProgress.stampIds,
       geometry
     });
     this.traversalRuntime = undefined;
@@ -170,7 +170,7 @@ export class RidgeScene extends Phaser.Scene {
       messages.scenes.ridge.memory.cickaWalkByBark,
       worldMemories
     );
-    this.addPlaceholderCopy(facts);
+    this.addPlaceholderCopy(facts, messages.catalog.ridge.ridge.name);
     this.createPlayer(platforms, facts, geometry);
     this.createRidgeInteractions(
       messages.navigation.interact,
@@ -763,9 +763,9 @@ export class RidgeScene extends Phaser.Scene {
     this.add.circle(x + 60, y - 37, 4, 0x1f1f1d, 0.58).setDepth(17);
   }
 
-  private addPlaceholderCopy(facts: RidgeBlockoutFacts): void {
+  private addPlaceholderCopy(facts: RidgeBlockoutFacts, title: string): void {
     const spawn = facts.spawn;
-    this.add.text(spawn.x, spawn.y - 260, 'Sketchbook Ridge', {
+    this.add.text(spawn.x, spawn.y - 260, title, {
       fontFamily: 'monospace',
       fontSize: '34px',
       color: '#1f1f1d'
@@ -859,12 +859,7 @@ function drawLadderVisual(
 
 function requireRidgeBlockoutFactAnchor(
   facts: RidgeBlockoutFacts,
-  selector: {
-    roomId: string;
-    symbol?: string;
-    kind?: string;
-    attrId?: string;
-  },
+  selector: RidgeBlockoutAnchorSelector,
   label: string
 ): RidgeAnchorFact {
   const point = findRidgeBlockoutFactAnchor(facts, selector);

--- a/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.test.ts
+++ b/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.test.ts
@@ -1,0 +1,440 @@
+import { describe, expect, it } from 'vitest';
+import type { InputCommandFrame } from '@/game/core/input/commands';
+import type {
+  RidgeBlockoutAssistZone,
+  RidgeBlockoutCollider,
+  RidgeBlockoutGeometry
+} from '../blockout';
+import {
+  createRidgeTraversalRuntime,
+  type RidgeTraversalBody,
+  type RidgeTraversalPlayer
+} from './ridgeTraversalRuntime';
+
+interface TestTraversalBody extends RidgeTraversalBody {
+  allowGravity: boolean;
+}
+
+interface TestTraversalPlayer extends RidgeTraversalPlayer {
+  readonly body: TestTraversalBody;
+}
+
+const baseBounds = {
+  x: 0,
+  y: 0,
+  width: 1000,
+  height: 1000
+};
+
+describe('Ridge traversal runtime', () => {
+  it('primes grounding before the player controller reads ramp and climb state', () => {
+    const runtime = createRidgeTraversalRuntime({
+      geometry: makeGeometry({
+        assistZones: [
+          makeAssistZone({
+            id: 'outskirts-ramp',
+            kind: 'ramp',
+            from: { x: 0, y: 100 },
+            to: { x: 100, y: 100 }
+          })
+        ]
+      })
+    });
+    const player = makePlayer({ x: 50, y: 80, height: 40 });
+
+    const result = runtime.primeGrounding(player);
+
+    expect(result.grounded).toBe(true);
+    expect(result.appliedAssists).toEqual(['grounding']);
+    expect(player.body.touching.down).toBe(true);
+    expect(player.body.blocked.down).toBe(true);
+  });
+
+  it('snaps walkable ramps and captures the new safe position', () => {
+    const runtime = createRidgeTraversalRuntime({
+      geometry: makeGeometry({
+        assistZones: [
+          makeAssistZone({
+            id: 'stair-ramp',
+            kind: 'ramp',
+            from: { x: 0, y: 100 },
+            to: { x: 100, y: 100 }
+          })
+        ]
+      })
+    });
+    const player = makePlayer({ x: 50, y: 75, height: 40, velocityY: 20 });
+
+    const result = runtime.update({
+      player,
+      commands: command(),
+      deltaMs: 1000 / 60
+    });
+
+    expect(result.appliedAssists).toContain('ramp');
+    expect(result.appliedAssists).toContain('safe-capture');
+    expect(player.y).toBe(80);
+    expect(player.body.velocity.y).toBe(0);
+    expect(result.state.lastSafePosition).toEqual({ x: 50, y: 80 });
+  });
+
+  it('runs climb before other assists and releases attachment when climb intent ends', () => {
+    const climb = makeAssistZone({
+      id: 'cord-climb',
+      kind: 'climb',
+      from: { x: 100, y: 200 },
+      to: { x: 100, y: 100 },
+      width: 80,
+      height: 160
+    });
+    const ramp = makeAssistZone({
+      id: 'overlapping-ramp',
+      kind: 'ramp',
+      from: { x: 0, y: 200 },
+      to: { x: 200, y: 200 },
+      width: 260,
+      height: 120
+    });
+    const runtime = createRidgeTraversalRuntime({
+      geometry: makeGeometry({ assistZones: [climb, ramp] })
+    });
+    const player = makePlayer({ x: 100, y: 180, height: 40 });
+
+    const climbResult = runtime.update({
+      player,
+      commands: command({ verticalAxis: -1 }),
+      deltaMs: 1000 / 60
+    });
+
+    expect(climbResult.appliedAssists).toContain('climb');
+    expect(climbResult.appliedAssists).not.toContain('ramp');
+    expect(climbResult.state.activeClimbZoneId).toBe('cord-climb');
+    expect(player.body.allowGravity).toBe(false);
+    expect(player.y).toBeCloseTo(179.4);
+
+    const releaseResult = runtime.update({
+      player,
+      commands: command({ jump: true }),
+      deltaMs: 1000 / 60
+    });
+
+    expect(releaseResult.appliedAssists).toContain('climb-release');
+    expect(releaseResult.state.activeClimbZoneId).toBeNull();
+    expect(player.body.allowGravity).toBe(true);
+  });
+
+  it('steers falling players toward authored drop lines', () => {
+    const runtime = createRidgeTraversalRuntime({
+      geometry: makeGeometry({
+        assistZones: [
+          makeAssistZone({
+            id: 'fold-drop',
+            kind: 'drop',
+            from: { x: 100, y: 50 },
+            to: { x: 100, y: 150 },
+            width: 100,
+            height: 160
+          })
+        ]
+      })
+    });
+    const player = makePlayer({ x: 80, y: 100, velocityY: 40 });
+
+    const result = runtime.update({
+      player,
+      commands: command(),
+      deltaMs: 1000 / 60
+    });
+
+    expect(result.appliedAssists).toContain('drop');
+    expect(player.x).toBeCloseTo(81.6);
+  });
+
+  it('steps onto small grounded ledges', () => {
+    const runtime = createRidgeTraversalRuntime({
+      geometry: makeGeometry({
+        colliders: [
+          makeCollider({
+            id: 'short-step',
+            kind: 'platform',
+            x: 72,
+            y: 100,
+            width: 20,
+            height: 20
+          })
+        ]
+      })
+    });
+    const player = makePlayer({
+      x: 50,
+      y: 80,
+      height: 40,
+      touchingDown: true
+    });
+
+    const result = runtime.update({
+      player,
+      commands: command({ moveAxis: 1 }),
+      deltaMs: 1000 / 60
+    });
+
+    expect(result.appliedAssists).toContain('step-up');
+    expect(player.x).toBe(68);
+    expect(player.y).toBe(70);
+  });
+
+  it('mantles onto reachable platform targets while airborne', () => {
+    const runtime = createRidgeTraversalRuntime({
+      geometry: makeGeometry({
+        colliders: [
+          makeCollider({
+            id: 'reachable-platform',
+            kind: 'platform',
+            x: 100,
+            y: 90,
+            width: 40,
+            height: 20
+          })
+        ]
+      })
+    });
+    const player = makePlayer({ x: 50, y: 110, height: 40, velocityY: 10 });
+
+    const result = runtime.update({
+      player,
+      commands: command({ moveAxis: 1 }),
+      deltaMs: 1000 / 60
+    });
+
+    expect(result.appliedAssists).toContain('mantle');
+    expect(player.x).toBe(96);
+    expect(player.y).toBe(60);
+  });
+
+  it('rejects assist paths that cross solid walls', () => {
+    const runtime = createRidgeTraversalRuntime({
+      geometry: makeGeometry({
+        gridColliders: [
+          makeCollider({
+            id: 'solid-wall',
+            kind: 'solid',
+            x: 50,
+            y: 77.5,
+            width: 5,
+            height: 5
+          })
+        ],
+        assistZones: [
+          makeAssistZone({
+            id: 'blocked-ramp',
+            kind: 'ramp',
+            from: { x: 0, y: 100 },
+            to: { x: 100, y: 100 }
+          })
+        ]
+      })
+    });
+    const player = makePlayer({ x: 50, y: 75, height: 40, velocityY: 20 });
+
+    const result = runtime.update({
+      player,
+      commands: command(),
+      deltaMs: 1000 / 60
+    });
+
+    expect(result.appliedAssists).not.toContain('ramp');
+    expect(player.y).toBe(75);
+    expect(result.state.solidBlockerCount).toBe(1);
+  });
+
+  it('recovers from the bottom band using the last captured safe position', () => {
+    const runtime = createRidgeTraversalRuntime({
+      geometry: makeGeometry()
+    });
+    const player = makePlayer({
+      x: 20,
+      y: 20,
+      touchingDown: true
+    });
+
+    const captureResult = runtime.update({
+      player,
+      commands: command(),
+      deltaMs: 1000 / 60
+    });
+    expect(captureResult.appliedAssists).toContain('safe-capture');
+    expect(captureResult.state.lastSafePosition).toEqual({ x: 20, y: 20 });
+
+    player.x = 300;
+    player.y = 980;
+    player.body.touching.down = false;
+    player.body.blocked.down = false;
+    player.body.velocity.y = 300;
+
+    const recoveryResult = runtime.update({
+      player,
+      commands: command(),
+      deltaMs: 1000 / 60
+    });
+
+    expect(recoveryResult.appliedAssists).toContain('fall-recovery');
+    expect(player.x).toBe(20);
+    expect(player.y).toBe(20);
+    expect(player.body.velocity.x).toBe(0);
+    expect(player.body.velocity.y).toBe(0);
+  });
+
+  it('keeps solid terrain out of mantle targets', () => {
+    const runtime = createRidgeTraversalRuntime({
+      geometry: makeGeometry({
+        gridColliders: [
+          makeCollider({
+            id: 'solid-hash-ledge',
+            kind: 'solid',
+            x: 100,
+            y: 90,
+            width: 40,
+            height: 20
+          })
+        ]
+      })
+    });
+    const player = makePlayer({ x: 50, y: 110, height: 40, velocityY: 10 });
+
+    const result = runtime.update({
+      player,
+      commands: command({ moveAxis: 1 }),
+      deltaMs: 1000 / 60
+    });
+
+    expect(result.appliedAssists).not.toContain('mantle');
+    expect(result.state.mantleTargetCount).toBe(0);
+    expect(player.x).toBe(50);
+    expect(player.y).toBe(110);
+  });
+});
+
+function command(overrides: Partial<InputCommandFrame> = {}): InputCommandFrame {
+  return {
+    moveAxis: 0,
+    verticalAxis: 0,
+    sprint: false,
+    jump: false,
+    interact: false,
+    exitContext: false,
+    ...overrides
+  };
+}
+
+function makeGeometry(options: {
+  assistZones?: readonly RidgeBlockoutAssistZone[];
+  colliders?: readonly RidgeBlockoutCollider[];
+  gridColliders?: readonly RidgeBlockoutCollider[];
+} = {}): RidgeBlockoutGeometry {
+  const gridColliders = options.gridColliders ?? [];
+  return {
+    bounds: baseBounds,
+    roomBounds: [],
+    anchorPoints: [],
+    gridColliders,
+    routeConnectors: [],
+    shortcutConnections: [],
+    assistZones: options.assistZones ?? [],
+    colliders: [
+      ...gridColliders,
+      ...(options.colliders ?? [])
+    ]
+  };
+}
+
+function makeAssistZone(options: {
+  id: string;
+  kind: RidgeBlockoutAssistZone['kind'];
+  from: { x: number; y: number };
+  to: { x: number; y: number };
+  width?: number;
+  height?: number;
+}): RidgeBlockoutAssistZone {
+  return {
+    id: options.id,
+    kind: options.kind,
+    movement: options.kind,
+    from: options.from,
+    to: options.to,
+    x: (options.from.x + options.to.x) / 2,
+    y: (options.from.y + options.to.y) / 2,
+    width: options.width ?? 160,
+    height: options.height ?? 100
+  };
+}
+
+function makeCollider(options: {
+  id: string;
+  kind: RidgeBlockoutCollider['kind'];
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}): RidgeBlockoutCollider {
+  return {
+    id: options.id,
+    kind: options.kind,
+    x: options.x,
+    y: options.y,
+    width: options.width,
+    height: options.height
+  };
+}
+
+function makePlayer(options: {
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+  velocityX?: number;
+  velocityY?: number;
+  touchingDown?: boolean;
+  blockedDown?: boolean;
+}): TestTraversalPlayer {
+  let playerY = options.y;
+  const body: TestTraversalBody = {
+    width: options.width ?? 20,
+    height: options.height ?? 40,
+    get bottom() {
+      return playerY + body.height / 2;
+    },
+    velocity: {
+      x: options.velocityX ?? 0,
+      y: options.velocityY ?? 0
+    },
+    touching: {
+      down: options.touchingDown ?? false
+    },
+    blocked: {
+      down: options.blockedDown ?? false
+    },
+    allowGravity: true,
+    setAllowGravity(allowGravity: boolean) {
+      body.allowGravity = allowGravity;
+    }
+  };
+
+  const player: TestTraversalPlayer = {
+    x: options.x,
+    get y() {
+      return playerY;
+    },
+    set y(value: number) {
+      playerY = value;
+    },
+    body,
+    setVelocityX(velocityX: number) {
+      body.velocity.x = velocityX;
+    },
+    setVelocityY(velocityY: number) {
+      body.velocity.y = velocityY;
+    }
+  };
+
+  return player;
+}

--- a/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.ts
+++ b/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.ts
@@ -1,6 +1,5 @@
 import type { InputCommandFrame } from '@/game/core/input/commands';
 import type {
-  RidgeBlockoutAssistZone,
   RidgeBlockoutCollider,
   RidgeBlockoutGeometry
 } from '../blockout';
@@ -8,6 +7,7 @@ import {
   canMantleLedge,
   canStepUp,
   chooseFallRecovery,
+  clamp,
   getClimbProgressDelta,
   getFrameRateIndependentLerpAlpha,
   getLedgeTop,
@@ -15,6 +15,7 @@ import {
   isMantleTargetCollider,
   isPointNearTraversalLine,
   isTraversalPathOccludedBySolid,
+  lerp,
   projectPointToSegmentT,
   resolveWalkableRampSurfaceY,
   shouldMaintainClimbAttachment,
@@ -137,7 +138,7 @@ class RidgeTraversalRuntimeImpl implements RidgeTraversalRuntime {
     );
     const climb = this.geometry.assistZones.find((zone) =>
       zone.kind === 'climb' &&
-      isNearTraversalLine(zone, { x: player.x, y: bottomY }, RIDGE_CLIMB_ATTACH_DISTANCE)
+      isPointNearTraversalLine(zone, { x: player.x, y: bottomY }, RIDGE_CLIMB_ATTACH_DISTANCE)
     );
 
     if (!ramp && !climb) {
@@ -221,7 +222,7 @@ class RidgeTraversalRuntimeImpl implements RidgeTraversalRuntime {
     const { player, commands, deltaMs } = frame;
     const zone = this.geometry.assistZones.find((candidate) =>
       candidate.kind === 'climb' &&
-      isNearTraversalLine(
+      isPointNearTraversalLine(
         candidate,
         { x: player.x, y: getPlayerBottomY(player) },
         RIDGE_CLIMB_ATTACH_DISTANCE
@@ -291,14 +292,14 @@ class RidgeTraversalRuntimeImpl implements RidgeTraversalRuntime {
 
     const zone = this.geometry.assistZones.find((candidate) =>
       candidate.kind === 'drop' &&
-      isNearTraversalLine(candidate, { x: player.x, y: player.y }, RIDGE_DROP_ATTACH_DISTANCE)
+      isPointNearTraversalLine(candidate, { x: player.x, y: player.y }, RIDGE_DROP_ATTACH_DISTANCE)
     );
     if (!zone) return false;
 
     const t = projectPointToSegmentT({ x: player.x, y: player.y }, zone);
     const point = getPointOnTraversalSegment(zone, t);
     const target = {
-      x: linear(
+      x: lerp(
         player.x,
         point.x,
         getFrameRateIndependentLerpAlpha(RIDGE_DROP_LERP_ALPHA_AT_60FPS, deltaMs)
@@ -363,26 +364,28 @@ class RidgeTraversalRuntimeImpl implements RidgeTraversalRuntime {
 
     const direction = Math.sign(commands.moveAxis);
     const bottomY = getPlayerBottomY(player);
-    const ledges = this.mantleTargets
-      .map((collider) => ({
-        collider,
-        distance: getHorizontalLedgeDistance(collider, player.x, direction)
-      }))
-      .filter((candidate) =>
-        candidate.distance >= 0 &&
-        canMantleLedge({
-          playerX: player.x,
-          playerBottomY: bottomY,
-          moveAxis: commands.moveAxis,
-          ledge: candidate.collider,
-          maxHorizontalDistance: RIDGE_MANTLE_HORIZONTAL_DISTANCE,
-          minVerticalDelta: RIDGE_MANTLE_MIN_VERTICAL_DELTA,
-          maxVerticalDelta: RIDGE_MANTLE_MAX_VERTICAL_DELTA
-        })
-      )
-      .sort((a, b) => a.distance - b.distance);
+    let closest:
+      | { collider: RidgeBlockoutCollider; distance: number }
+      | undefined;
+    for (const collider of this.mantleTargets) {
+      const distance = getHorizontalLedgeDistance(collider, player.x, direction);
+      if (distance < 0 || (closest && distance >= closest.distance)) continue;
+      if (!canMantleLedge({
+        playerX: player.x,
+        playerBottomY: bottomY,
+        moveAxis: commands.moveAxis,
+        ledge: collider,
+        maxHorizontalDistance: RIDGE_MANTLE_HORIZONTAL_DISTANCE,
+        minVerticalDelta: RIDGE_MANTLE_MIN_VERTICAL_DELTA,
+        maxVerticalDelta: RIDGE_MANTLE_MAX_VERTICAL_DELTA
+      })) {
+        continue;
+      }
 
-    const target = ledges[0]?.collider;
+      closest = { collider, distance };
+    }
+
+    const target = closest?.collider;
     if (!target) return false;
 
     const topY = getLedgeTop(target);
@@ -460,14 +463,6 @@ class RidgeTraversalRuntimeImpl implements RidgeTraversalRuntime {
   }
 }
 
-function isNearTraversalLine(
-  zone: RidgeBlockoutAssistZone,
-  point: { x: number; y: number },
-  maxDistance: number
-): boolean {
-  return isPointNearTraversalLine(zone, point, maxDistance);
-}
-
 function isSolidCollider(collider: RidgeBlockoutCollider): boolean {
   return collider.kind === 'solid';
 }
@@ -491,13 +486,15 @@ function findClosestLedge(
   direction: number,
   maxDistance: number
 ): { collider: RidgeBlockoutCollider; distance: number } | undefined {
-  return colliders
-    .map((collider) => ({
-      collider,
-      distance: getHorizontalLedgeDistance(collider, playerX, direction)
-    }))
-    .filter((candidate) => candidate.distance >= 0 && candidate.distance <= maxDistance)
-    .sort((a, b) => a.distance - b.distance)[0];
+  let closest: { collider: RidgeBlockoutCollider; distance: number } | undefined;
+  for (const collider of colliders) {
+    const distance = getHorizontalLedgeDistance(collider, playerX, direction);
+    if (distance < 0 || distance > maxDistance) continue;
+    if (!closest || distance < closest.distance) {
+      closest = { collider, distance };
+    }
+  }
+  return closest;
 }
 
 function getHorizontalLedgeDistance(
@@ -513,12 +510,4 @@ function getHorizontalLedgeDistance(
 
 function getColliderTop(collider: RidgeBlockoutCollider): number {
   return collider.y - collider.height / 2;
-}
-
-function linear(start: number, end: number, amount: number): number {
-  return start + (end - start) * amount;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
 }

--- a/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.ts
+++ b/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.ts
@@ -1,0 +1,524 @@
+import type { InputCommandFrame } from '@/game/core/input/commands';
+import type {
+  RidgeBlockoutAssistZone,
+  RidgeBlockoutCollider,
+  RidgeBlockoutGeometry
+} from '../blockout';
+import {
+  canMantleLedge,
+  canStepUp,
+  chooseFallRecovery,
+  getClimbProgressDelta,
+  getFrameRateIndependentLerpAlpha,
+  getLedgeTop,
+  getPointOnTraversalSegment,
+  isMantleTargetCollider,
+  isPointNearTraversalLine,
+  isTraversalPathOccludedBySolid,
+  projectPointToSegmentT,
+  resolveWalkableRampSurfaceY,
+  shouldMaintainClimbAttachment,
+  type RidgeSafePosition
+} from './traversalComfort';
+
+export interface RidgeTraversalBody {
+  readonly width: number;
+  readonly height: number;
+  readonly bottom: number;
+  readonly velocity: {
+    x: number;
+    y: number;
+  };
+  readonly touching: {
+    down: boolean;
+  };
+  readonly blocked: {
+    down: boolean;
+  };
+  setAllowGravity(allowGravity: boolean): void;
+}
+
+export interface RidgeTraversalPlayer {
+  x: number;
+  y: number;
+  readonly body: RidgeTraversalBody;
+  setVelocityX(velocityX: number): void;
+  setVelocityY(velocityY: number): void;
+}
+
+export type RidgeTraversalAssistName =
+  | 'grounding'
+  | 'climb'
+  | 'climb-release'
+  | 'ramp'
+  | 'drop'
+  | 'step-up'
+  | 'mantle'
+  | 'fall-recovery'
+  | 'safe-capture';
+
+export interface RidgeTraversalRuntimeState {
+  activeClimbZoneId: string | null;
+  lastSafePosition?: RidgeSafePosition;
+  mantleTargetCount: number;
+  solidBlockerCount: number;
+}
+
+export interface RidgeTraversalPrimeGroundingResult {
+  grounded: boolean;
+  appliedAssists: readonly RidgeTraversalAssistName[];
+  state: RidgeTraversalRuntimeState;
+}
+
+export interface RidgeTraversalUpdateFrame {
+  player: RidgeTraversalPlayer;
+  commands: InputCommandFrame;
+  deltaMs: number;
+}
+
+export interface RidgeTraversalFrameResult {
+  appliedAssists: readonly RidgeTraversalAssistName[];
+  state: RidgeTraversalRuntimeState;
+}
+
+export interface RidgeTraversalRuntime {
+  primeGrounding(player: RidgeTraversalPlayer): RidgeTraversalPrimeGroundingResult;
+  update(frame: RidgeTraversalUpdateFrame): RidgeTraversalFrameResult;
+  getState(): RidgeTraversalRuntimeState;
+}
+
+export interface RidgeTraversalRuntimeOptions {
+  geometry: RidgeBlockoutGeometry;
+  initialSafePosition?: RidgeSafePosition;
+}
+
+const RIDGE_RAMP_SNAP = {
+  maxSnapDownY: 28,
+  maxSnapUpY: 8
+} as const;
+const RIDGE_CLIMB_ATTACH_DISTANCE = 22;
+const RIDGE_DROP_ATTACH_DISTANCE = 28;
+const RIDGE_MANTLE_HORIZONTAL_DISTANCE = 32;
+const RIDGE_MANTLE_MIN_VERTICAL_DELTA = 24;
+const RIDGE_MANTLE_MAX_VERTICAL_DELTA = 96;
+const RIDGE_MANTLE_MIN_VELOCITY_Y = -20;
+const RIDGE_STEP_UP_MAX_HEIGHT = 18;
+const RIDGE_STEP_UP_HORIZONTAL_DISTANCE = 22;
+const RIDGE_CLIMB_PROGRESS_PER_SECOND = 0.36;
+const RIDGE_DROP_LERP_ALPHA_AT_60FPS = 0.08;
+const RIDGE_FALL_RECOVERY_THRESHOLD_Y = 48;
+
+export function createRidgeTraversalRuntime(
+  options: RidgeTraversalRuntimeOptions
+): RidgeTraversalRuntime {
+  return new RidgeTraversalRuntimeImpl(options);
+}
+
+class RidgeTraversalRuntimeImpl implements RidgeTraversalRuntime {
+  private readonly geometry: RidgeBlockoutGeometry;
+  private readonly solidBlockers: readonly RidgeBlockoutCollider[];
+  private readonly mantleTargets: readonly RidgeBlockoutCollider[];
+  private activeClimbZoneId: string | null = null;
+  private lastSafePosition?: RidgeSafePosition;
+
+  constructor(options: RidgeTraversalRuntimeOptions) {
+    this.geometry = options.geometry;
+    this.solidBlockers = options.geometry.gridColliders.filter(isSolidCollider);
+    this.mantleTargets = options.geometry.colliders.filter(isMantleTargetCollider);
+    this.lastSafePosition = options.initialSafePosition;
+  }
+
+  primeGrounding(player: RidgeTraversalPlayer): RidgeTraversalPrimeGroundingResult {
+    const bottomY = getPlayerBottomY(player);
+    const ramp = resolveWalkableRampSurfaceY(
+      this.geometry.assistZones,
+      { x: player.x, y: bottomY },
+      RIDGE_RAMP_SNAP
+    );
+    const climb = this.geometry.assistZones.find((zone) =>
+      zone.kind === 'climb' &&
+      isNearTraversalLine(zone, { x: player.x, y: bottomY }, RIDGE_CLIMB_ATTACH_DISTANCE)
+    );
+
+    if (!ramp && !climb) {
+      return {
+        grounded: false,
+        appliedAssists: [],
+        state: this.getState()
+      };
+    }
+
+    markBodyGrounded(player.body);
+    return {
+      grounded: true,
+      appliedAssists: ['grounding'],
+      state: this.getState()
+    };
+  }
+
+  update(frame: RidgeTraversalUpdateFrame): RidgeTraversalFrameResult {
+    const appliedAssists: RidgeTraversalAssistName[] = [];
+    const didClimb = this.applyClimbAssist(frame, appliedAssists);
+
+    if (!didClimb) {
+      this.releaseClimbAttachment(frame.player, appliedAssists);
+      this.applyRampAssist(frame.player, frame.commands, appliedAssists);
+      this.applyDropAssist(frame.player, frame.deltaMs, appliedAssists);
+      this.applyStepUpAssist(frame.player, frame.commands, appliedAssists);
+      this.applyMantleAssist(frame.player, frame.commands, appliedAssists);
+    }
+
+    this.recoverFromWorldBottom(frame.player, appliedAssists);
+    this.captureLastSafePosition(frame.player, appliedAssists);
+
+    return {
+      appliedAssists,
+      state: this.getState()
+    };
+  }
+
+  getState(): RidgeTraversalRuntimeState {
+    return {
+      activeClimbZoneId: this.activeClimbZoneId,
+      lastSafePosition: this.lastSafePosition
+        ? { ...this.lastSafePosition }
+        : undefined,
+      mantleTargetCount: this.mantleTargets.length,
+      solidBlockerCount: this.solidBlockers.length
+    };
+  }
+
+  private applyRampAssist(
+    player: RidgeTraversalPlayer,
+    commands: InputCommandFrame,
+    appliedAssists: RidgeTraversalAssistName[]
+  ): boolean {
+    if (commands.jump) return false;
+
+    const body = player.body;
+    const bottomY = getPlayerBottomY(player);
+    const ramp = resolveWalkableRampSurfaceY(
+      this.geometry.assistZones,
+      { x: player.x, y: bottomY },
+      RIDGE_RAMP_SNAP
+    );
+    if (!ramp || body.velocity.y < -60) return false;
+
+    const target = { x: player.x, y: ramp.y - body.height / 2 };
+    if (this.isAssistPathOccluded(player, target)) return false;
+
+    player.y = target.y;
+    player.setVelocityY(0);
+    markBodyGrounded(body);
+    appliedAssists.push('ramp');
+    return true;
+  }
+
+  private applyClimbAssist(
+    frame: RidgeTraversalUpdateFrame,
+    appliedAssists: RidgeTraversalAssistName[]
+  ): boolean {
+    const { player, commands, deltaMs } = frame;
+    const zone = this.geometry.assistZones.find((candidate) =>
+      candidate.kind === 'climb' &&
+      isNearTraversalLine(
+        candidate,
+        { x: player.x, y: getPlayerBottomY(player) },
+        RIDGE_CLIMB_ATTACH_DISTANCE
+      )
+    );
+    const isAttached = this.activeClimbZoneId !== null;
+    if (!zone) return false;
+    if (
+      commands.verticalAxis === 0 &&
+      !shouldMaintainClimbAttachment({
+        attached: isAttached,
+        jump: commands.jump,
+        horizontalAxis: commands.moveAxis,
+        nearClimbLine: true
+      })
+    ) {
+      return false;
+    }
+    if (commands.jump) return false;
+
+    const currentT = projectPointToSegmentT(
+      { x: player.x, y: getPlayerBottomY(player) },
+      zone
+    );
+    const nextT = clamp(
+      currentT + getClimbProgressDelta({
+        verticalAxis: commands.verticalAxis,
+        fromY: zone.from.y,
+        toY: zone.to.y,
+        progressPerSecond: RIDGE_CLIMB_PROGRESS_PER_SECOND,
+        deltaMs
+      }),
+      0,
+      1
+    );
+    const point = getPointOnTraversalSegment(zone, nextT);
+    const target = { x: point.x, y: point.y - player.body.height / 2 };
+    if (this.isAssistPathOccluded(player, target)) return false;
+
+    this.activeClimbZoneId = zone.id;
+    player.body.setAllowGravity(false);
+    player.x = target.x;
+    player.y = target.y;
+    player.setVelocityX(0);
+    player.setVelocityY(0);
+    markBodyGrounded(player.body);
+    appliedAssists.push('climb');
+    return true;
+  }
+
+  private releaseClimbAttachment(
+    player: RidgeTraversalPlayer,
+    appliedAssists: RidgeTraversalAssistName[]
+  ): void {
+    if (!this.activeClimbZoneId) return;
+    this.activeClimbZoneId = null;
+    player.body.setAllowGravity(true);
+    appliedAssists.push('climb-release');
+  }
+
+  private applyDropAssist(
+    player: RidgeTraversalPlayer,
+    deltaMs: number,
+    appliedAssists: RidgeTraversalAssistName[]
+  ): boolean {
+    if (player.body.velocity.y <= 0) return false;
+
+    const zone = this.geometry.assistZones.find((candidate) =>
+      candidate.kind === 'drop' &&
+      isNearTraversalLine(candidate, { x: player.x, y: player.y }, RIDGE_DROP_ATTACH_DISTANCE)
+    );
+    if (!zone) return false;
+
+    const t = projectPointToSegmentT({ x: player.x, y: player.y }, zone);
+    const point = getPointOnTraversalSegment(zone, t);
+    const target = {
+      x: linear(
+        player.x,
+        point.x,
+        getFrameRateIndependentLerpAlpha(RIDGE_DROP_LERP_ALPHA_AT_60FPS, deltaMs)
+      ),
+      y: player.y
+    };
+    if (this.isAssistPathOccluded(player, target)) return false;
+
+    player.x = target.x;
+    appliedAssists.push('drop');
+    return true;
+  }
+
+  private applyStepUpAssist(
+    player: RidgeTraversalPlayer,
+    commands: InputCommandFrame,
+    appliedAssists: RidgeTraversalAssistName[]
+  ): boolean {
+    if (commands.moveAxis === 0 || !isBodyGrounded(player.body)) return false;
+
+    const direction = Math.sign(commands.moveAxis);
+    const bottomY = getPlayerBottomY(player);
+    const candidate = findClosestLedge(
+      this.geometry.colliders,
+      player.x,
+      direction,
+      RIDGE_STEP_UP_HORIZONTAL_DISTANCE
+    )?.collider;
+    if (!candidate) return false;
+
+    const topY = getColliderTop(candidate);
+    if (!canStepUp({
+      playerBottomY: bottomY,
+      obstacleTopY: topY,
+      maxStepHeight: RIDGE_STEP_UP_MAX_HEIGHT
+    })) {
+      return false;
+    }
+
+    const target = {
+      x: player.x + direction * 18,
+      y: topY - player.body.height / 2
+    };
+    if (this.isAssistPathOccluded(player, target)) return false;
+
+    player.x = target.x;
+    player.y = target.y;
+    player.setVelocityY(0);
+    markBodyGrounded(player.body);
+    appliedAssists.push('step-up');
+    return true;
+  }
+
+  private applyMantleAssist(
+    player: RidgeTraversalPlayer,
+    commands: InputCommandFrame,
+    appliedAssists: RidgeTraversalAssistName[]
+  ): boolean {
+    if (commands.moveAxis === 0) return false;
+    if (isBodyGrounded(player.body)) return false;
+    if (player.body.velocity.y < RIDGE_MANTLE_MIN_VELOCITY_Y) return false;
+
+    const direction = Math.sign(commands.moveAxis);
+    const bottomY = getPlayerBottomY(player);
+    const ledges = this.mantleTargets
+      .map((collider) => ({
+        collider,
+        distance: getHorizontalLedgeDistance(collider, player.x, direction)
+      }))
+      .filter((candidate) =>
+        candidate.distance >= 0 &&
+        canMantleLedge({
+          playerX: player.x,
+          playerBottomY: bottomY,
+          moveAxis: commands.moveAxis,
+          ledge: candidate.collider,
+          maxHorizontalDistance: RIDGE_MANTLE_HORIZONTAL_DISTANCE,
+          minVerticalDelta: RIDGE_MANTLE_MIN_VERTICAL_DELTA,
+          maxVerticalDelta: RIDGE_MANTLE_MAX_VERTICAL_DELTA
+        })
+      )
+      .sort((a, b) => a.distance - b.distance);
+
+    const target = ledges[0]?.collider;
+    if (!target) return false;
+
+    const topY = getLedgeTop(target);
+    const nextPosition = {
+      x: direction > 0
+        ? target.x - target.width / 2 + player.body.width / 2 + 6
+        : target.x + target.width / 2 - player.body.width / 2 - 6,
+      y: topY - player.body.height / 2
+    };
+    if (this.isAssistPathOccluded(player, nextPosition)) return false;
+
+    player.x = nextPosition.x;
+    player.y = nextPosition.y;
+    player.setVelocityY(0);
+    markBodyGrounded(player.body);
+    appliedAssists.push('mantle');
+    return true;
+  }
+
+  private isAssistPathOccluded(
+    player: RidgeTraversalPlayer,
+    target: { x: number; y: number }
+  ): boolean {
+    return isTraversalPathOccludedBySolid({
+      from: { x: player.x, y: player.y },
+      to: target,
+      bodySize: {
+        width: player.body.width,
+        height: player.body.height
+      },
+      solidRects: this.solidBlockers
+    });
+  }
+
+  private recoverFromWorldBottom(
+    player: RidgeTraversalPlayer,
+    appliedAssists: RidgeTraversalAssistName[]
+  ): boolean {
+    const recovery = chooseFallRecovery({
+      playerY: player.y,
+      worldBottomY: this.geometry.bounds.y + this.geometry.bounds.height,
+      thresholdY: RIDGE_FALL_RECOVERY_THRESHOLD_Y,
+      lastSafePosition: this.lastSafePosition
+    });
+    if (!recovery) return false;
+
+    player.x = recovery.x;
+    player.y = recovery.y;
+    player.setVelocityX(0);
+    player.setVelocityY(0);
+    appliedAssists.push('fall-recovery');
+    return true;
+  }
+
+  private captureLastSafePosition(
+    player: RidgeTraversalPlayer,
+    appliedAssists: RidgeTraversalAssistName[]
+  ): boolean {
+    const bottomBandY = this.geometry.bounds.y +
+      this.geometry.bounds.height -
+      RIDGE_FALL_RECOVERY_THRESHOLD_Y;
+    if (player.y >= bottomBandY) return false;
+
+    const bottomY = getPlayerBottomY(player);
+    const ramp = resolveWalkableRampSurfaceY(
+      this.geometry.assistZones,
+      { x: player.x, y: bottomY },
+      RIDGE_RAMP_SNAP
+    );
+    if (!isBodyGrounded(player.body) && !ramp) return false;
+
+    this.lastSafePosition = { x: player.x, y: player.y };
+    appliedAssists.push('safe-capture');
+    return true;
+  }
+}
+
+function isNearTraversalLine(
+  zone: RidgeBlockoutAssistZone,
+  point: { x: number; y: number },
+  maxDistance: number
+): boolean {
+  return isPointNearTraversalLine(zone, point, maxDistance);
+}
+
+function isSolidCollider(collider: RidgeBlockoutCollider): boolean {
+  return collider.kind === 'solid';
+}
+
+function getPlayerBottomY(player: RidgeTraversalPlayer): number {
+  return player.body.bottom;
+}
+
+function markBodyGrounded(body: RidgeTraversalBody): void {
+  body.touching.down = true;
+  body.blocked.down = true;
+}
+
+function isBodyGrounded(body: RidgeTraversalBody): boolean {
+  return body.touching.down || body.blocked.down;
+}
+
+function findClosestLedge(
+  colliders: readonly RidgeBlockoutCollider[],
+  playerX: number,
+  direction: number,
+  maxDistance: number
+): { collider: RidgeBlockoutCollider; distance: number } | undefined {
+  return colliders
+    .map((collider) => ({
+      collider,
+      distance: getHorizontalLedgeDistance(collider, playerX, direction)
+    }))
+    .filter((candidate) => candidate.distance >= 0 && candidate.distance <= maxDistance)
+    .sort((a, b) => a.distance - b.distance)[0];
+}
+
+function getHorizontalLedgeDistance(
+  collider: RidgeBlockoutCollider,
+  playerX: number,
+  direction: number
+): number {
+  const left = collider.x - collider.width / 2;
+  const right = collider.x + collider.width / 2;
+  if (direction > 0) return left - playerX;
+  return playerX - right;
+}
+
+function getColliderTop(collider: RidgeBlockoutCollider): number {
+  return collider.y - collider.height / 2;
+}
+
+function linear(start: number, end: number, amount: number): number {
+  return start + (end - start) * amount;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/game/scenes/ridge/runtime/traversalComfort.ts
+++ b/src/game/scenes/ridge/runtime/traversalComfort.ts
@@ -263,11 +263,11 @@ export function getLedgeTop(ledge: RidgeLedgeCandidate): number {
   return ledge.y - ledge.height / 2;
 }
 
-function lerp(start: number, end: number, t: number): number {
+export function lerp(start: number, end: number, t: number): number {
   return start + (end - start) * t;
 }
 
-function clamp(value: number, min: number, max: number): number {
+export function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 


### PR DESCRIPTION
## Summary
- Added a Ridge-local traversal runtime that owns assist ordering for grounding, ramp walking, climb/drop handling, step-up, mantle, and fall recovery.
- Kept the low-level traversal math in `traversalComfort.ts` and moved scene orchestration out of `RidgeScene`.
- Added runtime-focused tests covering assist ordering, solid-wall blocking, and last-safe recovery behavior.

## Testing
- `npm test`
- `npm run check:types`
- `npm run lint`
- Local browser smoke on Ridge confirmed the scene boots and the early traversal path remains playable.