### PR TITLE
Make Cicka Home mutations data-driven from Ridge progress

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,11 +5,15 @@ This context defines the game-design language for the gamified portfolio and its
 ## Language
 
 **Ridge Map Language**:
-A human-editable text notation that describes Ridge topology, room blockouts, traversal primitives, and environment tags as source data.
+A human-editable text notation that describes Ridge topology, room blockouts,
+traversal primitives, shortcuts, anchors, and Cicka Home mutation declarations
+as source data.
 _Avoid_: map editor, final art map
 
 **Ridge Blockout**:
-A playable primitive Ridge map generated from the Ridge Map Language before final assets are placed.
+A playable primitive Ridge map generated from the Ridge Map Language before
+final assets are placed. The current blockout compiles into typed facts,
+geometry, connectors, and presentation inputs.
 _Avoid_: final map, finished level
 
 **Grid Cell**:
@@ -40,17 +44,27 @@ A scene-owned movement model for an opt-in mini-game, tuned around that
 mini-game's primary toy and input needs.
 _Avoid_: shared overworld movement
 
+**Cicka Home Mutation**:
+A Ridge-owned declaration that a durable progress source can change Cicka Home,
+such as adding a Stampede note or opening a return fold. Declarations without a
+real progress source stay typed as future promises instead of rendering.
+_Avoid_: stored sticker state, generic landmark memory
+
 ## Relationships
 
 - A **Topology Map** defines the route logic between **Room Beats**.
 - The **Ridge Map Language** describes **Room Beats** in a parseable text file.
-- The **Ridge Map Language** produces a **Ridge Blockout**.
+- The **Ridge Map Language** produces a **Ridge Blockout** and a compiled fact
+  layer for routes, anchors, shortcuts, and Cicka Home mutations.
 - A **Grid Cell** gives **Room Beats** their scale in the **Ridge Blockout**.
 - A **Ridge Blockout** is replaced or enriched by final assets after traversal feels good.
 - The current **Ridge Blockout** is the prototype **Exploration Map**.
 - The **Exploration Map** uses **Exploration Traversal**.
 - A mini-game may use its own **Mini-Game Movement System** instead of
   **Exploration Traversal**.
+- **Cicka Home Mutations** resolve compiled Ridge facts against durable Ridge
+  progress; active mutations can render Cicka Home changes, while unresolved
+  future mutations remain data only.
 - The old Overworld and Hobbies scenes are transitional surfaces. Long-term,
   their best content should fold into the **Exploration Map** as artifacts,
   entrances, Cicka reactions, Basement/Potassium paths, and mini-game props.

--- a/docs/adr/0001-ridge-blockout-as-exploration-map-source.md
+++ b/docs/adr/0001-ridge-blockout-as-exploration-map-source.md
@@ -1,3 +1,10 @@
 # Adopt Ridge Blockout As Exploration Map Source Of Truth
 
+Status: accepted; still current after the Ridge architecture-deepening slices.
+
 We will treat the Ridge Map Language and its Ridge Blockout as the source of truth for Ridge spatial facts and as the prototype Exploration Map. Exploration Traversal may become the common movement model for non-mini-game exploration, while opt-in mini-games keep their own Mini-Game Movement Systems; the old Overworld and Hobbies scenes remain operational during migration but are transitional long-term because their strongest content should fold into artifacts, entrances, Cicka reactions, Basement/Potassium paths, and mini-game props inside the Exploration Map.
+
+The implemented Ridge direction now compiles blockout source into typed room,
+route, anchor, shortcut, and home-mutation facts before runtime presentation and
+interaction modules consume it. This deepens the original decision rather than
+superseding it.

