### PR TITLE
Extract Ridge presentation and interaction seams from RidgeScene

### DIFF
--- a/docs/agents/sketchbook-ridge-team.md
+++ b/docs/agents/sketchbook-ridge-team.md
@@ -86,6 +86,14 @@ The Producer should not:
 
 Purpose: prevent merge-conflict mountains and architecture drift.
 
+The Architect has two useful workflow skills:
+
+- [`.agents/skills/zoom-out/SKILL.md`](../../.agents/skills/zoom-out/SKILL.md)
+  for mapping unfamiliar modules and callers before making a sequencing call.
+- [`.agents/skills/improve-codebase-architecture/SKILL.md`](../../.agents/skills/improve-codebase-architecture/SKILL.md)
+  for deeper architecture reviews that look for better module depth,
+  leverage, locality, and test seams.
+
 The Architect owns:
 
 - shared seam sequencing

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -29,46 +29,30 @@ import {
   RIDGE_BLOCKOUT,
   compileRidgeBlockoutFacts,
   deriveRidgeBlockoutGeometry,
-  type RidgeBlockoutAnchorPoint,
-  type RidgeBlockoutAnchorSelector,
-  type RidgeBlockoutAssistZone,
-  type RidgeBlockoutBounds,
-  type RidgeBlockoutCollider,
   type RidgeBlockoutGeometry,
-  type RidgeBlockoutFacts,
-  type RidgeBlockoutRoomBounds,
-  type RidgeAnchorFact,
-  findRidgeBlockoutFactAnchor
+  type RidgeBlockoutFacts
 } from '../blockout';
+import { getRidgeWorldMemories } from '../worldMemory';
 import {
-  RIDGE_TRAIL_CARD_TARGETS,
-  type RidgeTrailCardTargetId
-} from '../worldLayout';
-import {
-  getRidgeWorldMemories,
-  hasRidgeWorldMemory,
-  type RidgeWorldMemory
-} from '../worldMemory';
-import {
-  CICKA_INTERACTION_TARGET_ID,
-  getCickaInteractionResponse,
   shouldShowCickaInteractionPrompt,
-  type CickaInteractionCopy,
-  type CickaInteractionResponse
+  type CickaInteractionCopy
 } from '../cicka/interaction';
 import {
   createCickaAnimations,
   preloadCickaAssets
 } from '../cicka/assets';
-import {
-  createCickaPerch,
-  type CickaPerch
-} from '../cicka/CickaPerch';
-import type { TrailCardOverlayParams } from '@/game/overlays/trailCard/types';
+import type { CickaPerch } from '../cicka/CickaPerch';
 import {
   createRidgeTraversalRuntime,
   type RidgeTraversalRuntime
 } from './ridgeTraversalRuntime';
