### PR TITLE
Add repository line ending policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,5 +14,12 @@
 *.ogg binary
 *.glb binary
 *.gltf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.mp4 binary
+*.webm binary
+*.wasm binary
 *.zip binary
 *.pdf binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Normalize text files in the repo to LF so clones behave consistently across
+# Windows, WSL, Linux, and macOS.
+* text=auto eol=lf
+
+# Binary assets should never be line-ending normalized.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.mp3 binary
+*.wav binary
+*.ogg binary
+*.glb binary
+*.gltf binary
+*.zip binary
+*.pdf binary


### PR DESCRIPTION
## Summary
- Add a repo-level `.gitattributes` to normalize text files to LF across Windows, WSL, Linux, and macOS
- Mark common binary asset types so Git does not normalize their line endings

## Testing
- Not run (not requested)
- Verified the branch contains only the `.gitattributes` change