--- a/docs/architecture-direction.md
+++ b/docs/architecture-direction.md
@@ -60,6 +60,7 @@ This document is directional. For exact current implementation details, prefer [
 - **Overlay ids/lookup:** `src/game/overlays/overlayIds.ts`, `src/game/overlays/overlayRegistry.ts`, `src/game/overlays/OverlayHost.tsx`
 - **ECS foundation:** `src/game/core/ecs/`
 - **Shared scene runtime Modules:** `src/game/sharedSceneRuntime/player/SideViewPlayerRuntime.ts`, `src/game/sharedSceneRuntime/interactions/InteriorInteractionRuntime.ts`, `src/game/sharedSceneRuntime/sceneResumePolicy.ts`
+- **Ridge Exploration Map modules:** `src/game/scenes/ridge/blockout/` owns Ridge Map Language parsing, geometry, progress-gated shortcuts, and compiled facts. Ridge runtime modules own blockout presentation, traversal assists, landmark presentation, interaction targets, and Cicka Home mutation resolution.
 - **Phaser 4 render guardrails:** currently documented as runtime policy; introduce a shared render helper only when repeated policy code appears.
 
 When proposing future refactors, prefer extending these modules instead of re-introducing callback-only scene orchestration, ad-hoc overlay maps, or ad-hoc global state.

--- a/docs/game-design/ridge-map-language.md
+++ b/docs/game-design/ridge-map-language.md
@@ -1,15 +1,16 @@
 # Ridge Map Language
 
-Status: active design tool.
+Status: active runtime source and design tool.
 
 The Ridge Map Language is a small text format for designing Ridge room beats
 before final assets exist. It should be readable by Danilo, easy for agents to
-edit, and strict enough that a parser can generate a Phaser greybox later.
+edit, and strict enough that the parser can generate a Phaser greybox, typed
+facts, traversal connectors, and progress-gated presentation inputs.
 
 ## Decision
 
-`ridge.blockout.txt` is intended to become the runtime source for Ridge greybox
-generation. It is not only design prose.
+`ridge.blockout.txt` is the runtime source for Ridge greybox generation. It is
+not only design prose.
 
 The first full skeleton lives in [`ridge.blockout.txt`](./ridge.blockout.txt).
 Parser work should use that file, not a toy example, so the language evolves
@@ -63,11 +64,11 @@ First supported output is primitive:
 - prop markers
 - environment tags
 
-Parser v0 renders the whole seamless world into a Phaser greybox. It groups
-`#` and `_` cells into horizontal collider runs, generates first-walk connector
-platforms from route exit anchors, and only adds shortcut colliders when the
-matching Ridge progress exists. Final art, sprite placement polish, particles,
-sound, one-way platform behavior, and bespoke encounter logic stay outside v0.
+Parser v0 feeds the whole seamless world into a Phaser greybox. It groups `#`
+and `_` cells into horizontal collider runs, generates first-walk connectors
+from route exit anchors, and only adds shortcut colliders when the matching
+Ridge progress exists. Final art, sprite placement polish, particles, sound,
+one-way platform behavior, and bespoke encounter logic stay outside v0.
 
 ## Design Goals
 
@@ -108,8 +109,8 @@ Global declarations:
 | `route` | named intended traversal route |
 | `shortcut` | route opened by progress |
 | `future_route` | teased or not-yet-runtime route |
-| `optional_pocket` | small curiosity branch that is not required for progression |
-| `home_mutation` | visible/mechanical Cicka Home change caused by progress |
+| `optional_pocket` | parsed small curiosity branch; currently design data |
+| `home_mutation` | Cicka Home change declaration resolved against progress |
 
 Each room beat should have metadata plus a grid:
 
@@ -148,6 +149,30 @@ rect cicka_safe_zone x=8 y=3 w=14 h=7
 
 Discrete room transitions can still be used later for interiors, mini-games,
 basement pockets, or scenes that intentionally leave the Ridge world.
+
+## Compiled Facts
+
+The runtime compiles parser output into typed facts before callers use it.
+Current fact groups are:
+
+| Fact | Runtime role |
+| --- | --- |
+| Room beats | room id, title, theme/mood, links, props, declarations, bounds, and anchors |
+| Anchors | world-space anchor points with typed common attrs such as `id`, `to`, `requires`, `movement`, and `reward` |
+| Routes | ordered room links for active first-walk topology |
+| Future routes | route promises drawn as inactive future topology |
+| Shortcuts | progress-gated route facts with availability, movement, source anchor, and target landing |
+| Home mutations | Cicka Home mutation facts with `adds`, `opens`, and raw attrs preserved |
+
+Shortcut availability is derived from durable Ridge progress, not stored in the
+blockout. The current Stampede shortcut maps `stampede_sketch` to the durable
+`stampede-sketch` stamp. Locked shortcuts remain visible promises without
+active colliders or assist zones.
+
+Home mutations follow the same data-first rule. `stampede_sketch` currently
+activates the `stampede_note` addition and `fold_drop_landing` opening when the
+durable Stampede stamp exists. Other declarations, such as `work_artifact`,
+remain typed future promises until a real progress source exists.
 
 ## Symbol Draft
 
@@ -209,6 +234,7 @@ error.
 
 `src/game/scenes/ridge/blockout/` parses this file directly through Vite raw
 imports. `RidgeScene` renders every room into one whole-world greybox by
-default, derives typed traversal connectors from `movement=` metadata, and
-keeps future routes / locked shortcuts as visual promises without active
-colliders or assist zones.
+default, derives typed traversal connectors from `movement=` metadata, compiles
+typed facts for presentation/interaction modules, resolves shortcuts from
+durable Ridge progress, and keeps future routes, locked shortcuts, and future
+Cicka Home mutations as inactive promises until their progress source exists.

--- a/docs/game-design/sketchbook-ridge-milestone-plan.md
+++ b/docs/game-design/sketchbook-ridge-milestone-plan.md
@@ -57,6 +57,12 @@ Anything beyond that is future scope unless a slice explicitly pulls it in.
   promoted the prepared Cicka prototype spritesheet into
   `public/assets/ridge/cicka/` as the first runtime-wired AI sprite adoption
   proof, with audit notes and refined pipeline gates.
+- **Ridge Architecture Deepening (#60-#64)** is implemented as the current Ridge
+  architecture direction: #60 made the blockout the spatial source of truth,
+  #61 consolidated traversal comfort, #62 added compiled blockout facts, #63
+  slimmed `RidgeScene` into lifecycle glue, and #64 made Cicka Home mutation
+  resolution data-driven. #65 is the documentation cleanup slice that records
+  this final shape.
 - **Asset staging is now an active coordination concern**: prepared POC assets
   still exist for Potassium, Stampede, and future Ridge character/prop families.
   Cicka's adopted runtime copy now lives under `public/assets/ridge/cicka/`;
@@ -316,6 +322,12 @@ Outputs:
 - first Cicka Note, memory reaction, or pre-translator interaction.
 
 Current checkpoint:
+
+- **Architecture-deepening child issues #60-#64 are represented in code**:
+  spatial facts now derive from the Ridge Blockout, traversal assists are owned
+  by the Ridge traversal runtime, Ridge scene presentation is split into
+  blockout/landmark modules, and Cicka Home mutations resolve from compiled
+  facts plus durable Ridge progress.
 
 - **M5a Durable Sticker Layer** accepted: `worldMemory.ts` derives visible
   Ridge memory ids from durable progress, empty progress returns no memories,

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -43,6 +43,7 @@ game vocabulary is explicit:
 - **Shared scene runtime** - reusable Phaser-facing machinery lives in `src/game/sharedSceneRuntime`: side-view player lifecycle, camera policy, scene presentation, resume policy, keyboard pause, interior interactions, text, textures, and vision helpers.
 - **Pure gameplay decisions** - `src/game/core` contains deterministic ECS, input, and player logic that can be tested without Phaser, React, browser globals, or bridge state.
 - **Scene-owned modules** - scene folders own local layout, triggers, Phaser objects, scene contexts, scene-local overlays, and heavy scene runtime modules.
+- **Ridge exploration runtime** - Ridge treats `docs/game-design/ridge.blockout.txt` as runtime source data. The Ridge scene parses the blockout, derives geometry, compiles typed facts, resolves durable progress, and hands those outputs to scene-owned presentation, traversal, interaction, and Cicka Home mutation modules.
 
 ## Scene presentation and camera
 
@@ -94,6 +95,10 @@ re-apply camera bounds/profile math.
 - Use `sceneResumePolicy` for resume persistence and reset rules. The low-level resume store should not be imported directly by scenes or adapters.
 - Side-view player scenes should compose `SideViewPlayerRuntime` before creating colliders against `runtime.player`; pass its camera config when the scene should follow and clamp the player.
 - Interior rooms should describe prop targets and effect commands, then let `InteriorInteractionRuntime` choose the active target and prompt/effect result. Phaser text mutation, bridge writes, and scene-local helpers stay in the scene.
+- Ridge spatial changes should start in the Ridge Map Language source, then flow through the Ridge blockout parser, geometry derivation, and compiled fact layer. Keep raw string attributes at the parser boundary; callers should consume typed facts or geometry outputs.
+- Ridge traversal assists are owned by the Ridge traversal runtime. The current runtime consumes compiled geometry and applies ramp, climb, drop, step-up, mantle, safe-position capture, and fall-recovery decisions around the shared side-view player.
+- Ridge landmark presentation owns ordinary landmark visuals such as Stampede blanket, Telegraph, Relay, Domino, guide, and high ledges. Cicka Home mutation visuals are resolved separately from compiled home-mutation facts and durable Ridge progress.
+- Cicka Home mutation declarations are data-driven but conservative: active mutations render only when a durable source exists, and future declarations stay typed promises until their progress source is implemented.
 
 ## Folder ownership
 
@@ -142,6 +147,20 @@ Potassium uses focused runtime modules to keep the large arcade scene navigable:
 - `potassiumSlipProjectileControl` is the pure control-state seam for banana launch, recall, and drag feel.
 - `potassiumSlipEnemyFactory` is the enemy setup seam for kind facts, spawn placement, and body/attachment setup.
 - `potassiumSlipPhaserData` is the typed data seam for Potassium-specific Phaser object metadata.
+
+Ridge uses focused runtime modules to keep the Exploration Map editable:
+
+- The blockout parser accepts the Ridge Map Language source and validates rooms,
+  symbols, anchors, route references, shortcuts, traversal movement values, and
+  runtime cell overlap.
+- The geometry layer turns grid cells, exits, and progress-gated shortcuts into
+  bounds, collider runs, connector platforms, and assist zones.
+- The compiled fact layer exposes room beats, route links, anchors, shortcuts,
+  and home mutations for presentation and interaction callers.
+- Ridge traversal runtime owns forgiving movement assists for the Exploration
+  Map; opt-in mini-games such as Stampede keep their own movement systems.
+- Cicka Home mutation resolution maps compiled home-mutation facts to durable
+  Ridge progress and keeps unresolved future mutations inactive.
 
 ## Manual smoke verification
 

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -21,7 +21,7 @@ function walk(dir) {
     if (ignoredDirs.has(entry.name)) continue;
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      const relativePath = path.relative(repoRoot, fullPath);
+      const relativePath = path.relative(repoRoot, fullPath).split(path.sep).join('/');
       if (ignoredRelativeDirs.has(relativePath)) continue;
       walk(fullPath);
     } else if (entry.isFile() && entry.name.endsWith('.md')) {

--- a/src/game/scenes/ridge/cicka/CickaPerch.ts
+++ b/src/game/scenes/ridge/cicka/CickaPerch.ts
@@ -41,6 +41,9 @@ export interface CickaPerchUpdateFrame {
 
 export interface CickaPerch {
   interactionFacts: CickaPerchInteractionFacts;
+  trackOwnedObject<GameObject extends Phaser.GameObjects.GameObject>(
+    gameObject: GameObject
+  ): GameObject;
   update(frame: CickaPerchUpdateFrame): void;
   showLine(line: string, nowMs: number, durationMs?: number): void;
   isSpeechVisible(nowMs: number): boolean;
@@ -176,6 +179,7 @@ export function createCickaPerch(options: CreateCickaPerchOptions): CickaPerch {
 
   return {
     interactionFacts,
+    trackOwnedObject: track,
     update,
     showLine,
     isSpeechVisible,

--- a/src/game/scenes/ridge/cicka/CickaPerch.ts
+++ b/src/game/scenes/ridge/cicka/CickaPerch.ts
@@ -50,12 +50,12 @@ export interface CickaPerch {
 export interface CreateCickaPerchOptions {
   scene: Phaser.Scene;
   landmark: { x: number; y: number };
-  hasStampedeNoteMemory: boolean;
+  hasStampedeNoteMutation: boolean;
   walkByLine: string;
 }
 
 export function createCickaPerch(options: CreateCickaPerchOptions): CickaPerch {
-  const { scene, landmark, hasStampedeNoteMemory, walkByLine } = options;
+  const { scene, landmark, hasStampedeNoteMutation, walkByLine } = options;
   const x = landmark.x;
   const y = landmark.y;
   const ownedObjects: Phaser.GameObjects.GameObject[] = [];
@@ -107,10 +107,6 @@ export function createCickaPerch(options: CreateCickaPerchOptions): CickaPerch {
     .setDepth(26));
   sprite.play(CICKA_ANIMATION_KEYS.perchIdle);
 
-  if (hasStampedeNoteMemory) {
-    addCickaStampedeNoteMemory(scene, track, x, y);
-  }
-
   const speechBubble = createCickaSpeechBubble(
     scene,
     track,
@@ -147,7 +143,7 @@ export function createCickaPerch(options: CreateCickaPerchOptions): CickaPerch {
 
   function update(frame: CickaPerchUpdateFrame): void {
     const walkByUpdate = updateCickaWalkBy(walkByState, {
-      enabled: hasStampedeNoteMemory,
+      enabled: hasStampedeNoteMutation,
       playerX: frame.playerX,
       playerY: frame.playerY,
       cickaX: x,
@@ -207,20 +203,3 @@ function createCickaSpeechBubble(
   return { container, label };
 }
 
-function addCickaStampedeNoteMemory(
-  scene: Phaser.Scene,
-  track: <GameObject extends Phaser.GameObjects.GameObject>(gameObject: GameObject) => GameObject,
-  x: number,
-  y: number
-): void {
-  track(scene.add.rectangle(x + 62, y - 72, 42, 30, 0xf7f1df, 1)
-    .setStrokeStyle(2, 0x1f1f1d, 0.88)
-    .setAngle(5));
-  track(scene.add.line(x + 42, y - 63, -8, 5, 8, -5, 0x1f1f1d, 0.3).setLineWidth(2));
-  track(scene.add.circle(x + 59, y - 70, 5, 0x1f1f1d, 0.72));
-  track(scene.add.circle(x + 51, y - 81, 3, 0x1f1f1d, 0.72));
-  track(scene.add.circle(x + 60, y - 84, 3, 0x1f1f1d, 0.72));
-  track(scene.add.circle(x + 69, y - 81, 3, 0x1f1f1d, 0.72));
-  track(scene.add.line(x + 78, y - 70, -7, 5, 10, -5, 0x1f1f1d, 0.48).setLineWidth(2));
-  track(scene.add.line(x + 79, y - 63, -6, 4, 9, -4, 0x1f1f1d, 0.38).setLineWidth(2));
-}

--- a/src/game/scenes/ridge/cicka/homeMutationPresentation.test.ts
+++ b/src/game/scenes/ridge/cicka/homeMutationPresentation.test.ts
@@ -1,0 +1,76 @@
+import type * as Phaser from 'phaser';
+import { describe, expect, it, vi } from 'vitest';
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+import { addCickaHomeMutationPresentation } from './homeMutationPresentation';
+import type { CickaHomeMutation } from './homeMutations';
+
+describe('Cicka Home mutation presentation', () => {
+  it('tracks Stampede note visuals for perch lifecycle cleanup', () => {
+    const scene = createScene();
+    const trackedObjects: Phaser.GameObjects.GameObject[] = [];
+
+    addCickaHomeMutationPresentation({
+      scene: scene.scene,
+      landmark: { x: 100, y: 200 },
+      mutations: [createStampedeNoteMutation()],
+      track: (gameObject) => {
+        trackedObjects.push(gameObject);
+        return gameObject;
+      }
+    });
+
+    expect(trackedObjects).toHaveLength(8);
+    expect(scene.add.rectangle).toHaveBeenCalledTimes(1);
+    expect(scene.add.line).toHaveBeenCalledTimes(3);
+    expect(scene.add.circle).toHaveBeenCalledTimes(4);
+  });
+});
+
+function createStampedeNoteMutation(): CickaHomeMutation {
+  return {
+    id: 'stampede_sketch',
+    adds: 'stampede_note',
+    opens: 'fold_drop_landing',
+    attrs: {
+      adds: 'stampede_note',
+      opens: 'fold_drop_landing'
+    },
+    source: {
+      kind: 'stamp',
+      id: STAMPEDE_SKETCH_RIDGE_STAMP_ID
+    }
+  };
+}
+
+function createScene(): {
+  scene: Phaser.Scene;
+  add: {
+    rectangle: ReturnType<typeof vi.fn>;
+    line: ReturnType<typeof vi.fn>;
+    circle: ReturnType<typeof vi.fn>;
+  };
+} {
+  const add = {
+    rectangle: vi.fn(() => createGameObject()),
+    line: vi.fn(() => createGameObject()),
+    circle: vi.fn(() => createGameObject())
+  };
+
+  return {
+    scene: {
+      add
+    } as unknown as Phaser.Scene,
+    add
+  };
+}
+
+function createGameObject(): Phaser.GameObjects.GameObject {
+  const gameObject = {
+    setStrokeStyle: vi.fn(() => gameObject),
+    setAngle: vi.fn(() => gameObject),
+    setLineWidth: vi.fn(() => gameObject),
+    destroy: vi.fn()
+  };
+
+  return gameObject as unknown as Phaser.GameObjects.GameObject;
+}

--- a/src/game/scenes/ridge/cicka/homeMutationPresentation.ts
+++ b/src/game/scenes/ridge/cicka/homeMutationPresentation.ts
@@ -2,35 +2,43 @@ import type * as Phaser from 'phaser';
 import type { CickaHomeMutation } from './homeMutations';
 import { hasCickaHomeMutationAdd } from './homeMutations';
 
+export type TrackCickaHomeMutationObject = <
+  GameObject extends Phaser.GameObjects.GameObject
+>(
+  gameObject: GameObject
+) => GameObject;
+
 export interface CickaHomeMutationPresentationOptions {
   scene: Phaser.Scene;
   landmark: { x: number; y: number };
   mutations: readonly CickaHomeMutation[];
+  track: TrackCickaHomeMutationObject;
 }
 
 export function addCickaHomeMutationPresentation(
   options: CickaHomeMutationPresentationOptions
 ): void {
-  const { scene, landmark, mutations } = options;
+  const { scene, landmark, mutations, track } = options;
 
   if (hasCickaHomeMutationAdd(mutations, 'stampede_note')) {
-    addCickaStampedeNoteMutation(scene, landmark.x, landmark.y);
+    addCickaStampedeNoteMutation(scene, track, landmark.x, landmark.y);
   }
 }
 
 function addCickaStampedeNoteMutation(
   scene: Phaser.Scene,
+  track: TrackCickaHomeMutationObject,
   x: number,
   y: number
 ): void {
-  scene.add.rectangle(x + 62, y - 72, 42, 30, 0xf7f1df, 1)
+  track(scene.add.rectangle(x + 62, y - 72, 42, 30, 0xf7f1df, 1)
     .setStrokeStyle(2, 0x1f1f1d, 0.88)
-    .setAngle(5);
-  scene.add.line(x + 42, y - 63, -8, 5, 8, -5, 0x1f1f1d, 0.3).setLineWidth(2);
-  scene.add.circle(x + 59, y - 70, 5, 0x1f1f1d, 0.72);
-  scene.add.circle(x + 51, y - 81, 3, 0x1f1f1d, 0.72);
-  scene.add.circle(x + 60, y - 84, 3, 0x1f1f1d, 0.72);
-  scene.add.circle(x + 69, y - 81, 3, 0x1f1f1d, 0.72);
-  scene.add.line(x + 78, y - 70, -7, 5, 10, -5, 0x1f1f1d, 0.48).setLineWidth(2);
-  scene.add.line(x + 79, y - 63, -6, 4, 9, -4, 0x1f1f1d, 0.38).setLineWidth(2);
+    .setAngle(5));
+  track(scene.add.line(x + 42, y - 63, -8, 5, 8, -5, 0x1f1f1d, 0.3).setLineWidth(2));
+  track(scene.add.circle(x + 59, y - 70, 5, 0x1f1f1d, 0.72));
+  track(scene.add.circle(x + 51, y - 81, 3, 0x1f1f1d, 0.72));
+  track(scene.add.circle(x + 60, y - 84, 3, 0x1f1f1d, 0.72));
+  track(scene.add.circle(x + 69, y - 81, 3, 0x1f1f1d, 0.72));
+  track(scene.add.line(x + 78, y - 70, -7, 5, 10, -5, 0x1f1f1d, 0.48).setLineWidth(2));
+  track(scene.add.line(x + 79, y - 63, -6, 4, 9, -4, 0x1f1f1d, 0.38).setLineWidth(2));
 }

--- a/src/game/scenes/ridge/cicka/homeMutationPresentation.ts
+++ b/src/game/scenes/ridge/cicka/homeMutationPresentation.ts
@@ -1,0 +1,36 @@
+import type * as Phaser from 'phaser';
+import type { CickaHomeMutation } from './homeMutations';
+import { hasCickaHomeMutationAdd } from './homeMutations';
+
+export interface CickaHomeMutationPresentationOptions {
+  scene: Phaser.Scene;
+  landmark: { x: number; y: number };
+  mutations: readonly CickaHomeMutation[];
+}
+
+export function addCickaHomeMutationPresentation(
+  options: CickaHomeMutationPresentationOptions
+): void {
+  const { scene, landmark, mutations } = options;
+
+  if (hasCickaHomeMutationAdd(mutations, 'stampede_note')) {
+    addCickaStampedeNoteMutation(scene, landmark.x, landmark.y);
+  }
+}
+
+function addCickaStampedeNoteMutation(
+  scene: Phaser.Scene,
+  x: number,
+  y: number
+): void {
+  scene.add.rectangle(x + 62, y - 72, 42, 30, 0xf7f1df, 1)
+    .setStrokeStyle(2, 0x1f1f1d, 0.88)
+    .setAngle(5);
+  scene.add.line(x + 42, y - 63, -8, 5, 8, -5, 0x1f1f1d, 0.3).setLineWidth(2);
+  scene.add.circle(x + 59, y - 70, 5, 0x1f1f1d, 0.72);
+  scene.add.circle(x + 51, y - 81, 3, 0x1f1f1d, 0.72);
+  scene.add.circle(x + 60, y - 84, 3, 0x1f1f1d, 0.72);
+  scene.add.circle(x + 69, y - 81, 3, 0x1f1f1d, 0.72);
+  scene.add.line(x + 78, y - 70, -7, 5, 10, -5, 0x1f1f1d, 0.48).setLineWidth(2);
+  scene.add.line(x + 79, y - 63, -6, 4, 9, -4, 0x1f1f1d, 0.38).setLineWidth(2);
+}

--- a/src/game/scenes/ridge/cicka/homeMutations.test.ts
+++ b/src/game/scenes/ridge/cicka/homeMutations.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+import type { BridgeRidgeProgressState } from '@/game/bridge/store';
+import {
+  RIDGE_BLOCKOUT,
+  compileRidgeBlockoutFacts
+} from '../blockout';
+import {
+  hasCickaHomeMutationAdd,
+  resolveCickaHomeMutations
+} from './homeMutations';
+
+function createRidgeProgress(
+  overrides: Partial<BridgeRidgeProgressState> = {}
+): BridgeRidgeProgressState {
+  return {
+    stampIds: [],
+    manualPageIds: [],
+    mobility: {
+      glidePips: 0
+    },
+    shortcutIds: [],
+    ...overrides
+  };
+}
+
+describe('Cicka Home mutations', () => {
+  it('activates no mutations for empty Ridge progress', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const resolution = resolveCickaHomeMutations(
+      facts.homeMutations,
+      createRidgeProgress()
+    );
+
+    expect(resolution.active).toEqual([]);
+  });
+
+  it('activates the compiled Stampede mutation from the durable Stampede stamp', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const resolution = resolveCickaHomeMutations(
+      facts.homeMutations,
+      createRidgeProgress({
+        stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
+      })
+    );
+
+    expect(resolution.active).toContainEqual(expect.objectContaining({
+      id: 'stampede_sketch',
+      adds: 'stampede_note',
+      opens: 'fold_drop_landing',
+      source: {
+        kind: 'stamp',
+        id: STAMPEDE_SKETCH_RIDGE_STAMP_ID
+      }
+    }));
+    expect(hasCickaHomeMutationAdd(resolution.active, 'stampede_note')).toBe(true);
+  });
+
+  it('does not activate Cicka Home mutations from unrelated progress', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const resolution = resolveCickaHomeMutations(
+      facts.homeMutations,
+      createRidgeProgress({
+        stampIds: ['future-stamp'],
+        manualPageIds: ['future-manual-page'],
+        shortcutIds: ['telegraph_clear'],
+        mobility: {
+          glidePips: 3
+        }
+      })
+    );
+
+    expect(resolution.active).toEqual([]);
+  });
+
+  it('keeps non-Stampede mutations as typed future promises', () => {
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT);
+    const resolution = resolveCickaHomeMutations(
+      facts.homeMutations,
+      createRidgeProgress({
+        stampIds: [STAMPEDE_SKETCH_RIDGE_STAMP_ID]
+      })
+    );
+
+    expect(resolution.promises).toContainEqual(expect.objectContaining({
+      id: 'work_artifact',
+      adds: 'work_display',
+      source: {
+        kind: 'future-progress'
+      }
+    }));
+    expect(resolution.active).not.toContainEqual(expect.objectContaining({
+      id: 'work_artifact'
+    }));
+  });
+});

--- a/src/game/scenes/ridge/cicka/homeMutations.ts
+++ b/src/game/scenes/ridge/cicka/homeMutations.ts
@@ -1,0 +1,71 @@
+import { STAMPEDE_SKETCH_RIDGE_STAMP_ID } from '@/game/bridge/ridgeProgressIds';
+import type {
+  BridgeRidgeProgressState,
+  RidgeStampId
+} from '@/game/bridge/store';
+import type { RidgeHomeMutationFact } from '../blockout';
+
+export type CickaHomeMutationProgressSource =
+  | {
+      kind: 'stamp';
+      id: RidgeStampId;
+    };
+
+export interface CickaHomeMutation extends RidgeHomeMutationFact {
+  source: CickaHomeMutationProgressSource;
+}
+
+export interface CickaHomeMutationPromise extends RidgeHomeMutationFact {
+  source: {
+    kind: 'future-progress';
+  };
+}
+
+export interface CickaHomeMutationResolution {
+  active: readonly CickaHomeMutation[];
+  promises: readonly CickaHomeMutationPromise[];
+}
+
+const CICKA_HOME_MUTATION_PROGRESS_SOURCES: Readonly<Record<string, CickaHomeMutationProgressSource>> = {
+  stampede_sketch: {
+    kind: 'stamp',
+    id: STAMPEDE_SKETCH_RIDGE_STAMP_ID
+  }
+};
+
+export function resolveCickaHomeMutations(
+  homeMutations: readonly RidgeHomeMutationFact[],
+  ridgeProgress: BridgeRidgeProgressState
+): CickaHomeMutationResolution {
+  const active: CickaHomeMutation[] = [];
+  const promises: CickaHomeMutationPromise[] = [];
+
+  homeMutations.forEach((mutation) => {
+    const source = CICKA_HOME_MUTATION_PROGRESS_SOURCES[mutation.id];
+    if (!source) {
+      promises.push({
+        ...mutation,
+        source: {
+          kind: 'future-progress'
+        }
+      });
+      return;
+    }
+
+    if (source.kind === 'stamp' && ridgeProgress.stampIds.includes(source.id)) {
+      active.push({
+        ...mutation,
+        source
+      });
+    }
+  });
+
+  return { active, promises };
+}
+
+export function hasCickaHomeMutationAdd(
+  mutations: readonly Pick<CickaHomeMutation, 'adds'>[],
+  addId: string
+): boolean {
+  return mutations.some((mutation) => mutation.adds === addId);
+}

--- a/src/game/scenes/ridge/cicka/homeMutations.ts
+++ b/src/game/scenes/ridge/cicka/homeMutations.ts
@@ -26,12 +26,23 @@ export interface CickaHomeMutationResolution {
   promises: readonly CickaHomeMutationPromise[];
 }
 
+type CickaHomeMutationProgressSourceActiveChecks = {
+  [Kind in CickaHomeMutationProgressSource['kind']]: (
+    source: Extract<CickaHomeMutationProgressSource, { kind: Kind }>,
+    ridgeProgress: BridgeRidgeProgressState
+  ) => boolean;
+};
+
 const CICKA_HOME_MUTATION_PROGRESS_SOURCES: Readonly<Record<string, CickaHomeMutationProgressSource>> = {
   stampede_sketch: {
     kind: 'stamp',
     id: STAMPEDE_SKETCH_RIDGE_STAMP_ID
   }
 };
+
+const CICKA_HOME_MUTATION_PROGRESS_SOURCE_ACTIVE_CHECKS = {
+  stamp: (source, ridgeProgress) => ridgeProgress.stampIds.includes(source.id)
+} satisfies CickaHomeMutationProgressSourceActiveChecks;
 
 export function resolveCickaHomeMutations(
   homeMutations: readonly RidgeHomeMutationFact[],
@@ -52,23 +63,25 @@ export function resolveCickaHomeMutations(
       return;
     }
 
-    switch (source.kind) {
-      case 'stamp':
-        if (ridgeProgress.stampIds.includes(source.id)) {
-          active.push({
-            ...mutation,
-            source
-          });
-        }
-        break;
-      default: {
-        const exhaustiveSource: never = source;
-        return exhaustiveSource;
-      }
+    if (isCickaHomeMutationSourceActive(source, ridgeProgress)) {
+      active.push({
+        ...mutation,
+        source
+      });
     }
   });
 
   return { active, promises };
+}
+
+function isCickaHomeMutationSourceActive(
+  source: CickaHomeMutationProgressSource,
+  ridgeProgress: BridgeRidgeProgressState
+): boolean {
+  switch (source.kind) {
+    case 'stamp':
+      return CICKA_HOME_MUTATION_PROGRESS_SOURCE_ACTIVE_CHECKS.stamp(source, ridgeProgress);
+  }
 }
 
 export function hasCickaHomeMutationAdd(

--- a/src/game/scenes/ridge/cicka/homeMutations.ts
+++ b/src/game/scenes/ridge/cicka/homeMutations.ts
@@ -52,11 +52,19 @@ export function resolveCickaHomeMutations(
       return;
     }
 
-    if (source.kind === 'stamp' && ridgeProgress.stampIds.includes(source.id)) {
-      active.push({
-        ...mutation,
-        source
-      });
+    switch (source.kind) {
+      case 'stamp':
+        if (ridgeProgress.stampIds.includes(source.id)) {
+          active.push({
+            ...mutation,
+            source
+          });
+        }
+        break;
+      default: {
+        const exhaustiveSource: never = source;
+        return exhaustiveSource;
+      }
     }
   });
 

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -42,6 +42,7 @@ import {
   preloadCickaAssets
 } from '../cicka/assets';
 import type { CickaPerch } from '../cicka/CickaPerch';
+import { resolveCickaHomeMutations } from '../cicka/homeMutations';
 import {
   createRidgeTraversalRuntime,
   type RidgeTraversalRuntime
@@ -118,6 +119,10 @@ export class RidgeScene extends Phaser.Scene {
     const facts = compileRidgeBlockoutFacts(blockout, {
       geometry
     });
+    const cickaHomeMutations = resolveCickaHomeMutations(
+      facts.homeMutations,
+      ridgeProgress
+    );
     this.traversalRuntime = undefined;
 
     this.cameras.main.setBackgroundColor('#f7f1df');
@@ -142,7 +147,8 @@ export class RidgeScene extends Phaser.Scene {
         stampedeFirstClearLabel: messages.scenes.ridge.memory.stampedeFirstClearLabel,
         cickaWalkByLine: messages.scenes.ridge.memory.cickaWalkByBark
       },
-      worldMemories: getRidgeWorldMemories(ridgeProgress)
+      worldMemories: getRidgeWorldMemories(ridgeProgress),
+      cickaHomeMutations: cickaHomeMutations.active
     });
     this.cickaPerch = landmarkPresentation.cickaPerch;
     this.createPlayer(blockoutPresentation.platforms, facts, geometry);

--- a/src/game/scenes/ridge/runtime/ridgeInteractionTargets.test.ts
+++ b/src/game/scenes/ridge/runtime/ridgeInteractionTargets.test.ts
@@ -31,6 +31,7 @@ function createTestCickaPerch(): CickaPerch {
       prompt: { x: 120, y: 80 },
       interactRadius: 78
     },
+    trackOwnedObject: (gameObject) => gameObject,
     update: () => {},
     showLine: () => {},
     isSpeechVisible: () => false,

--- a/src/game/scenes/ridge/runtime/ridgeLandmarkPresentation.ts
+++ b/src/game/scenes/ridge/runtime/ridgeLandmarkPresentation.ts
@@ -112,7 +112,8 @@ export function createRidgeLandmarkPresentation(
   addCickaHomeMutationPresentation({
     scene,
     landmark: cickaLandmark,
-    mutations: cickaHomeMutations
+    mutations: cickaHomeMutations,
+    track: cickaPerch.trackOwnedObject
   });
 
   addOutskirtsArtifactSlot(scene, anchors.outskirtsArtifact.x, anchors.outskirtsArtifact.y);

--- a/src/game/scenes/ridge/runtime/ridgeLandmarkPresentation.ts
+++ b/src/game/scenes/ridge/runtime/ridgeLandmarkPresentation.ts
@@ -8,6 +8,11 @@ import {
   createCickaPerch,
   type CickaPerch
 } from '../cicka/CickaPerch';
+import { addCickaHomeMutationPresentation } from '../cicka/homeMutationPresentation';
+import {
+  hasCickaHomeMutationAdd,
+  type CickaHomeMutation
+} from '../cicka/homeMutations';
 import {
   hasRidgeWorldMemory,
   type RidgeWorldMemory
@@ -81,6 +86,7 @@ export interface RidgeLandmarkPresentationOptions {
   facts: RidgeBlockoutFacts;
   copy: RidgeLandmarkPresentationCopy;
   worldMemories: readonly RidgeWorldMemory[];
+  cickaHomeMutations: readonly CickaHomeMutation[];
 }
 
 export interface RidgeLandmarkPresentation {
@@ -90,20 +96,23 @@ export interface RidgeLandmarkPresentation {
 export function createRidgeLandmarkPresentation(
   options: RidgeLandmarkPresentationOptions
 ): RidgeLandmarkPresentation {
-  const { scene, facts, copy, worldMemories } = options;
+  const { scene, facts, copy, worldMemories, cickaHomeMutations } = options;
   const anchors = resolveRidgeLandmarkAnchors(facts);
+  const cickaLandmark = {
+    x: anchors.cicka.x,
+    y: anchors.cicka.y + CICKA_PERCH_OFFSET_Y
+  };
 
   const cickaPerch = createCickaPerch({
     scene,
-    landmark: {
-      x: anchors.cicka.x,
-      y: anchors.cicka.y + CICKA_PERCH_OFFSET_Y
-    },
-    hasStampedeNoteMemory: hasRidgeWorldMemory(
-      worldMemories.filter((memory) => memory.landmarkKind === 'cicka-perch'),
-      'cicka-stampede-note'
-    ),
+    landmark: cickaLandmark,
+    hasStampedeNoteMutation: hasCickaHomeMutationAdd(cickaHomeMutations, 'stampede_note'),
     walkByLine: copy.cickaWalkByLine
+  });
+  addCickaHomeMutationPresentation({
+    scene,
+    landmark: cickaLandmark,
+    mutations: cickaHomeMutations
   });
 
   addOutskirtsArtifactSlot(scene, anchors.outskirtsArtifact.x, anchors.outskirtsArtifact.y);


### PR DESCRIPTION
## Summary
- Add a typed Cicka Home mutation resolver that maps compiled Ridge home-mutation facts to durable progress sources.
- Render active Cicka Home mutation visuals through a dedicated runtime helper and keep unrelated landmark rendering unchanged.
- Move Stampede note drawing out of `CickaPerch` and keep Cicka interaction behavior keyed from the active Stampede-derived mutation state.
- Add unit coverage for empty progress, Stampede activation, unrelated progress, and future `work_artifact` promise handling.

## Testing
- Added targeted unit tests for the new resolver and mutation selection behavior.
- Ran Ridge world-memory, Cicka interaction, and ridge landmark presentation tests to confirm existing behavior still passes.
- Performed local type and test validation for the Ridge change set.