+import { createRidgeBlockoutPresentation } from './ridgeBlockoutPresentation';
+import { createRidgeLandmarkPresentation } from './ridgeLandmarkPresentation';
+import {
+  createRidgeInteractionTargets,
+  type RidgeInteractionEffect,
+  type RidgeInteractionTargetId
+} from './ridgeInteractionTargets';
 
 interface RidgeSceneStartData {
   onClose?: () => void;
@@ -77,18 +61,7 @@ interface RidgeSceneStartData {
   resumePosition?: { x: number; y: number };
 }
 
-type RidgeInteractionEffect =
-  | { kind: 'close' }
-  | { kind: 'openTrailCard'; params: TrailCardOverlayParams }
-  | { kind: 'showCickaResponse'; response: CickaInteractionResponse };
-
-type RidgeInteractionTargetId =
-  | RidgeTrailCardTargetId
-  | typeof CICKA_INTERACTION_TARGET_ID;
-
 const PLAYER_SPAWN_OFFSET_Y = -80;
-const CICKA_PERCH_OFFSET_Y = -10;
-const TRAIL_CARD_PROMPT_OFFSET_Y = -86;
 const RIDGE_PLAYER_EDGE_PADDING = 48;
 const RIDGE_COYOTE_TIME_MS = 120;
 const RIDGE_JUMP_BUFFER_MS = 120;
@@ -156,22 +129,23 @@ export class RidgeScene extends Phaser.Scene {
     );
     createCickaAnimations(this);
 
-    const worldMemories = getRidgeWorldMemories(ridgeProgress);
-    this.addBackdrop(geometry.bounds);
-    this.addRoomBounds(geometry.roomBounds);
-    this.addFutureRoutePromises(facts);
-    this.addTraversalConnectorVisuals(geometry);
-    const platforms = this.addBlockoutColliders(geometry);
-    this.addShortcutPromises(facts);
-    this.addAnchorMarkers(geometry);
-    this.addLandmarksFromBlockout(
+    const blockoutPresentation = createRidgeBlockoutPresentation({
+      scene: this,
       facts,
-      messages.scenes.ridge.memory.stampedeFirstClearLabel,
-      messages.scenes.ridge.memory.cickaWalkByBark,
-      worldMemories
-    );
-    this.addPlaceholderCopy(facts, messages.catalog.ridge.ridge.name);
-    this.createPlayer(platforms, facts, geometry);
+      geometry
+    });
+    const landmarkPresentation = createRidgeLandmarkPresentation({
+      scene: this,
+      facts,
+      copy: {
+        title: messages.catalog.ridge.ridge.name,
+        stampedeFirstClearLabel: messages.scenes.ridge.memory.stampedeFirstClearLabel,
+        cickaWalkByLine: messages.scenes.ridge.memory.cickaWalkByBark
+      },
+      worldMemories: getRidgeWorldMemories(ridgeProgress)
+    });
+    this.cickaPerch = landmarkPresentation.cickaPerch;
+    this.createPlayer(blockoutPresentation.platforms, facts, geometry);
     this.createRidgeInteractions(
       messages.navigation.interact,
       messages.scenes.ridge.cicka.interaction,
@@ -240,255 +214,6 @@ export class RidgeScene extends Phaser.Scene {
     }
 
     this.interactPrompt?.setPosition(interaction.prompt.x, interaction.prompt.y).setVisible(true);
-  }
-
-  private addBackdrop(bounds: RidgeBlockoutBounds): void {
-    this.add.rectangle(
-      bounds.width / 2,
-      bounds.height / 2,
-      bounds.width,
-      bounds.height,
-      0xf7f1df,
-      1
-    ).setDepth(-100);
-
-    const graphics = this.add.graphics().setDepth(-90);
-    graphics.lineStyle(3, 0x1f1f1d, 0.06);
-    for (let y = 160; y < bounds.height; y += 420) {
-      graphics.strokeLineShape(new Phaser.Geom.Line(0, y, bounds.width, y));
-    }
-
-    for (let x = 180; x < bounds.width; x += 420) {
-      const y = 260 + Math.sin(x / 180) * 34;
-      graphics.lineStyle(4, 0x1f1f1d, 0.12);
-      graphics.strokeLineShape(new Phaser.Geom.Line(x - 150, y + 34, x + 150, y - 34));
-      graphics.lineStyle(3, 0x1f1f1d, 0.09);
-      graphics.strokeLineShape(new Phaser.Geom.Line(x - 52, y + 60, x + 140, y + 24));
-    }
-  }
-
-  private addRoomBounds(roomBounds: readonly RidgeBlockoutRoomBounds[]): void {
-    roomBounds.forEach((room) => {
-      this.add.rectangle(
-        room.x + room.width / 2,
-        room.y + room.height / 2,
-        room.width,
-        room.height,
-        0xf7f1df,
-        0.03
-      )
-        .setStrokeStyle(2, 0x1f1f1d, 0.12)
-        .setDepth(-20);
-      this.add.text(room.x + 12, room.y + 12, room.title, {
-        fontFamily: 'monospace',
-        fontSize: '16px',
-        color: '#4b4337',
-        backgroundColor: '#f7f1dfcc',
-        padding: { x: 4, y: 2 }
-      }).setDepth(20);
-    });
-  }
-
-  private addFutureRoutePromises(facts: RidgeBlockoutFacts): void {
-    const graphics = this.add.graphics().setDepth(-8);
-    graphics.lineStyle(3, 0x596f8f, 0.18);
-
-    facts.futureRoutes.forEach((route) => {
-      route.links.forEach((link) => {
-        const from = this.getRoomCenter(facts, link.fromRoomId);
-        const to = this.getRoomCenter(facts, link.toRoomId);
-        if (!from || !to) return;
-        graphics.strokeLineShape(new Phaser.Geom.Line(from.x, from.y, to.x, to.y));
-      });
-    });
-  }
-
-  private addTraversalConnectorVisuals(geometry: RidgeBlockoutGeometry): void {
-    const graphics = this.add.graphics().setDepth(3);
-    geometry.routeConnectors.forEach((connector) => {
-      connector.assistZones.forEach((zone) => {
-        const color = getAssistZoneColor(zone);
-        if (zone.kind === 'climb') {
-          drawLadderVisual(graphics, zone, color);
-          this.add.rectangle(zone.x, zone.y, 24, zone.height, 0x1f1f1d, 0.08)
-            .setStrokeStyle(2, color, 0.28)
-            .setDepth(2);
-          return;
-        }
-
-        graphics.lineStyle(8, color, zone.kind === 'drop' ? 0.24 : 0.38);
-        graphics.strokeLineShape(new Phaser.Geom.Line(
-          zone.from.x,
-          zone.from.y,
-          zone.to.x,
-          zone.to.y
-        ));
-      });
-    });
-
-    geometry.shortcutConnections.forEach((connection) => {
-      connection.assistZones.forEach((zone) => {
-        graphics.lineStyle(6, getAssistZoneColor(zone), 0.3);
-        graphics.strokeLineShape(new Phaser.Geom.Line(
-          zone.from.x,
-          zone.from.y,
-          zone.to.x,
-          zone.to.y
-        ));
-      });
-    });
-  }
-
-  private addBlockoutColliders(
-    geometry: RidgeBlockoutGeometry
-  ): Phaser.GameObjects.Zone[] {
-    return geometry.colliders.map((collider) => {
-      this.addColliderVisual(collider);
-      const zone = this.add.zone(collider.x, collider.y, collider.width, collider.height);
-      this.physics.add.existing(zone, true);
-      return zone;
-    });
-  }
-
-  private addColliderVisual(collider: RidgeBlockoutCollider): void {
-    const style = getColliderStyle(collider);
-    this.add.rectangle(
-      collider.x,
-      collider.y,
-      collider.width,
-      collider.height,
-      style.fill,
-      style.alpha
-    )
-      .setStrokeStyle(style.strokeWidth, 0x1f1f1d, style.strokeAlpha)
-      .setDepth(style.depth);
-  }
-
-  private addShortcutPromises(facts: RidgeBlockoutFacts): void {
-    facts.shortcuts.forEach((connection) => {
-      if (!connection.from) return;
-      const graphics = this.add.graphics().setDepth(6);
-      graphics.lineStyle(4, connection.available ? 0xf0d35f : 0x1f1f1d, connection.available ? 0.34 : 0.16);
-      graphics.strokeLineShape(new Phaser.Geom.Line(
-        connection.from.x,
-        connection.from.y,
-        connection.to.x,
-        connection.to.y
-      ));
-
-      if (!connection.available) {
-        const centerX = (connection.from.x + connection.to.x) / 2;
-        const centerY = (connection.from.y + connection.to.y) / 2;
-        this.add.rectangle(centerX, centerY, 96, 18, 0xf7f1df, 0.24)
-          .setStrokeStyle(2, 0x1f1f1d, 0.18)
-          .setAngle(-4)
-          .setDepth(7);
-      }
-    });
-  }
-
-  private addAnchorMarkers(geometry: RidgeBlockoutGeometry): void {
-    geometry.anchorPoints.forEach((anchor) => {
-      if (!['A', '*', '?', '^', 'N', 'M'].includes(anchor.symbol)) return;
-      this.add.circle(anchor.x, anchor.y, 9, getAnchorColor(anchor), 0.58)
-        .setStrokeStyle(2, 0x1f1f1d, 0.45)
-        .setDepth(14);
-      this.add.text(anchor.x + 12, anchor.y - 14, anchor.symbol, {
-        fontFamily: 'monospace',
-        fontSize: '13px',
-        color: '#1f1f1d',
-        backgroundColor: '#f7f1df99',
-        padding: { x: 2, y: 1 }
-      }).setDepth(15);
-    });
-  }
-
-  private addLandmarksFromBlockout(
-    facts: RidgeBlockoutFacts,
-    stampedeFirstClearLabel: string,
-    cickaWalkByLine: string,
-    worldMemories: readonly RidgeWorldMemory[]
-  ): void {
-    this.cickaPerch = undefined;
-
-    const cickaPoint = requireRidgeBlockoutFactAnchor(facts, {
-      roomId: 'cicka_home',
-      symbol: 'C',
-      kind: 'npc',
-      attrId: 'cicka'
-    }, 'Cicka Home perch');
-    this.cickaPerch = createCickaPerch({
-      scene: this,
-      landmark: {
-        x: cickaPoint.x,
-        y: cickaPoint.y + CICKA_PERCH_OFFSET_Y
-      },
-      hasStampedeNoteMemory: hasRidgeWorldMemory(
-        worldMemories.filter((memory) => memory.landmarkKind === 'cicka-perch'),
-        'cicka-stampede-note'
-      ),
-      walkByLine: cickaWalkByLine
-    });
-
-    const outskirtsArtifact = requireRidgeBlockoutFactAnchor(facts, {
-      roomId: 'outskirts',
-      symbol: 'A',
-      attrId: 'city_edge_memory'
-    }, 'Outskirts artifact');
-    this.addOutskirtsArtifactSlot(outskirtsArtifact.x, outskirtsArtifact.y);
-
-    const stampedePoint = requireRidgeBlockoutFactAnchor(facts, {
-      roomId: 'stampede_blanket',
-      symbol: '*',
-      kind: 'minigame',
-      attrId: 'stampede_sketch'
-    }, 'Stampede blanket');
-    this.addStampedeBlanket(
-      stampedePoint.x,
-      stampedePoint.y,
-      stampedeFirstClearLabel,
-      worldMemories.filter((memory) => memory.landmarkKind === 'stampede-blanket')
-    );
-
-    const telegraphPoint = requireRidgeBlockoutFactAnchor(facts, {
-      roomId: 'telegraph_terrace',
-      symbol: '*',
-      kind: 'minigame',
-      attrId: 'telegraph_future'
-    }, 'Telegraph Terrace bag');
-    this.addTelegraphBag(telegraphPoint.x, telegraphPoint.y);
-
-    const guidePoint = requireRidgeBlockoutFactAnchor(facts, {
-      roomId: 'guide_overlook',
-      symbol: 'N',
-      kind: 'npc',
-      attrId: 'ridge_guide'
-    }, 'Ridge guide');
-    this.addRidgeGuide(guidePoint.x, guidePoint.y);
-
-    const relayPoint = requireRidgeBlockoutFactAnchor(facts, {
-      roomId: 'relay_gate',
-      symbol: '?',
-      kind: 'gate',
-      attrId: 'relay_proof_slots'
-    }, 'Relay Gate');
-    this.addRelayGate(relayPoint.x, relayPoint.y);
-    this.addRelaySpire(relayPoint.x + 230, relayPoint.y - 180);
-
-    const dominoPoint = requireRidgeBlockoutFactAnchor(facts, {
-      roomId: 'domino_desk',
-      symbol: 'A',
-      attrId: 'domino_project_scrap'
-    }, 'Domino Desk');
-    this.addDominoDesk(dominoPoint.x, dominoPoint.y);
-
-    const highLedgePoint = requireRidgeBlockoutFactAnchor(facts, {
-      roomId: 'high_ledge',
-      symbol: '?',
-      kind: 'gate',
-      attrId: 'movement_reward_tease'
-    }, 'High Ledge teaser');
-    this.addHighLedgeTeaser(highLedgePoint.x, highLedgePoint.y);
   }
 
   private createPlayer(
@@ -575,298 +300,12 @@ export class RidgeScene extends Phaser.Scene {
     >({
       interactRadius: 72,
       exitEffect: { kind: 'close' },
-      targets: [
-        ...(this.cickaPerch ? [{
-          ...this.cickaPerch.interactionFacts,
-          effect: (): RidgeInteractionEffect => ({
-            kind: 'showCickaResponse',
-            response: getCickaInteractionResponse(
-              getRidgeWorldMemories(bridgeStore.getState().progress.ridge),
-              cickaInteractionCopy
-            )
-          })
-        }] : []),
-        ...this.createTrailCardTargets(facts)
-      ]
-    });
-  }
-
-  private createTrailCardTargets(
-    facts: RidgeBlockoutFacts
-  ): Array<{
-    id: RidgeTrailCardTargetId;
-    kind: 'trail-card';
-    x: number;
-    distanceAnchorY: number;
-    prompt: { x: number; y: number };
-    effect: RidgeInteractionEffect;
-  }> {
-    return RIDGE_TRAIL_CARD_TARGETS.map((target) => {
-      const anchorPoint = requireRidgeBlockoutFactAnchor(
+      targets: createRidgeInteractionTargets({
         facts,
-        target.anchor,
-        `${target.id} Trail Card`
-      );
-      return {
-        id: target.id,
-        kind: 'trail-card',
-        x: anchorPoint.x,
-        distanceAnchorY: anchorPoint.y,
-        prompt: {
-          x: anchorPoint.x,
-          y: anchorPoint.y + TRAIL_CARD_PROMPT_OFFSET_Y
-        },
-        effect: {
-          kind: 'openTrailCard',
-          params: target.card
-        }
-      };
+        cickaPerch: this.cickaPerch,
+        cickaInteractionCopy,
+        getWorldMemories: () => getRidgeWorldMemories(bridgeStore.getState().progress.ridge)
+      })
     });
   }
-
-  private getRoomCenter(
-    facts: Pick<RidgeBlockoutFacts, 'rooms'>,
-    roomId: string
-  ): { x: number; y: number } | undefined {
-    const room = facts.rooms.find((candidate) => candidate.id === roomId);
-    return room
-      ? {
-        x: room.bounds.x + room.bounds.width / 2,
-        y: room.bounds.y + room.bounds.height / 2
-      }
-      : undefined;
-  }
-
-  private addOutskirtsArtifactSlot(x: number, y: number): void {
-    this.add.rectangle(x - 44, y + 22, 92, 8, 0x1f1f1d, 0.2).setDepth(18);
-    this.add.rectangle(x - 18, y - 4, 58, 36, 0xf7f1df, 0.94)
-      .setStrokeStyle(3, 0x1f1f1d, 0.72)
-      .setAngle(-5)
-      .setDepth(18);
-    this.add.rectangle(x + 34, y - 16, 34, 24, 0xf0d35f, 0.82)
-      .setStrokeStyle(2, 0x1f1f1d, 0.72)
-      .setAngle(7)
-      .setDepth(18);
-    this.add.circle(x + 34, y - 16, 4, 0x1f1f1d, 0.76).setDepth(19);
-    this.add.circle(x + 44, y - 10, 3, 0x1f1f1d, 0.76).setDepth(19);
-  }
-
-  private addStampedeBlanket(
-    x: number,
-    y: number,
-    stampedeFirstClearLabel: string,
-    memories: readonly RidgeWorldMemory[]
-  ): void {
-    this.add.rectangle(x, y + 22, 104, 32, 0xb85f5a, 0.9).setDepth(16);
-    this.add.rectangle(x - 26, y + 22, 18, 32, 0xf7f1df, 0.7).setDepth(17);
-    this.add.rectangle(x + 26, y + 22, 18, 32, 0xf7f1df, 0.7).setDepth(17);
-    this.add.circle(x - 22, y - 4, 11, 0x1f1f1d, 0.92).setDepth(17);
-    this.add.circle(x + 28, y + 2, 9, 0x1f1f1d, 0.75).setDepth(17);
-    if (memories.length) {
-      this.addStampedeBlanketMemories(x, y + 22, stampedeFirstClearLabel, memories);
-    }
-  }
-
-  private addStampedeBlanketMemories(
-    x: number,
-    y: number,
-    stampedeFirstClearLabel: string,
-    memories: readonly RidgeWorldMemory[]
-  ): void {
-    if (hasRidgeWorldMemory(memories, 'stampede-settled-swarm')) {
-      [
-        { x: -55, y: -36, radius: 4 },
-        { x: -42, y: -49, radius: 3 },
-        { x: -30, y: -39, radius: 2 },
-        { x: 54, y: -30, radius: 3 },
-        { x: 66, y: -43, radius: 2 }
-      ].forEach((dot) => {
-        this.add.circle(x + dot.x, y + dot.y, dot.radius, 0x1f1f1d, 0.24).setDepth(18);
-      });
-    }
-    if (hasRidgeWorldMemory(memories, 'stampede-held-sticker')) {
-      this.add.rectangle(x + 42, y - 48, 58, 26, 0xf7f1df, 1)
-        .setStrokeStyle(3, 0x1f1f1d, 0.95)
-        .setAngle(-8)
-        .setDepth(19);
-      this.add.text(x + 20, y - 57, stampedeFirstClearLabel, {
-        fontFamily: 'monospace',
-        fontSize: '12px',
-        color: '#1f1f1d'
-      }).setAngle(-8).setDepth(20);
-    }
-    if (hasRidgeWorldMemory(memories, 'stampede-glide-pip-decal')) {
-      this.add.circle(x + 74, y - 18, 11, 0xf7f1df, 1)
-        .setStrokeStyle(2, 0x1f1f1d, 0.9)
-        .setDepth(19);
-      this.add.line(x + 74, y - 18, -6, 6, 6, -6, 0x1f1f1d, 0.85).setLineWidth(2).setDepth(20);
-    }
-  }
-
-  private addTelegraphBag(x: number, y: number): void {
-    this.add.rectangle(x, y, 70, 54, 0x596f8f, 0.84).setDepth(16);
-    this.add.rectangle(x, y - 34, 48, 16, 0x1f1f1d, 0.88).setDepth(17);
-    this.add.arc(x, y - 40, 36, Math.PI, Math.PI * 2, false, 0x1f1f1d, 0.2)
-      .setStrokeStyle(4, 0x1f1f1d, 0.7)
-      .setDepth(17);
-    this.add.line(x + 62, y - 18, -30, -20, 30, 20, 0x1f1f1d, 0.7).setLineWidth(4).setDepth(18);
-  }
-
-  private addRidgeGuide(x: number, y: number): void {
-    this.add.circle(x, y - 28, 16, 0xf7f1df, 1).setStrokeStyle(3, 0x1f1f1d, 1).setDepth(18);
-    this.add.rectangle(x, y + 8, 32, 58, 0xf7f1df, 1).setStrokeStyle(3, 0x1f1f1d, 1).setDepth(18);
-    this.add.line(x - 8, y + 2, -30, -16, -52, -28, 0x1f1f1d, 1).setLineWidth(4).setDepth(19);
-    this.add.rectangle(x + 42, y - 8, 42, 28, 0xf0d35f, 0.9).setStrokeStyle(3, 0x1f1f1d, 1).setDepth(18);
-    this.add.text(x + 29, y - 17, '?', {
-      fontFamily: 'monospace',
-      fontSize: '22px',
-      color: '#1f1f1d'
-    }).setDepth(19);
-  }
-
-  private addRelayGate(x: number, y: number): void {
-    this.add.rectangle(x, y, 108, 128, 0xf7f1df, 0.86)
-      .setStrokeStyle(5, 0x1f1f1d, 0.86)
-      .setDepth(16);
-    this.add.rectangle(x, y + 6, 66, 98, 0x1f1f1d, 0.18)
-      .setStrokeStyle(3, 0x1f1f1d, 0.58)
-      .setDepth(17);
-    this.add.circle(x, y - 62, 16, 0xf0d35f, 0.86)
-      .setStrokeStyle(3, 0x1f1f1d, 0.72)
-      .setDepth(18);
-  }
-
-  private addRelaySpire(x: number, y: number): void {
-    this.add.triangle(x, y, 0, 180, 46, 0, 92, 180, 0x1c1a18, 0.56).setDepth(9);
-    this.add.rectangle(x + 46, y + 125, 34, 250, 0x1c1a18, 0.56).setDepth(9);
-    this.add.line(x + 46, y, -80, 35, 80, 35, 0x1c1a18, 0.34).setLineWidth(3).setDepth(9);
-    this.add.circle(x + 46, y - 39, 12, 0xf0d35f, 0.84).setDepth(10);
-  }
-
-  private addDominoDesk(x: number, y: number): void {
-    this.add.rectangle(x, y, 108, 50, 0xd7c78f, 0.96).setStrokeStyle(4, 0x1f1f1d, 1).setDepth(16);
-    this.add.rectangle(x + 70, y - 40, 46, 94, 0xf7f1df, 1).setStrokeStyle(4, 0x1f1f1d, 1).setDepth(16);
-    this.add.circle(x - 28, y - 16, 7, 0x1f1f1d, 1).setDepth(17);
-    this.add.circle(x, y - 16, 7, 0x1f1f1d, 1).setDepth(17);
-    this.add.circle(x + 28, y - 16, 7, 0x1f1f1d, 1).setDepth(17);
-  }
-
-  private addHighLedgeTeaser(x: number, y: number): void {
-    this.add.rectangle(x, y, 142, 18, 0xf7f1df, 0.92)
-      .setStrokeStyle(3, 0x1f1f1d, 0.72)
-      .setDepth(16);
-    this.add.rectangle(x - 42, y - 18, 48, 26, 0xf0d35f, 0.76)
-      .setStrokeStyle(2, 0x1f1f1d, 0.62)
-      .setAngle(-7)
-      .setDepth(17);
-    this.add.circle(x + 44, y - 32, 6, 0x1f1f1d, 0.68).setDepth(17);
-    this.add.circle(x + 60, y - 37, 4, 0x1f1f1d, 0.58).setDepth(17);
-  }
-
-  private addPlaceholderCopy(facts: RidgeBlockoutFacts, title: string): void {
-    const spawn = facts.spawn;
-    this.add.text(spawn.x, spawn.y - 260, title, {
-      fontFamily: 'monospace',
-      fontSize: '34px',
-      color: '#1f1f1d'
-    }).setOrigin(0.5).setDepth(60);
-    this.add.text(spawn.x, spawn.y - 214, `${facts.title} - parsed ${facts.rooms.length} room beats`, {
-      fontFamily: 'monospace',
-      fontSize: '16px',
-      color: '#4b4337'
-    }).setOrigin(0.5).setDepth(60);
-  }
-}
-
-function getColliderStyle(collider: RidgeBlockoutCollider): {
-  fill: number;
-  alpha: number;
-  strokeWidth: number;
-  strokeAlpha: number;
-  depth: number;
-} {
-  switch (collider.kind) {
-    case 'solid':
-      return { fill: 0x2f4736, alpha: 0.94, strokeWidth: 1, strokeAlpha: 0.16, depth: 1 };
-    case 'platform':
-      return { fill: 0xd7c78f, alpha: 0.94, strokeWidth: 2, strokeAlpha: 0.42, depth: 4 };
-    case 'route-connector':
-      return { fill: 0xf7f1df, alpha: 0.96, strokeWidth: 2, strokeAlpha: 0.52, depth: 5 };
-    case 'shortcut-connector':
-      return { fill: 0xf0d35f, alpha: 0.82, strokeWidth: 2, strokeAlpha: 0.6, depth: 6 };
-  }
-}
-
-function getAnchorColor(anchor: RidgeBlockoutAnchorPoint): number {
-  switch (anchor.symbol) {
-    case '*':
-      return 0xb85f5a;
-    case '?':
-      return 0x596f8f;
-    case '^':
-      return 0xf0d35f;
-    case 'A':
-      return 0xd7c78f;
-    default:
-      return 0xf7f1df;
-  }
-}
-
-function getAssistZoneColor(zone: RidgeBlockoutAssistZone): number {
-  switch (zone.kind) {
-    case 'ramp':
-      return 0xd7c78f;
-    case 'climb':
-      return 0x596f8f;
-    case 'drop':
-      return 0xf0d35f;
-  }
-}
-
-function drawLadderVisual(
-  graphics: Phaser.GameObjects.Graphics,
-  zone: RidgeBlockoutAssistZone,
-  color: number
-): void {
-  const railOffset = 9;
-  const minY = Math.min(zone.from.y, zone.to.y);
-  const maxY = Math.max(zone.from.y, zone.to.y);
-
-  graphics.lineStyle(4, color, 0.5);
-  graphics.strokeLineShape(new Phaser.Geom.Line(
-    zone.from.x - railOffset,
-    zone.from.y,
-    zone.to.x - railOffset,
-    zone.to.y
-  ));
-  graphics.strokeLineShape(new Phaser.Geom.Line(
-    zone.from.x + railOffset,
-    zone.from.y,
-    zone.to.x + railOffset,
-    zone.to.y
-  ));
-
-  graphics.lineStyle(3, 0x1f1f1d, 0.22);
-  for (let y = minY + 20; y < maxY; y += 34) {
-    graphics.strokeLineShape(new Phaser.Geom.Line(
-      zone.from.x - railOffset - 4,
-      y,
-      zone.from.x + railOffset + 4,
-      y
-    ));
-  }
-}
-
-function requireRidgeBlockoutFactAnchor(
-  facts: RidgeBlockoutFacts,
-  selector: RidgeBlockoutAnchorSelector,
-  label: string
-): RidgeAnchorFact {
-  const point = findRidgeBlockoutFactAnchor(facts, selector);
-  if (!point) {
-    throw new Error(
-      `Ridge blockout anchor for ${label} could not be resolved in room "${selector.roomId}"`
-    );
-  }
-  return point;
 }

--- a/src/game/scenes/ridge/runtime/ridgeBlockoutPresentation.ts
+++ b/src/game/scenes/ridge/runtime/ridgeBlockoutPresentation.ts
@@ -1,0 +1,287 @@
+import * as Phaser from 'phaser';
+import {
+  type RidgeBlockoutAnchorPoint,
+  type RidgeBlockoutAssistZone,
+  type RidgeBlockoutBounds,
+  type RidgeBlockoutCollider,
+  type RidgeBlockoutFacts,
+  type RidgeBlockoutGeometry,
+  type RidgeBlockoutRoomBounds
+} from '../blockout';
+import { getRidgeBlockoutRoomCenter } from './ridgePresentationFacts';
+
+export interface RidgeBlockoutPresentationOptions {
+  scene: Phaser.Scene;
+  facts: RidgeBlockoutFacts;
+  geometry: RidgeBlockoutGeometry;
+}
+
+export interface RidgeBlockoutPresentation {
+  platforms: Phaser.GameObjects.Zone[];
+}
+
+export function createRidgeBlockoutPresentation(
+  options: RidgeBlockoutPresentationOptions
+): RidgeBlockoutPresentation {
+  const { scene, facts, geometry } = options;
+
+  addBackdrop(scene, geometry.bounds);
+  addRoomBounds(scene, geometry.roomBounds);
+  addFutureRoutePromises(scene, facts);
+  addTraversalConnectorVisuals(scene, geometry);
+  const platforms = addBlockoutColliders(scene, geometry);
+  addShortcutPromises(scene, facts);
+  addAnchorMarkers(scene, geometry);
+
+  return { platforms };
+}
+
+function addBackdrop(scene: Phaser.Scene, bounds: RidgeBlockoutBounds): void {
+  scene.add.rectangle(
+    bounds.width / 2,
+    bounds.height / 2,
+    bounds.width,
+    bounds.height,
+    0xf7f1df,
+    1
+  ).setDepth(-100);
+
+  const graphics = scene.add.graphics().setDepth(-90);
+  graphics.lineStyle(3, 0x1f1f1d, 0.06);
+  for (let y = 160; y < bounds.height; y += 420) {
+    graphics.strokeLineShape(new Phaser.Geom.Line(0, y, bounds.width, y));
+  }
+
+  for (let x = 180; x < bounds.width; x += 420) {
+    const y = 260 + Math.sin(x / 180) * 34;
+    graphics.lineStyle(4, 0x1f1f1d, 0.12);
+    graphics.strokeLineShape(new Phaser.Geom.Line(x - 150, y + 34, x + 150, y - 34));
+    graphics.lineStyle(3, 0x1f1f1d, 0.09);
+    graphics.strokeLineShape(new Phaser.Geom.Line(x - 52, y + 60, x + 140, y + 24));
+  }
+}
+
+function addRoomBounds(
+  scene: Phaser.Scene,
+  roomBounds: readonly RidgeBlockoutRoomBounds[]
+): void {
+  roomBounds.forEach((room) => {
+    scene.add.rectangle(
+      room.x + room.width / 2,
+      room.y + room.height / 2,
+      room.width,
+      room.height,
+      0xf7f1df,
+      0.03
+    )
+      .setStrokeStyle(2, 0x1f1f1d, 0.12)
+      .setDepth(-20);
+    scene.add.text(room.x + 12, room.y + 12, room.title, {
+      fontFamily: 'monospace',
+      fontSize: '16px',
+      color: '#4b4337',
+      backgroundColor: '#f7f1dfcc',
+      padding: { x: 4, y: 2 }
+    }).setDepth(20);
+  });
+}
+
+function addFutureRoutePromises(
+  scene: Phaser.Scene,
+  facts: RidgeBlockoutFacts
+): void {
+  const graphics = scene.add.graphics().setDepth(-8);
+  graphics.lineStyle(3, 0x596f8f, 0.18);
+
+  facts.futureRoutes.forEach((route) => {
+    route.links.forEach((link) => {
+      const from = getRidgeBlockoutRoomCenter(facts, link.fromRoomId);
+      const to = getRidgeBlockoutRoomCenter(facts, link.toRoomId);
+      if (!from || !to) return;
+      graphics.strokeLineShape(new Phaser.Geom.Line(from.x, from.y, to.x, to.y));
+    });
+  });
+}
+
+function addTraversalConnectorVisuals(
+  scene: Phaser.Scene,
+  geometry: RidgeBlockoutGeometry
+): void {
+  const graphics = scene.add.graphics().setDepth(3);
+  geometry.routeConnectors.forEach((connector) => {
+    connector.assistZones.forEach((zone) => {
+      const color = getAssistZoneColor(zone);
+      if (zone.kind === 'climb') {
+        drawLadderVisual(graphics, zone, color);
+        scene.add.rectangle(zone.x, zone.y, 24, zone.height, 0x1f1f1d, 0.08)
+          .setStrokeStyle(2, color, 0.28)
+          .setDepth(2);
+        return;
+      }
+
+      graphics.lineStyle(8, color, zone.kind === 'drop' ? 0.24 : 0.38);
+      graphics.strokeLineShape(new Phaser.Geom.Line(
+        zone.from.x,
+        zone.from.y,
+        zone.to.x,
+        zone.to.y
+      ));
+    });
+  });
+
+  geometry.shortcutConnections.forEach((connection) => {
+    connection.assistZones.forEach((zone) => {
+      graphics.lineStyle(6, getAssistZoneColor(zone), 0.3);
+      graphics.strokeLineShape(new Phaser.Geom.Line(
+        zone.from.x,
+        zone.from.y,
+        zone.to.x,
+        zone.to.y
+      ));
+    });
+  });
+}
+
+function addBlockoutColliders(
+  scene: Phaser.Scene,
+  geometry: RidgeBlockoutGeometry
+): Phaser.GameObjects.Zone[] {
+  return geometry.colliders.map((collider) => {
+    addColliderVisual(scene, collider);
+    const zone = scene.add.zone(collider.x, collider.y, collider.width, collider.height);
+    scene.physics.add.existing(zone, true);
+    return zone;
+  });
+}
+
+function addColliderVisual(scene: Phaser.Scene, collider: RidgeBlockoutCollider): void {
+  const style = getColliderStyle(collider);
+  scene.add.rectangle(
+    collider.x,
+    collider.y,
+    collider.width,
+    collider.height,
+    style.fill,
+    style.alpha
+  )
+    .setStrokeStyle(style.strokeWidth, 0x1f1f1d, style.strokeAlpha)
+    .setDepth(style.depth);
+}
+
+function addShortcutPromises(scene: Phaser.Scene, facts: RidgeBlockoutFacts): void {
+  facts.shortcuts.forEach((connection) => {
+    if (!connection.from) return;
+    const graphics = scene.add.graphics().setDepth(6);
+    graphics.lineStyle(4, connection.available ? 0xf0d35f : 0x1f1f1d, connection.available ? 0.34 : 0.16);
+    graphics.strokeLineShape(new Phaser.Geom.Line(
+      connection.from.x,
+      connection.from.y,
+      connection.to.x,
+      connection.to.y
+    ));
+
+    if (!connection.available) {
+      const centerX = (connection.from.x + connection.to.x) / 2;
+      const centerY = (connection.from.y + connection.to.y) / 2;
+      scene.add.rectangle(centerX, centerY, 96, 18, 0xf7f1df, 0.24)
+        .setStrokeStyle(2, 0x1f1f1d, 0.18)
+        .setAngle(-4)
+        .setDepth(7);
+    }
+  });
+}
+
+function addAnchorMarkers(scene: Phaser.Scene, geometry: RidgeBlockoutGeometry): void {
+  geometry.anchorPoints.forEach((anchor) => {
+    if (!['A', '*', '?', '^', 'N', 'M'].includes(anchor.symbol)) return;
+    scene.add.circle(anchor.x, anchor.y, 9, getAnchorColor(anchor), 0.58)
+      .setStrokeStyle(2, 0x1f1f1d, 0.45)
+      .setDepth(14);
+    scene.add.text(anchor.x + 12, anchor.y - 14, anchor.symbol, {
+      fontFamily: 'monospace',
+      fontSize: '13px',
+      color: '#1f1f1d',
+      backgroundColor: '#f7f1df99',
+      padding: { x: 2, y: 1 }
+    }).setDepth(15);
+  });
+}
+
+function getColliderStyle(collider: RidgeBlockoutCollider): {
+  fill: number;
+  alpha: number;
+  strokeWidth: number;
+  strokeAlpha: number;
+  depth: number;
+} {
+  switch (collider.kind) {
+    case 'solid':
+      return { fill: 0x2f4736, alpha: 0.94, strokeWidth: 1, strokeAlpha: 0.16, depth: 1 };
+    case 'platform':
+      return { fill: 0xd7c78f, alpha: 0.94, strokeWidth: 2, strokeAlpha: 0.42, depth: 4 };
+    case 'route-connector':
+      return { fill: 0xf7f1df, alpha: 0.96, strokeWidth: 2, strokeAlpha: 0.52, depth: 5 };
+    case 'shortcut-connector':
+      return { fill: 0xf0d35f, alpha: 0.82, strokeWidth: 2, strokeAlpha: 0.6, depth: 6 };
+  }
+}
+
+function getAnchorColor(anchor: RidgeBlockoutAnchorPoint): number {
+  switch (anchor.symbol) {
+    case '*':
+      return 0xb85f5a;
+    case '?':
+      return 0x596f8f;
+    case '^':
+      return 0xf0d35f;
+    case 'A':
+      return 0xd7c78f;
+    default:
+      return 0xf7f1df;
+  }
+}
+
+function getAssistZoneColor(zone: RidgeBlockoutAssistZone): number {
+  switch (zone.kind) {
+    case 'ramp':
+      return 0xd7c78f;
+    case 'climb':
+      return 0x596f8f;
+    case 'drop':
+      return 0xf0d35f;
+  }
+}
+
+function drawLadderVisual(
+  graphics: Phaser.GameObjects.Graphics,
+  zone: RidgeBlockoutAssistZone,
+  color: number
+): void {
+  const railOffset = 9;
+  const minY = Math.min(zone.from.y, zone.to.y);
+  const maxY = Math.max(zone.from.y, zone.to.y);
+
+  graphics.lineStyle(4, color, 0.5);
+  graphics.strokeLineShape(new Phaser.Geom.Line(
+    zone.from.x - railOffset,
+    zone.from.y,
+    zone.to.x - railOffset,
+    zone.to.y
+  ));
+  graphics.strokeLineShape(new Phaser.Geom.Line(
+    zone.from.x + railOffset,
+    zone.from.y,
+    zone.to.x + railOffset,
+    zone.to.y
+  ));
+
+  graphics.lineStyle(3, 0x1f1f1d, 0.22);
+  for (let y = minY + 20; y < maxY; y += 34) {
+    graphics.strokeLineShape(new Phaser.Geom.Line(
+      zone.from.x - railOffset - 4,
+      y,
+      zone.from.x + railOffset + 4,
+      y
+    ));
+  }
+}

--- a/src/game/scenes/ridge/runtime/ridgeBlockoutPresentation.ts
+++ b/src/game/scenes/ridge/runtime/ridgeBlockoutPresentation.ts
@@ -10,6 +10,37 @@ import {
 } from '../blockout';
 import { getRidgeBlockoutRoomCenter } from './ridgePresentationFacts';
 
+const BACKDROP_BASE_DEPTH = -100;
+const BACKDROP_SKETCH_DEPTH = -90;
+const BACKDROP_RULED_LINE = {
+  startY: 160,
+  spacingY: 420,
+  width: 3,
+  color: 0x1f1f1d,
+  alpha: 0.06
+} as const;
+const BACKDROP_DIAGONAL_SCRAPS = {
+  startX: 180,
+  spacingX: 420,
+  waveBaseY: 260,
+  waveDivisor: 180,
+  waveAmplitude: 34,
+  primary: {
+    width: 4,
+    color: 0x1f1f1d,
+    alpha: 0.12,
+    from: { x: -150, y: 34 },
+    to: { x: 150, y: -34 }
+  },
+  secondary: {
+    width: 3,
+    color: 0x1f1f1d,
+    alpha: 0.09,
+    from: { x: -52, y: 60 },
+    to: { x: 140, y: 24 }
+  }
+} as const;
+
 export interface RidgeBlockoutPresentationOptions {
   scene: Phaser.Scene;
   facts: RidgeBlockoutFacts;
@@ -44,20 +75,48 @@ function addBackdrop(scene: Phaser.Scene, bounds: RidgeBlockoutBounds): void {
     bounds.height,
     0xf7f1df,
     1
-  ).setDepth(-100);
+  ).setDepth(BACKDROP_BASE_DEPTH);
 
-  const graphics = scene.add.graphics().setDepth(-90);
-  graphics.lineStyle(3, 0x1f1f1d, 0.06);
-  for (let y = 160; y < bounds.height; y += 420) {
+  const graphics = scene.add.graphics().setDepth(BACKDROP_SKETCH_DEPTH);
+  graphics.lineStyle(
+    BACKDROP_RULED_LINE.width,
+    BACKDROP_RULED_LINE.color,
+    BACKDROP_RULED_LINE.alpha
+  );
+  for (let y = BACKDROP_RULED_LINE.startY; y < bounds.height; y += BACKDROP_RULED_LINE.spacingY) {
     graphics.strokeLineShape(new Phaser.Geom.Line(0, y, bounds.width, y));
   }
 
-  for (let x = 180; x < bounds.width; x += 420) {
-    const y = 260 + Math.sin(x / 180) * 34;
-    graphics.lineStyle(4, 0x1f1f1d, 0.12);
-    graphics.strokeLineShape(new Phaser.Geom.Line(x - 150, y + 34, x + 150, y - 34));
-    graphics.lineStyle(3, 0x1f1f1d, 0.09);
-    graphics.strokeLineShape(new Phaser.Geom.Line(x - 52, y + 60, x + 140, y + 24));
+  for (
+    let x = BACKDROP_DIAGONAL_SCRAPS.startX;
+    x < bounds.width;
+    x += BACKDROP_DIAGONAL_SCRAPS.spacingX
+  ) {
+    const y = BACKDROP_DIAGONAL_SCRAPS.waveBaseY +
+      Math.sin(x / BACKDROP_DIAGONAL_SCRAPS.waveDivisor) *
+      BACKDROP_DIAGONAL_SCRAPS.waveAmplitude;
+    graphics.lineStyle(
+      BACKDROP_DIAGONAL_SCRAPS.primary.width,
+      BACKDROP_DIAGONAL_SCRAPS.primary.color,
+      BACKDROP_DIAGONAL_SCRAPS.primary.alpha
+    );
+    graphics.strokeLineShape(new Phaser.Geom.Line(
+      x + BACKDROP_DIAGONAL_SCRAPS.primary.from.x,
+      y + BACKDROP_DIAGONAL_SCRAPS.primary.from.y,
+      x + BACKDROP_DIAGONAL_SCRAPS.primary.to.x,
+      y + BACKDROP_DIAGONAL_SCRAPS.primary.to.y
+    ));
+    graphics.lineStyle(
+      BACKDROP_DIAGONAL_SCRAPS.secondary.width,
+      BACKDROP_DIAGONAL_SCRAPS.secondary.color,
+      BACKDROP_DIAGONAL_SCRAPS.secondary.alpha
+    );
+    graphics.strokeLineShape(new Phaser.Geom.Line(
+      x + BACKDROP_DIAGONAL_SCRAPS.secondary.from.x,
+      y + BACKDROP_DIAGONAL_SCRAPS.secondary.from.y,
+      x + BACKDROP_DIAGONAL_SCRAPS.secondary.to.x,
+      y + BACKDROP_DIAGONAL_SCRAPS.secondary.to.y
+    ));
   }
 }
 

--- a/src/game/scenes/ridge/runtime/ridgeInteractionTargets.test.ts
+++ b/src/game/scenes/ridge/runtime/ridgeInteractionTargets.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+import { STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
+import {
+  RIDGE_BLOCKOUT,
+  compileRidgeBlockoutFacts
+} from '../blockout';
+import {
+  CICKA_INTERACTION_TARGET_ID,
+  type CickaInteractionCopy
+} from '../cicka/interaction';
+import type { CickaPerch } from '../cicka/CickaPerch';
+import { getRidgeWorldMemories } from '../worldMemory';
+import {
+  createRidgeInteractionTargets,
+  type RidgeInteractionEffect
+} from './ridgeInteractionTargets';
+
+const cickaCopy: CickaInteractionCopy = {
+  fresh: 'meow.',
+  stampedeMemory: 'mrrp!'
+};
+
+function createTestCickaPerch(): CickaPerch {
+  return {
+    interactionFacts: {
+      id: CICKA_INTERACTION_TARGET_ID,
+      kind: 'cicka',
+      x: 120,
+      distanceAnchorY: 130,
+      prompt: { x: 120, y: 80 },
+      interactRadius: 78
+    },
+    update: () => {},
+    showLine: () => {},
+    isSpeechVisible: () => false,
+    destroy: () => {}
+  };
+}
+
+describe('ridge interaction targets', () => {
+  it('builds Cicka and Trail Card targets from compiled facts', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const targets = createRidgeInteractionTargets({
+      facts,
+      cickaPerch: createTestCickaPerch(),
+      cickaInteractionCopy: cickaCopy,
+      getWorldMemories: () => []
+    });
+
+    expect(targets.map((target) => target.id)).toEqual([
+      CICKA_INTERACTION_TARGET_ID,
+      STAMPEDE_SKETCH_RIDGE_STAMP_ID,
+      'telegraph-terrace',
+      'domino-desk'
+    ]);
+    expect(targets.every((target) => Number.isFinite(target.prompt.y))).toBe(true);
+  });
+
+  it('preserves Trail Card params when creating open effects', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const targets = createRidgeInteractionTargets({
+      facts,
+      cickaInteractionCopy: cickaCopy,
+      getWorldMemories: () => []
+    });
+    const stampede = targets.find((target) => target.id === STAMPEDE_SKETCH_RIDGE_STAMP_ID);
+    const telegraph = targets.find((target) => target.id === 'telegraph-terrace');
+    const domino = targets.find((target) => target.id === 'domino-desk');
+
+    expect(stampede?.effect).toEqual({
+      kind: 'openTrailCard',
+      params: expect.objectContaining({
+        title: 'Stampede Sketch',
+        enterSceneId: STAMPEDE_SKETCH_SCENE_ID
+      })
+    });
+    expect(telegraph?.effect).toEqual({
+      kind: 'openTrailCard',
+      params: expect.objectContaining({
+        title: 'Telegraph Terrace',
+        unavailableReason: 'Telegraph Terrace is a later prototype.'
+      })
+    });
+    expect(domino?.effect).toEqual({
+      kind: 'openTrailCard',
+      params: expect.objectContaining({
+        title: 'Domino Desk',
+        unavailableReason: 'Domino Desk is future scope.'
+      })
+    });
+  });
+
+  it('reads fresh world memories when resolving the Cicka response effect', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    let hasStampedeMemory = false;
+    const targets = createRidgeInteractionTargets({
+      facts,
+      cickaPerch: createTestCickaPerch(),
+      cickaInteractionCopy: cickaCopy,
+      getWorldMemories: () =>
+        getRidgeWorldMemories({
+          stampIds: hasStampedeMemory ? [STAMPEDE_SKETCH_RIDGE_STAMP_ID] : []
+        })
+    });
+    const cicka = targets.find((target) => target.id === CICKA_INTERACTION_TARGET_ID);
+    if (typeof cicka?.effect !== 'function') {
+      throw new Error('missing Cicka response effect');
+    }
+
+    expect((cicka.effect() as RidgeInteractionEffect)).toEqual({
+      kind: 'showCickaResponse',
+      response: { id: 'fresh', line: 'meow.' }
+    });
+
+    hasStampedeMemory = true;
+
+    expect((cicka.effect() as RidgeInteractionEffect)).toEqual({
+      kind: 'showCickaResponse',
+      response: { id: 'stampede-memory', line: 'mrrp!' }
+    });
+  });
+});

--- a/src/game/scenes/ridge/runtime/ridgeInteractionTargets.ts
+++ b/src/game/scenes/ridge/runtime/ridgeInteractionTargets.ts
@@ -1,0 +1,84 @@
+import type { InteriorInteractionTarget } from '@/game/sharedSceneRuntime/interactions/InteriorInteractionRuntime';
+import type { TrailCardOverlayParams } from '@/game/overlays/trailCard/types';
+import {
+  RIDGE_TRAIL_CARD_TARGETS,
+  type RidgeTrailCardTargetId
+} from '../worldLayout';
+import {
+  CICKA_INTERACTION_TARGET_ID,
+  getCickaInteractionResponse,
+  type CickaInteractionCopy,
+  type CickaInteractionResponse
+} from '../cicka/interaction';
+import type { CickaPerch } from '../cicka/CickaPerch';
+import type { RidgeBlockoutFacts } from '../blockout';
+import type { RidgeWorldMemory } from '../worldMemory';
+import { requireRidgeBlockoutFactAnchor } from './ridgePresentationFacts';
+
+const TRAIL_CARD_PROMPT_OFFSET_Y = -86;
+
+export type RidgeInteractionEffect =
+  | { kind: 'close' }
+  | { kind: 'openTrailCard'; params: TrailCardOverlayParams }
+  | { kind: 'showCickaResponse'; response: CickaInteractionResponse };
+
+export type RidgeInteractionTargetId =
+  | RidgeTrailCardTargetId
+  | typeof CICKA_INTERACTION_TARGET_ID;
+
+export type RidgeInteractionTarget = InteriorInteractionTarget<
+  RidgeInteractionTargetId,
+  RidgeInteractionEffect
+>;
+
+export interface RidgeInteractionTargetOptions {
+  facts: RidgeBlockoutFacts;
+  cickaPerch?: CickaPerch;
+  cickaInteractionCopy: CickaInteractionCopy;
+  getWorldMemories: () => readonly RidgeWorldMemory[];
+}
+
+export function createRidgeInteractionTargets(
+  options: RidgeInteractionTargetOptions
+): RidgeInteractionTarget[] {
+  const { facts, cickaPerch, cickaInteractionCopy, getWorldMemories } = options;
+  return [
+    ...(cickaPerch ? [{
+      ...cickaPerch.interactionFacts,
+      effect: (): RidgeInteractionEffect => ({
+        kind: 'showCickaResponse',
+        response: getCickaInteractionResponse(
+          getWorldMemories(),
+          cickaInteractionCopy
+        )
+      })
+    }] : []),
+    ...createTrailCardTargets(facts)
+  ];
+}
+
+function createTrailCardTargets(
+  facts: RidgeBlockoutFacts
+): RidgeInteractionTarget[] {
+  return RIDGE_TRAIL_CARD_TARGETS.map((target) => {
+    const anchorPoint = requireRidgeBlockoutFactAnchor(
+      facts,
+      target.anchor,
+      `${target.id} Trail Card`
+    );
+    return {
+      id: target.id,
+      kind: 'trail-card',
+      x: anchorPoint.x,
+      distanceAnchorY: anchorPoint.y,
+      prompt: {
+        x: anchorPoint.x,
+        y: anchorPoint.y + TRAIL_CARD_PROMPT_OFFSET_Y
+      },
+      effect: {
+        kind: 'openTrailCard',
+        params: target.card
+      }
+    };
+  });
+}

--- a/src/game/scenes/ridge/runtime/ridgeLandmarkPresentation.test.ts
+++ b/src/game/scenes/ridge/runtime/ridgeLandmarkPresentation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RIDGE_BLOCKOUT,
+  compileRidgeBlockoutFacts
+} from '../blockout';
+import {
+  RIDGE_LANDMARK_ANCHOR_SELECTORS,
+  resolveRidgeLandmarkAnchors
+} from './ridgeLandmarkPresentation';
+
+describe('ridge landmark presentation', () => {
+  it('resolves the landmark anchors used by Ridge presentation', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const anchors = resolveRidgeLandmarkAnchors(facts);
+
+    expect(Object.keys(anchors)).toEqual(Object.keys(RIDGE_LANDMARK_ANCHOR_SELECTORS));
+    expect(anchors.cicka).toMatchObject({
+      roomId: 'cicka_home',
+      symbol: 'C',
+      kind: 'npc',
+      id: 'cicka'
+    });
+    expect(anchors.stampede).toMatchObject({
+      roomId: 'stampede_blanket',
+      symbol: '*',
+      kind: 'minigame',
+      id: 'stampede_sketch'
+    });
+    expect(anchors.telegraph).toMatchObject({
+      roomId: 'telegraph_terrace',
+      symbol: '*',
+      kind: 'minigame',
+      id: 'telegraph_future'
+    });
+    expect(anchors.relay).toMatchObject({
+      roomId: 'relay_gate',
+      symbol: '?',
+      kind: 'gate',
+      id: 'relay_proof_slots'
+    });
+    expect(anchors.domino).toMatchObject({
+      roomId: 'domino_desk',
+      symbol: 'A',
+      id: 'domino_project_scrap'
+    });
+    expect(anchors.guide).toMatchObject({
+      roomId: 'guide_overlook',
+      symbol: 'N',
+      kind: 'npc',
+      id: 'ridge_guide'
+    });
+    expect(anchors.highLedge).toMatchObject({
+      roomId: 'high_ledge',
+      symbol: '?',
+      kind: 'gate',
+      id: 'movement_reward_tease'
+    });
+    expect(Object.values(anchors).every((anchor) =>
+      Number.isFinite(anchor.x) && Number.isFinite(anchor.y)
+    )).toBe(true);
+  });
+});

--- a/src/game/scenes/ridge/runtime/ridgeLandmarkPresentation.ts
+++ b/src/game/scenes/ridge/runtime/ridgeLandmarkPresentation.ts
@@ -15,6 +15,7 @@ import {
 import { requireRidgeBlockoutFactAnchor } from './ridgePresentationFacts';
 
 const CICKA_PERCH_OFFSET_Y = -10;
+const RELAY_SPIRE_OFFSET = { x: 230, y: -180 } as const;
 
 export const RIDGE_LANDMARK_ANCHOR_SELECTORS = {
   cicka: {
@@ -116,10 +117,14 @@ export function createRidgeLandmarkPresentation(
   addTelegraphBag(scene, anchors.telegraph.x, anchors.telegraph.y);
   addRidgeGuide(scene, anchors.guide.x, anchors.guide.y);
   addRelayGate(scene, anchors.relay.x, anchors.relay.y);
-  addRelaySpire(scene, anchors.relay.x + 230, anchors.relay.y - 180);
+  addRelaySpire(
+    scene,
+    anchors.relay.x + RELAY_SPIRE_OFFSET.x,
+    anchors.relay.y + RELAY_SPIRE_OFFSET.y
+  );
   addDominoDesk(scene, anchors.domino.x, anchors.domino.y);
   addHighLedgeTeaser(scene, anchors.highLedge.x, anchors.highLedge.y);
-  addPlaceholderCopy(scene, facts, copy.title);
+  addPlaceholderCopy(scene, facts.spawn, copy.title);
 
   return { cickaPerch };
 }
@@ -301,18 +306,12 @@ function addHighLedgeTeaser(scene: Phaser.Scene, x: number, y: number): void {
 
 function addPlaceholderCopy(
   scene: Phaser.Scene,
-  facts: RidgeBlockoutFacts,
+  spawn: RidgeAnchorFact,
   title: string
 ): void {
-  const spawn = facts.spawn;
   scene.add.text(spawn.x, spawn.y - 260, title, {
     fontFamily: 'monospace',
     fontSize: '34px',
     color: '#1f1f1d'
-  }).setOrigin(0.5).setDepth(60);
-  scene.add.text(spawn.x, spawn.y - 214, `${facts.title} - parsed ${facts.rooms.length} room beats`, {
-    fontFamily: 'monospace',
-    fontSize: '16px',
-    color: '#4b4337'
   }).setOrigin(0.5).setDepth(60);
 }

--- a/src/game/scenes/ridge/runtime/ridgeLandmarkPresentation.ts
+++ b/src/game/scenes/ridge/runtime/ridgeLandmarkPresentation.ts
@@ -1,0 +1,318 @@
+import type * as Phaser from 'phaser';
+import {
+  type RidgeAnchorFact,
+  type RidgeBlockoutAnchorSelector,
+  type RidgeBlockoutFacts
+} from '../blockout';
+import {
+  createCickaPerch,
+  type CickaPerch
+} from '../cicka/CickaPerch';
+import {
+  hasRidgeWorldMemory,
+  type RidgeWorldMemory
+} from '../worldMemory';
+import { requireRidgeBlockoutFactAnchor } from './ridgePresentationFacts';
+
+const CICKA_PERCH_OFFSET_Y = -10;
+
+export const RIDGE_LANDMARK_ANCHOR_SELECTORS = {
+  cicka: {
+    roomId: 'cicka_home',
+    symbol: 'C',
+    kind: 'npc',
+    attrId: 'cicka'
+  },
+  outskirtsArtifact: {
+    roomId: 'outskirts',
+    symbol: 'A',
+    attrId: 'city_edge_memory'
+  },
+  stampede: {
+    roomId: 'stampede_blanket',
+    symbol: '*',
+    kind: 'minigame',
+    attrId: 'stampede_sketch'
+  },
+  telegraph: {
+    roomId: 'telegraph_terrace',
+    symbol: '*',
+    kind: 'minigame',
+    attrId: 'telegraph_future'
+  },
+  guide: {
+    roomId: 'guide_overlook',
+    symbol: 'N',
+    kind: 'npc',
+    attrId: 'ridge_guide'
+  },
+  relay: {
+    roomId: 'relay_gate',
+    symbol: '?',
+    kind: 'gate',
+    attrId: 'relay_proof_slots'
+  },
+  domino: {
+    roomId: 'domino_desk',
+    symbol: 'A',
+    attrId: 'domino_project_scrap'
+  },
+  highLedge: {
+    roomId: 'high_ledge',
+    symbol: '?',
+    kind: 'gate',
+    attrId: 'movement_reward_tease'
+  }
+} as const satisfies Record<string, RidgeBlockoutAnchorSelector>;
+
+export type RidgeLandmarkAnchorId = keyof typeof RIDGE_LANDMARK_ANCHOR_SELECTORS;
+
+export type RidgeLandmarkAnchors = Record<RidgeLandmarkAnchorId, RidgeAnchorFact>;
+
+export interface RidgeLandmarkPresentationCopy {
+  title: string;
+  stampedeFirstClearLabel: string;
+  cickaWalkByLine: string;
+}
+
+export interface RidgeLandmarkPresentationOptions {
+  scene: Phaser.Scene;
+  facts: RidgeBlockoutFacts;
+  copy: RidgeLandmarkPresentationCopy;
+  worldMemories: readonly RidgeWorldMemory[];
+}
+
+export interface RidgeLandmarkPresentation {
+  cickaPerch: CickaPerch;
+}
+
+export function createRidgeLandmarkPresentation(
+  options: RidgeLandmarkPresentationOptions
+): RidgeLandmarkPresentation {
+  const { scene, facts, copy, worldMemories } = options;
+  const anchors = resolveRidgeLandmarkAnchors(facts);
+
+  const cickaPerch = createCickaPerch({
+    scene,
+    landmark: {
+      x: anchors.cicka.x,
+      y: anchors.cicka.y + CICKA_PERCH_OFFSET_Y
+    },
+    hasStampedeNoteMemory: hasRidgeWorldMemory(
+      worldMemories.filter((memory) => memory.landmarkKind === 'cicka-perch'),
+      'cicka-stampede-note'
+    ),
+    walkByLine: copy.cickaWalkByLine
+  });
+
+  addOutskirtsArtifactSlot(scene, anchors.outskirtsArtifact.x, anchors.outskirtsArtifact.y);
+  addStampedeBlanket(
+    scene,
+    anchors.stampede.x,
+    anchors.stampede.y,
+    copy.stampedeFirstClearLabel,
+    worldMemories.filter((memory) => memory.landmarkKind === 'stampede-blanket')
+  );
+  addTelegraphBag(scene, anchors.telegraph.x, anchors.telegraph.y);
+  addRidgeGuide(scene, anchors.guide.x, anchors.guide.y);
+  addRelayGate(scene, anchors.relay.x, anchors.relay.y);
+  addRelaySpire(scene, anchors.relay.x + 230, anchors.relay.y - 180);
+  addDominoDesk(scene, anchors.domino.x, anchors.domino.y);
+  addHighLedgeTeaser(scene, anchors.highLedge.x, anchors.highLedge.y);
+  addPlaceholderCopy(scene, facts, copy.title);
+
+  return { cickaPerch };
+}
+
+export function resolveRidgeLandmarkAnchors(
+  facts: RidgeBlockoutFacts
+): RidgeLandmarkAnchors {
+  return {
+    cicka: requireRidgeBlockoutFactAnchor(
+      facts,
+      RIDGE_LANDMARK_ANCHOR_SELECTORS.cicka,
+      'Cicka Home perch'
+    ),
+    outskirtsArtifact: requireRidgeBlockoutFactAnchor(
+      facts,
+      RIDGE_LANDMARK_ANCHOR_SELECTORS.outskirtsArtifact,
+      'Outskirts artifact'
+    ),
+    stampede: requireRidgeBlockoutFactAnchor(
+      facts,
+      RIDGE_LANDMARK_ANCHOR_SELECTORS.stampede,
+      'Stampede blanket'
+    ),
+    telegraph: requireRidgeBlockoutFactAnchor(
+      facts,
+      RIDGE_LANDMARK_ANCHOR_SELECTORS.telegraph,
+      'Telegraph Terrace bag'
+    ),
+    guide: requireRidgeBlockoutFactAnchor(
+      facts,
+      RIDGE_LANDMARK_ANCHOR_SELECTORS.guide,
+      'Ridge guide'
+    ),
+    relay: requireRidgeBlockoutFactAnchor(
+      facts,
+      RIDGE_LANDMARK_ANCHOR_SELECTORS.relay,
+      'Relay Gate'
+    ),
+    domino: requireRidgeBlockoutFactAnchor(
+      facts,
+      RIDGE_LANDMARK_ANCHOR_SELECTORS.domino,
+      'Domino Desk'
+    ),
+    highLedge: requireRidgeBlockoutFactAnchor(
+      facts,
+      RIDGE_LANDMARK_ANCHOR_SELECTORS.highLedge,
+      'High Ledge teaser'
+    )
+  };
+}
+
+function addOutskirtsArtifactSlot(scene: Phaser.Scene, x: number, y: number): void {
+  scene.add.rectangle(x - 44, y + 22, 92, 8, 0x1f1f1d, 0.2).setDepth(18);
+  scene.add.rectangle(x - 18, y - 4, 58, 36, 0xf7f1df, 0.94)
+    .setStrokeStyle(3, 0x1f1f1d, 0.72)
+    .setAngle(-5)
+    .setDepth(18);
+  scene.add.rectangle(x + 34, y - 16, 34, 24, 0xf0d35f, 0.82)
+    .setStrokeStyle(2, 0x1f1f1d, 0.72)
+    .setAngle(7)
+    .setDepth(18);
+  scene.add.circle(x + 34, y - 16, 4, 0x1f1f1d, 0.76).setDepth(19);
+  scene.add.circle(x + 44, y - 10, 3, 0x1f1f1d, 0.76).setDepth(19);
+}
+
+function addStampedeBlanket(
+  scene: Phaser.Scene,
+  x: number,
+  y: number,
+  stampedeFirstClearLabel: string,
+  memories: readonly RidgeWorldMemory[]
+): void {
+  scene.add.rectangle(x, y + 22, 104, 32, 0xb85f5a, 0.9).setDepth(16);
+  scene.add.rectangle(x - 26, y + 22, 18, 32, 0xf7f1df, 0.7).setDepth(17);
+  scene.add.rectangle(x + 26, y + 22, 18, 32, 0xf7f1df, 0.7).setDepth(17);
+  scene.add.circle(x - 22, y - 4, 11, 0x1f1f1d, 0.92).setDepth(17);
+  scene.add.circle(x + 28, y + 2, 9, 0x1f1f1d, 0.75).setDepth(17);
+  if (memories.length) {
+    addStampedeBlanketMemories(scene, x, y + 22, stampedeFirstClearLabel, memories);
+  }
+}
+
+function addStampedeBlanketMemories(
+  scene: Phaser.Scene,
+  x: number,
+  y: number,
+  stampedeFirstClearLabel: string,
+  memories: readonly RidgeWorldMemory[]
+): void {
+  if (hasRidgeWorldMemory(memories, 'stampede-settled-swarm')) {
+    [
+      { x: -55, y: -36, radius: 4 },
+      { x: -42, y: -49, radius: 3 },
+      { x: -30, y: -39, radius: 2 },
+      { x: 54, y: -30, radius: 3 },
+      { x: 66, y: -43, radius: 2 }
+    ].forEach((dot) => {
+      scene.add.circle(x + dot.x, y + dot.y, dot.radius, 0x1f1f1d, 0.24).setDepth(18);
+    });
+  }
+  if (hasRidgeWorldMemory(memories, 'stampede-held-sticker')) {
+    scene.add.rectangle(x + 42, y - 48, 58, 26, 0xf7f1df, 1)
+      .setStrokeStyle(3, 0x1f1f1d, 0.95)
+      .setAngle(-8)
+      .setDepth(19);
+    scene.add.text(x + 20, y - 57, stampedeFirstClearLabel, {
+      fontFamily: 'monospace',
+      fontSize: '12px',
+      color: '#1f1f1d'
+    }).setAngle(-8).setDepth(20);
+  }
+  if (hasRidgeWorldMemory(memories, 'stampede-glide-pip-decal')) {
+    scene.add.circle(x + 74, y - 18, 11, 0xf7f1df, 1)
+      .setStrokeStyle(2, 0x1f1f1d, 0.9)
+      .setDepth(19);
+    scene.add.line(x + 74, y - 18, -6, 6, 6, -6, 0x1f1f1d, 0.85).setLineWidth(2).setDepth(20);
+  }
+}
+
+function addTelegraphBag(scene: Phaser.Scene, x: number, y: number): void {
+  scene.add.rectangle(x, y, 70, 54, 0x596f8f, 0.84).setDepth(16);
+  scene.add.rectangle(x, y - 34, 48, 16, 0x1f1f1d, 0.88).setDepth(17);
+  scene.add.arc(x, y - 40, 36, Math.PI, Math.PI * 2, false, 0x1f1f1d, 0.2)
+    .setStrokeStyle(4, 0x1f1f1d, 0.7)
+    .setDepth(17);
+  scene.add.line(x + 62, y - 18, -30, -20, 30, 20, 0x1f1f1d, 0.7).setLineWidth(4).setDepth(18);
+}
+
+function addRidgeGuide(scene: Phaser.Scene, x: number, y: number): void {
+  scene.add.circle(x, y - 28, 16, 0xf7f1df, 1).setStrokeStyle(3, 0x1f1f1d, 1).setDepth(18);
+  scene.add.rectangle(x, y + 8, 32, 58, 0xf7f1df, 1).setStrokeStyle(3, 0x1f1f1d, 1).setDepth(18);
+  scene.add.line(x - 8, y + 2, -30, -16, -52, -28, 0x1f1f1d, 1).setLineWidth(4).setDepth(19);
+  scene.add.rectangle(x + 42, y - 8, 42, 28, 0xf0d35f, 0.9).setStrokeStyle(3, 0x1f1f1d, 1).setDepth(18);
+  scene.add.text(x + 29, y - 17, '?', {
+    fontFamily: 'monospace',
+    fontSize: '22px',
+    color: '#1f1f1d'
+  }).setDepth(19);
+}
+
+function addRelayGate(scene: Phaser.Scene, x: number, y: number): void {
+  scene.add.rectangle(x, y, 108, 128, 0xf7f1df, 0.86)
+    .setStrokeStyle(5, 0x1f1f1d, 0.86)
+    .setDepth(16);
+  scene.add.rectangle(x, y + 6, 66, 98, 0x1f1f1d, 0.18)
+    .setStrokeStyle(3, 0x1f1f1d, 0.58)
+    .setDepth(17);
+  scene.add.circle(x, y - 62, 16, 0xf0d35f, 0.86)
+    .setStrokeStyle(3, 0x1f1f1d, 0.72)
+    .setDepth(18);
+}
+
+function addRelaySpire(scene: Phaser.Scene, x: number, y: number): void {
+  scene.add.triangle(x, y, 0, 180, 46, 0, 92, 180, 0x1c1a18, 0.56).setDepth(9);
+  scene.add.rectangle(x + 46, y + 125, 34, 250, 0x1c1a18, 0.56).setDepth(9);
+  scene.add.line(x + 46, y, -80, 35, 80, 35, 0x1c1a18, 0.34).setLineWidth(3).setDepth(9);
+  scene.add.circle(x + 46, y - 39, 12, 0xf0d35f, 0.84).setDepth(10);
+}
+
+function addDominoDesk(scene: Phaser.Scene, x: number, y: number): void {
+  scene.add.rectangle(x, y, 108, 50, 0xd7c78f, 0.96).setStrokeStyle(4, 0x1f1f1d, 1).setDepth(16);
+  scene.add.rectangle(x + 70, y - 40, 46, 94, 0xf7f1df, 1).setStrokeStyle(4, 0x1f1f1d, 1).setDepth(16);
+  scene.add.circle(x - 28, y - 16, 7, 0x1f1f1d, 1).setDepth(17);
+  scene.add.circle(x, y - 16, 7, 0x1f1f1d, 1).setDepth(17);
+  scene.add.circle(x + 28, y - 16, 7, 0x1f1f1d, 1).setDepth(17);
+}
+
+function addHighLedgeTeaser(scene: Phaser.Scene, x: number, y: number): void {
+  scene.add.rectangle(x, y, 142, 18, 0xf7f1df, 0.92)
+    .setStrokeStyle(3, 0x1f1f1d, 0.72)
+    .setDepth(16);
+  scene.add.rectangle(x - 42, y - 18, 48, 26, 0xf0d35f, 0.76)
+    .setStrokeStyle(2, 0x1f1f1d, 0.62)
+    .setAngle(-7)
+    .setDepth(17);
+  scene.add.circle(x + 44, y - 32, 6, 0x1f1f1d, 0.68).setDepth(17);
+  scene.add.circle(x + 60, y - 37, 4, 0x1f1f1d, 0.58).setDepth(17);
+}
+
+function addPlaceholderCopy(
+  scene: Phaser.Scene,
+  facts: RidgeBlockoutFacts,
+  title: string
+): void {
+  const spawn = facts.spawn;
+  scene.add.text(spawn.x, spawn.y - 260, title, {
+    fontFamily: 'monospace',
+    fontSize: '34px',
+    color: '#1f1f1d'
+  }).setOrigin(0.5).setDepth(60);
+  scene.add.text(spawn.x, spawn.y - 214, `${facts.title} - parsed ${facts.rooms.length} room beats`, {
+    fontFamily: 'monospace',
+    fontSize: '16px',
+    color: '#4b4337'
+  }).setOrigin(0.5).setDepth(60);
+}

--- a/src/game/scenes/ridge/runtime/ridgePresentationFacts.ts
+++ b/src/game/scenes/ridge/runtime/ridgePresentationFacts.ts
@@ -1,0 +1,33 @@
+import {
+  findRidgeBlockoutFactAnchor,
+  type RidgeAnchorFact,
+  type RidgeBlockoutAnchorSelector,
+  type RidgeBlockoutFacts
+} from '../blockout';
+
+export function requireRidgeBlockoutFactAnchor(
+  facts: RidgeBlockoutFacts,
+  selector: RidgeBlockoutAnchorSelector,
+  label: string
+): RidgeAnchorFact {
+  const point = findRidgeBlockoutFactAnchor(facts, selector);
+  if (!point) {
+    throw new Error(
+      `Ridge blockout anchor for ${label} could not be resolved in room "${selector.roomId}"`
+    );
+  }
+  return point;
+}
+
+export function getRidgeBlockoutRoomCenter(
+  facts: Pick<RidgeBlockoutFacts, 'rooms'>,
+  roomId: string
+): { x: number; y: number } | undefined {
+  const room = facts.rooms.find((candidate) => candidate.id === roomId);
+  return room
+    ? {
+      x: room.bounds.x + room.bounds.width / 2,
+      y: room.bounds.y + room.bounds.height / 2
+    }
+    : undefined;
+}


### PR DESCRIPTION
## Summary
- Split Ridge scene presentation into Ridge-local modules for blockout visuals, landmark rendering, and interaction target assembly
- Keep `RidgeScene` focused on Phaser lifecycle orchestration, player/traversal setup, overlay bridging, and prompt handling
- Add focused tests for the new Ridge interaction and landmark boundaries

## Testing
- `npm run test -- src/game/scenes/ridge`
- `npm run check:types`
- `npm run lint`
- Local browser smoke on Ridge and Stampede scene transitions