### PR TITLE
Add Ridge debug overlays and stabilize preview runtime surfaces

### DIFF
--- a/src/dev/ridgeBlockoutViewer/ModelCanvas.tsx
+++ b/src/dev/ridgeBlockoutViewer/ModelCanvas.tsx
@@ -49,7 +49,7 @@ export function ModelCanvas({
   worldRef: RefObject<SVGGElement | null>;
 }) {
   return (
-    <section className="relative min-h-0 min-w-0 overflow-hidden border-4 border-[#1a1a1a] bg-[#fdfcf7] shadow-[7px_7px_0_rgba(26,26,26,1)]">
+    <section className="relative h-full min-h-0 min-w-0 overflow-hidden border-4 border-[#1a1a1a] bg-[#fdfcf7] shadow-[7px_7px_0_rgba(26,26,26,1)]">
       <ModelToolbar
         zoom={view.zoom}
         onZoomIn={onZoomIn}

--- a/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.test.tsx
+++ b/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.test.tsx
@@ -7,6 +7,8 @@ import { bridgeActions, bridgeStore } from '@/game/bridge/store';
 import { RIDGE_SCENE_ID, STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
 import type { RidgeDevControls } from '@/game/scenes/ridge/runtime/ridgeDevControls';
 import RidgeBlockoutViewer from './RidgeBlockoutViewer';
+import { createRidgeBlockoutViewerModel } from './model';
+import { fitRoomToViewport, getWorldTransform } from './modelViewport';
 
 let lastRidgeDevControls: RidgeDevControls | undefined;
 let lastReturnToOverworld: (() => void) | undefined;
@@ -308,6 +310,66 @@ describe('RidgeBlockoutViewer', () => {
     expect(window.location.search).toContain('view=model');
   });
 
+  it('focuses the model view on the room containing the latest preview player snapshot', async () => {
+    const model = createRidgeBlockoutViewerModel();
+    const cickaHome = getViewerRoom(model, 'cicka_home');
+    render(<RidgeBlockoutViewer />);
+
+    act(() => {
+      lastRidgeDevControls?.publishPlayerSnapshot?.({
+        x: cickaHome.x + cickaHome.width / 2,
+        y: cickaHome.y + cickaHome.height / 2
+      });
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Model' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ridge-viewer-world').getAttribute('transform')).toBe(
+        getExpectedRoomTransform(cickaHome)
+      );
+    });
+  });
+
+  it('focuses the nearest room when the preview player snapshot is on a connector', async () => {
+    const model = createRidgeBlockoutViewerModel();
+    const cickaHome = getViewerRoom(model, 'cicka_home');
+    render(<RidgeBlockoutViewer />);
+
+    act(() => {
+      lastRidgeDevControls?.publishPlayerSnapshot?.({
+        x: cickaHome.x - 12,
+        y: cickaHome.y + cickaHome.height / 2
+      });
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Model' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ridge-viewer-world').getAttribute('transform')).toBe(
+        getExpectedRoomTransform(cickaHome)
+      );
+    });
+  });
+
+  it('keeps the runtime preview mounted and paused while inspecting the model', async () => {
+    render(<RidgeBlockoutViewer />);
+
+    expect(await screen.findByText('Runtime scene: ridge')).not.toBeNull();
+    await userEvent.click(screen.getByRole('button', { name: 'Model' }));
+
+    const preview = screen.getByTestId('ridge-runtime-preview');
+    expect(bridgeStore.getState().activeSceneId).toBe(RIDGE_SCENE_ID);
+    expect(lastGameIsPaused).toBe(true);
+    expect(preview.hidden).toBe(false);
+    expect(preview.getAttribute('aria-hidden')).toBe('true');
+    expect(preview.className).toContain('invisible');
+    expect(preview.tabIndex).toBe(-1);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Preview' }));
+
+    expect(screen.getByTestId('mock-ridge-game').textContent).toContain('Runtime scene: ridge');
+    expect(bridgeStore.getState().activeSceneId).toBe(RIDGE_SCENE_ID);
+  });
+
   it('renders generated blockout summary and inspection layers', () => {
     render(<RidgeBlockoutViewer />);
     fireEvent.click(screen.getByRole('button', { name: 'Model' }));
@@ -385,3 +447,20 @@ describe('RidgeBlockoutViewer', () => {
     expect(selected.textContent).toContain('cicka');
   });
 });
+
+function getViewerRoom(
+  model: ReturnType<typeof createRidgeBlockoutViewerModel>,
+  roomId: string
+) {
+  const room = model.rooms.find((candidate) => candidate.id === roomId);
+  if (!room) throw new Error(`Missing Ridge viewer room "${roomId}"`);
+  return room;
+}
+
+function getExpectedRoomTransform(room: ReturnType<typeof getViewerRoom>): string {
+  return getWorldTransform(fitRoomToViewport({
+    room,
+    viewportHeight: 700,
+    viewportWidth: 1000
+  }));
+}

--- a/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.test.tsx
+++ b/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.test.tsx
@@ -1,31 +1,36 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { bridgeActions } from '@/game/bridge/store';
+import { bridgeActions, bridgeStore } from '@/game/bridge/store';
+import { RIDGE_SCENE_ID, STAMPEDE_SKETCH_SCENE_ID } from '@/game/scenes/sceneIds';
 import type { RidgeDevControls } from '@/game/scenes/ridge/runtime/ridgeDevControls';
 import RidgeBlockoutViewer from './RidgeBlockoutViewer';
 
 let lastRidgeDevControls: RidgeDevControls | undefined;
 let lastReturnToOverworld: (() => void) | undefined;
 let lastGameIsPaused: boolean | undefined;
+let lastGamePresentationMode: string | undefined;
 
 vi.mock('@/game/shell/Game', () => ({
   default: ({
     activeSceneId,
     isPaused,
+    presentationMode,
     ridgeDevControls,
     onReturnToOverworld
   }: {
     activeSceneId: string;
     isPaused: boolean;
+    presentationMode: string;
     ridgeDevControls?: RidgeDevControls;
     onReturnToOverworld: () => void;
   }) => {
     lastRidgeDevControls = ridgeDevControls;
     lastReturnToOverworld = onReturnToOverworld;
     lastGameIsPaused = isPaused;
+    lastGamePresentationMode = presentationMode;
     return <div data-testid="mock-ridge-game">Runtime scene: {activeSceneId}</div>;
   }
 }));
@@ -41,6 +46,7 @@ describe('RidgeBlockoutViewer', () => {
     lastRidgeDevControls = undefined;
     lastReturnToOverworld = undefined;
     lastGameIsPaused = undefined;
+    lastGamePresentationMode = undefined;
   });
 
   afterEach(() => {
@@ -53,6 +59,7 @@ describe('RidgeBlockoutViewer', () => {
     lastRidgeDevControls = undefined;
     lastReturnToOverworld = undefined;
     lastGameIsPaused = undefined;
+    lastGamePresentationMode = undefined;
   });
 
   it('defaults to the runtime preview tab and boots Ridge through the game shell', async () => {
@@ -117,6 +124,89 @@ describe('RidgeBlockoutViewer', () => {
     expect(lastGameIsPaused).toBe(false);
     expect(document.activeElement).toBe(preview);
     expect(screen.queryByTestId('ridge-preview-paused-overlay')).toBeNull();
+  });
+
+  it('renders Trail Card overlays inside the preview instead of leaving a ghost pause', async () => {
+    render(<RidgeBlockoutViewer />);
+
+    act(() => {
+      bridgeActions.openOverlay('trailCard', {
+        params: {
+          title: 'Stampede Sketch',
+          mood: 'Kite overexcited ink ideas',
+          timeEstimate: '60-90 seconds',
+          rewardPreview: 'Stamp + glide pip',
+          enterSceneId: STAMPEDE_SKETCH_SCENE_ID
+        },
+        returnToSceneId: RIDGE_SCENE_ID
+      });
+    });
+
+    expect(lastGameIsPaused).toBe(true);
+    expect(screen.getByTestId('ridge-preview-input-status').textContent).toContain('Runtime paused');
+    expect(screen.queryByTestId('ridge-preview-paused-overlay')).toBeNull();
+    expect(await screen.findByRole('dialog', { name: 'Stampede Sketch' })).toBeDefined();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Back to Ridge' }));
+
+    await waitFor(() => expect(bridgeStore.getState().activeOverlay).toBeNull());
+    expect(lastGameIsPaused).toBe(false);
+    expect(screen.getByTestId('ridge-preview-input-status').textContent).toContain('Game input');
+  });
+
+  it('routes Trail Card scene entry through the preview runtime owner', async () => {
+    render(<RidgeBlockoutViewer />);
+
+    act(() => {
+      bridgeActions.openOverlay('trailCard', {
+        params: {
+          title: 'Stampede Sketch',
+          mood: 'Kite overexcited ink ideas',
+          timeEstimate: '60-90 seconds',
+          rewardPreview: 'Stamp + glide pip',
+          enterSceneId: STAMPEDE_SKETCH_SCENE_ID
+        },
+        returnToSceneId: RIDGE_SCENE_ID
+      });
+    });
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Enter' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Runtime scene: stampedeSketch')).toBeDefined();
+    });
+    expect(bridgeStore.getState().activeOverlay).toBeNull();
+    expect(lastGameIsPaused).toBe(false);
+    expect(lastGamePresentationMode).toBe('vertical-board');
+    expect(screen.getByRole('button', { name: 'Back to Ridge' })).toBeDefined();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Back to Ridge' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Runtime scene: ridge')).toBeDefined();
+    });
+  });
+
+  it('hosts Stampede scene UI surfaces inside the preview runtime', () => {
+    render(<RidgeBlockoutViewer />);
+
+    act(() => {
+      bridgeActions.enterScene(STAMPEDE_SKETCH_SCENE_ID);
+      bridgeActions.setSceneUiPanel(STAMPEDE_SKETCH_SCENE_ID, 'stampedeStartPrompt');
+      bridgeActions.setSceneUiStatus(STAMPEDE_SKETCH_SCENE_ID, 'stampedeStatus', {
+        timeRemainingSeconds: 68,
+        phaseLabel: 'Breather',
+        pageNoise: 0.4,
+        healthRemaining: 4,
+        contactLimit: 5
+      });
+    });
+
+    expect(screen.getByRole('dialog', { name: 'Ready?' })).toBeDefined();
+    expect(screen.getByRole('button', { name: /^start$/i })).toBeDefined();
+    expect(screen.getByText('1:08')).toBeDefined();
+    expect(screen.getByLabelText('HP 4 of 5')).toBeDefined();
+    expect(screen.getByRole('progressbar', { name: /page noise/i }).getAttribute('aria-valuenow')).toBe('40');
   });
 
   it('keeps the runtime preview in Ridge when the scene close callback fires', async () => {

--- a/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.test.tsx
+++ b/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.test.tsx
@@ -8,16 +8,20 @@ import type { RidgeDevControls } from '@/game/scenes/ridge/runtime/ridgeDevContr
 import RidgeBlockoutViewer from './RidgeBlockoutViewer';
 
 let lastRidgeDevControls: RidgeDevControls | undefined;
+let lastReturnToOverworld: (() => void) | undefined;
 
 vi.mock('@/game/shell/Game', () => ({
   default: ({
     activeSceneId,
-    ridgeDevControls
+    ridgeDevControls,
+    onReturnToOverworld
   }: {
     activeSceneId: string;
     ridgeDevControls?: RidgeDevControls;
+    onReturnToOverworld: () => void;
   }) => {
     lastRidgeDevControls = ridgeDevControls;
+    lastReturnToOverworld = onReturnToOverworld;
     return <div data-testid="mock-ridge-game">Runtime scene: {activeSceneId}</div>;
   }
 }));
@@ -31,6 +35,7 @@ describe('RidgeBlockoutViewer', () => {
     bridgeActions.setSceneLoading(null);
     bridgeActions.resetTouch();
     lastRidgeDevControls = undefined;
+    lastReturnToOverworld = undefined;
   });
 
   afterEach(() => {
@@ -41,6 +46,7 @@ describe('RidgeBlockoutViewer', () => {
     bridgeActions.setSceneLoading(null);
     bridgeActions.resetTouch();
     lastRidgeDevControls = undefined;
+    lastReturnToOverworld = undefined;
   });
 
   it('defaults to the runtime preview tab and boots Ridge through the game shell', async () => {
@@ -51,6 +57,17 @@ describe('RidgeBlockoutViewer', () => {
     expect(screen.getByTestId('ridge-runtime-preview')).not.toBeNull();
     expect(await screen.findByText('Runtime scene: ridge')).not.toBeNull();
     expect(screen.queryByTestId('ridge-blockout-svg')).toBeNull();
+  });
+
+  it('keeps the runtime preview in Ridge when the scene close callback fires', async () => {
+    render(<RidgeBlockoutViewer />);
+    expect(await screen.findByText('Runtime scene: ridge')).not.toBeNull();
+
+    act(() => {
+      lastReturnToOverworld?.();
+    });
+
+    expect(screen.getByText('Runtime scene: ridge')).not.toBeNull();
   });
 
   it('keeps the compact header controls and validation status visible', () => {
@@ -73,6 +90,29 @@ describe('RidgeBlockoutViewer', () => {
     expect(screen.getByLabelText('Preview zoom')).toHaveProperty('value', '1.25');
   });
 
+  it('updates the runtime preview debug overlay settings', async () => {
+    render(<RidgeBlockoutViewer />);
+
+    expect(lastRidgeDevControls?.resolveDebugSettings?.()).toMatchObject({
+      graybox: false,
+      showColliders: false,
+      showPlayerBody: false,
+      showInteractZones: false,
+      showTraversalAssists: false
+    });
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Colliders' }));
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Interact zones' }));
+
+    expect(lastRidgeDevControls?.resolveDebugSettings?.()).toMatchObject({
+      graybox: false,
+      showColliders: true,
+      showPlayerBody: false,
+      showInteractZones: true,
+      showTraversalAssists: false
+    });
+  });
+
   it('dispatches preview teleport requests from source-backed anchors', async () => {
     render(<RidgeBlockoutViewer />);
 
@@ -85,6 +125,19 @@ describe('RidgeBlockoutViewer', () => {
     });
     expect(request?.x).toBeGreaterThan(0);
     expect(request?.y).toBeGreaterThan(0);
+  });
+
+  it('dispatches a preview reset request back to the Ridge spawn', async () => {
+    render(<RidgeBlockoutViewer />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Reset player' }));
+
+    const request = lastRidgeDevControls?.consumeResetRequest?.();
+    expect(request).toMatchObject({
+      label: 'start'
+    });
+    expect(screen.getByText('Sent: reset start')).not.toBeNull();
+    expect(lastRidgeDevControls?.consumeResetRequest?.()).toBeNull();
   });
 
   it('switches to the source-backed model inspector tab', async () => {

--- a/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.test.tsx
+++ b/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.test.tsx
@@ -9,19 +9,23 @@ import RidgeBlockoutViewer from './RidgeBlockoutViewer';
 
 let lastRidgeDevControls: RidgeDevControls | undefined;
 let lastReturnToOverworld: (() => void) | undefined;
+let lastGameIsPaused: boolean | undefined;
 
 vi.mock('@/game/shell/Game', () => ({
   default: ({
     activeSceneId,
+    isPaused,
     ridgeDevControls,
     onReturnToOverworld
   }: {
     activeSceneId: string;
+    isPaused: boolean;
     ridgeDevControls?: RidgeDevControls;
     onReturnToOverworld: () => void;
   }) => {
     lastRidgeDevControls = ridgeDevControls;
     lastReturnToOverworld = onReturnToOverworld;
+    lastGameIsPaused = isPaused;
     return <div data-testid="mock-ridge-game">Runtime scene: {activeSceneId}</div>;
   }
 }));
@@ -36,6 +40,7 @@ describe('RidgeBlockoutViewer', () => {
     bridgeActions.resetTouch();
     lastRidgeDevControls = undefined;
     lastReturnToOverworld = undefined;
+    lastGameIsPaused = undefined;
   });
 
   afterEach(() => {
@@ -47,6 +52,7 @@ describe('RidgeBlockoutViewer', () => {
     bridgeActions.resetTouch();
     lastRidgeDevControls = undefined;
     lastReturnToOverworld = undefined;
+    lastGameIsPaused = undefined;
   });
 
   it('defaults to the runtime preview tab and boots Ridge through the game shell', async () => {
@@ -56,7 +62,61 @@ describe('RidgeBlockoutViewer', () => {
     expect(screen.getByRole('button', { name: 'Model' }).getAttribute('aria-pressed')).toBe('false');
     expect(screen.getByTestId('ridge-runtime-preview')).not.toBeNull();
     expect(await screen.findByText('Runtime scene: ridge')).not.toBeNull();
+    expect(lastGameIsPaused).toBe(false);
     expect(screen.queryByTestId('ridge-blockout-svg')).toBeNull();
+  });
+
+  it('pauses game input while preview panel controls own focus', async () => {
+    render(<RidgeBlockoutViewer />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Reset player' }));
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Reset player' }));
+    expect(lastGameIsPaused).toBe(true);
+    expect(screen.getByTestId('ridge-preview-input-status').textContent).toContain('Panel focus');
+    expect(screen.getByTestId('ridge-preview-paused-overlay').textContent).toContain('Paused');
+    expect(screen.getByTestId('ridge-preview-paused-overlay').textContent).toContain('Panel focus');
+  });
+
+  it('keeps native Space activation on focused panel buttons without resuming game input', async () => {
+    render(<RidgeBlockoutViewer />);
+    await userEvent.click(screen.getByRole('button', { name: 'Reset player' }));
+    lastRidgeDevControls?.consumeResetRequest?.();
+
+    await userEvent.keyboard('[Space]');
+
+    expect(lastGameIsPaused).toBe(true);
+    expect(lastRidgeDevControls?.consumeResetRequest?.()).toMatchObject({ label: 'start' });
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Reset player' }));
+  });
+
+  it('resumes game input when the runtime preview owns focus again', async () => {
+    render(<RidgeBlockoutViewer />);
+    const preview = screen.getByTestId('ridge-runtime-preview');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Reset player' }));
+    expect(lastGameIsPaused).toBe(true);
+
+    await userEvent.click(preview);
+
+    expect(lastGameIsPaused).toBe(false);
+    expect(document.activeElement).toBe(preview);
+    expect(screen.getByTestId('ridge-preview-input-status').textContent).toContain('Game input');
+    expect(screen.queryByTestId('ridge-preview-paused-overlay')).toBeNull();
+  });
+
+  it('resumes game input from the preview focus control', async () => {
+    render(<RidgeBlockoutViewer />);
+    const preview = screen.getByTestId('ridge-runtime-preview');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Reset player' }));
+    expect(lastGameIsPaused).toBe(true);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Focus game' }));
+
+    expect(lastGameIsPaused).toBe(false);
+    expect(document.activeElement).toBe(preview);
+    expect(screen.queryByTestId('ridge-preview-paused-overlay')).toBeNull();
   });
 
   it('keeps the runtime preview in Ridge when the scene close callback fires', async () => {
@@ -76,7 +136,15 @@ describe('RidgeBlockoutViewer', () => {
     expect(screen.getByRole('heading', { name: 'Ridge Blockout Viewer' })).not.toBeNull();
     expect(screen.getByRole('button', { name: 'Preview' })).not.toBeNull();
     expect(screen.getByRole('button', { name: 'Model' })).not.toBeNull();
-    expect(screen.getByTestId('ridge-viewer-header-validation-status').textContent).toContain('Clean');
+    expect(screen.getByTestId('ridge-viewer-header-validation-status').textContent).toContain('Map valid');
+  });
+
+  it('uses clear runtime preview labels for zoom and input state', () => {
+    render(<RidgeBlockoutViewer />);
+
+    expect(screen.getByText('Live Ridge')).not.toBeNull();
+    expect(screen.getByText('Camera zoom 100%')).not.toBeNull();
+    expect(screen.queryByText(/Actual Ridge runtime/)).toBeNull();
   });
 
   it('updates the runtime preview camera zoom control', async () => {
@@ -156,7 +224,7 @@ describe('RidgeBlockoutViewer', () => {
 
     expect(screen.getByRole('heading', { name: 'Ridge Blockout Viewer' })).not.toBeNull();
     expect(screen.getByText('Folded Desk Ridge')).not.toBeNull();
-    expect(screen.getByTestId('ridge-viewer-validation-status').textContent).toContain('Validation clean');
+    expect(screen.getByTestId('ridge-viewer-validation-status').textContent).toContain('Map valid');
     expect(screen.getByLabelText('Room Cicka Home')).not.toBeNull();
     expect(screen.getByLabelText(/Anchor C in Cicka Home: npc/)).not.toBeNull();
     expect(screen.getByText('Route: first_walk')).not.toBeNull();

--- a/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.tsx
+++ b/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.tsx
@@ -67,10 +67,13 @@ export default function RidgeBlockoutViewer() {
             <SummaryPanel model={model} />
             {activeView === 'preview' ? (
               <PreviewPanel
+                debugSettings={previewControls.debugSettings}
                 lastTeleportLabel={previewControls.lastTeleportLabel}
                 onPreviewZoomChange={previewControls.setPreviewZoomLevel}
                 onPreviewZoomIn={() => previewControls.adjustPreviewZoom(0.25)}
                 onPreviewZoomOut={() => previewControls.adjustPreviewZoom(-0.25)}
+                onResetPlayer={previewControls.requestPlayerReset}
+                onToggleDebugSetting={previewControls.toggleDebugSetting}
                 onTeleport={previewControls.requestTeleport}
                 playerSnapshot={previewControls.playerSnapshot}
                 previewZoom={previewControls.previewZoom}

--- a/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.tsx
+++ b/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.tsx
@@ -1,6 +1,9 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { ModelCanvas } from './ModelCanvas';
-import { RidgeRuntimePreview } from './RidgeRuntimePreview';
+import {
+  RidgeRuntimePreview,
+  type RidgePreviewInputOwner
+} from './RidgeRuntimePreview';
 import { RidgeViewerHeader } from './RidgeViewerHeader';
 import { useModelViewport } from './hooks/useModelViewport';
 import { useRidgePreviewControls } from './hooks/useRidgePreviewControls';
@@ -22,48 +25,65 @@ export default function RidgeBlockoutViewer() {
   const { activeView, switchView } = useRidgeViewerView();
   const { layers, toggleLayer } = useRidgeViewerLayers();
   const [selection, setSelection] = useState<Selection | null>(null);
+  const [previewInputOwner, setPreviewInputOwner] = useState<RidgePreviewInputOwner>('game');
   const modelViewport = useModelViewport(model.rooms);
   const previewControls = useRidgePreviewControls();
   const selectedDetails = selection ? getSelectionDetails(model, selection) : null;
   const teleportGroups = useMemo(() => getTeleportGroups(model), [model]);
+  const claimPanelInput = useCallback(() => setPreviewInputOwner('panel'), []);
+  const claimGameInput = useCallback(() => setPreviewInputOwner('game'), []);
 
   return (
     <div className="h-[100dvh] max-h-[100dvh] overflow-hidden bg-[#f4f1ea] text-[#1a1a1a]">
       <div className="grid h-full min-h-0 min-w-0 grid-rows-[auto_minmax(0,1fr)] gap-2 p-2 lg:p-3">
-        <RidgeViewerHeader
-          activeView={activeView}
-          model={model}
-          onSwitchView={switchView}
-        />
+        <div onFocusCapture={claimPanelInput} onPointerDownCapture={claimPanelInput}>
+          <RidgeViewerHeader
+            activeView={activeView}
+            model={model}
+            onSwitchView={switchView}
+          />
+        </div>
 
         <main className="grid min-h-0 min-w-0 grid-rows-[minmax(0,1fr)_minmax(220px,35dvh)] gap-2 lg:grid-cols-[minmax(0,1fr)_320px] lg:grid-rows-none">
           {activeView === 'preview' ? (
             <RidgeRuntimePreview
+              inputOwner={previewInputOwner}
+              onClaimGameInput={claimGameInput}
               previewZoom={previewControls.previewZoom}
               ridgeDevControls={previewControls.ridgeDevControls}
             />
           ) : (
-            <ModelCanvas
-              layers={layers}
-              model={model}
-              onFocusRoom={modelViewport.focusRoom}
-              onPointerDown={modelViewport.handlePointerDown}
-              onPointerMove={modelViewport.handlePointerMove}
-              onResetView={modelViewport.resetView}
-              onSelect={setSelection}
-              onStopDragging={modelViewport.stopDragging}
-              onWheel={modelViewport.handleWheel}
-              onZoomIn={() => modelViewport.adjustZoom(0.02)}
-              onZoomOut={() => modelViewport.adjustZoom(-0.02)}
-              playerSnapshot={previewControls.playerSnapshot}
-              svgRef={modelViewport.svgRef}
-              transform={modelViewport.transform}
-              view={modelViewport.view}
-              worldRef={modelViewport.worldRef}
-            />
+            <div
+              className="h-full min-h-0 min-w-0"
+              onFocusCapture={claimPanelInput}
+              onPointerDownCapture={claimPanelInput}
+            >
+              <ModelCanvas
+                layers={layers}
+                model={model}
+                onFocusRoom={modelViewport.focusRoom}
+                onPointerDown={modelViewport.handlePointerDown}
+                onPointerMove={modelViewport.handlePointerMove}
+                onResetView={modelViewport.resetView}
+                onSelect={setSelection}
+                onStopDragging={modelViewport.stopDragging}
+                onWheel={modelViewport.handleWheel}
+                onZoomIn={() => modelViewport.adjustZoom(0.02)}
+                onZoomOut={() => modelViewport.adjustZoom(-0.02)}
+                playerSnapshot={previewControls.playerSnapshot}
+                svgRef={modelViewport.svgRef}
+                transform={modelViewport.transform}
+                view={modelViewport.view}
+                worldRef={modelViewport.worldRef}
+              />
+            </div>
           )}
 
-          <aside className="min-h-0 min-w-0 overflow-y-auto overflow-x-hidden border-4 border-[#1a1a1a] bg-[#fbfbf9] p-4 shadow-[7px_7px_0_rgba(26,26,26,1)]">
+          <aside
+            className="min-h-0 min-w-0 overflow-y-auto overflow-x-hidden border-4 border-[#1a1a1a] bg-[#fbfbf9] p-4 shadow-[7px_7px_0_rgba(26,26,26,1)]"
+            onFocusCapture={claimPanelInput}
+            onPointerDownCapture={claimPanelInput}
+          >
             <SummaryPanel model={model} />
             {activeView === 'preview' ? (
               <PreviewPanel

--- a/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.tsx
+++ b/src/dev/ridgeBlockoutViewer/RidgeBlockoutViewer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ModelCanvas } from './ModelCanvas';
 import {
   RidgeRuntimePreview,
@@ -10,6 +10,7 @@ import { useRidgePreviewControls } from './hooks/useRidgePreviewControls';
 import { useRidgeViewerLayers } from './hooks/useRidgeViewerLayers';
 import { useRidgeViewerView } from './hooks/useRidgeViewerView';
 import { createRidgeBlockoutViewerModel } from './model';
+import { findViewerRoomForPoint } from './modelViewport';
 import { PreviewPanel } from './panels/PreviewPanel';
 import { LayerPanel } from './panels/LayerPanel';
 import { RoomFocusPanel } from './panels/RoomFocusPanel';
@@ -26,12 +27,35 @@ export default function RidgeBlockoutViewer() {
   const { layers, toggleLayer } = useRidgeViewerLayers();
   const [selection, setSelection] = useState<Selection | null>(null);
   const [previewInputOwner, setPreviewInputOwner] = useState<RidgePreviewInputOwner>('game');
+  const [hasPreviewMounted, setHasPreviewMounted] = useState(activeView === 'preview');
+  const pendingModelFocusRoomIdRef = useRef<string | null>(null);
   const modelViewport = useModelViewport(model.rooms);
   const previewControls = useRidgePreviewControls();
   const selectedDetails = selection ? getSelectionDetails(model, selection) : null;
   const teleportGroups = useMemo(() => getTeleportGroups(model), [model]);
   const claimPanelInput = useCallback(() => setPreviewInputOwner('panel'), []);
   const claimGameInput = useCallback(() => setPreviewInputOwner('game'), []);
+  const switchViewerView = useCallback((nextView: 'preview' | 'model') => {
+    if (nextView === 'preview') {
+      setHasPreviewMounted(true);
+    }
+    if (nextView === 'model' && activeView === 'preview' && previewControls.playerSnapshot) {
+      pendingModelFocusRoomIdRef.current =
+        findViewerRoomForPoint(model.rooms, previewControls.playerSnapshot)?.id ?? null;
+    }
+    switchView(nextView);
+  }, [activeView, model.rooms, previewControls.playerSnapshot, switchView]);
+
+  useEffect(() => {
+    if (activeView !== 'model') return;
+    const roomId = pendingModelFocusRoomIdRef.current;
+    if (!roomId) return;
+
+    pendingModelFocusRoomIdRef.current = null;
+    requestAnimationFrame(() => {
+      modelViewport.focusRoom(roomId);
+    });
+  }, [activeView, modelViewport]);
 
   return (
     <div className="h-[100dvh] max-h-[100dvh] overflow-hidden bg-[#f4f1ea] text-[#1a1a1a]">
@@ -40,44 +64,50 @@ export default function RidgeBlockoutViewer() {
           <RidgeViewerHeader
             activeView={activeView}
             model={model}
-            onSwitchView={switchView}
+            onSwitchView={switchViewerView}
           />
         </div>
 
         <main className="grid min-h-0 min-w-0 grid-rows-[minmax(0,1fr)_minmax(220px,35dvh)] gap-2 lg:grid-cols-[minmax(0,1fr)_320px] lg:grid-rows-none">
-          {activeView === 'preview' ? (
-            <RidgeRuntimePreview
-              inputOwner={previewInputOwner}
-              onClaimGameInput={claimGameInput}
-              previewZoom={previewControls.previewZoom}
-              ridgeDevControls={previewControls.ridgeDevControls}
-            />
-          ) : (
-            <div
-              className="h-full min-h-0 min-w-0"
-              onFocusCapture={claimPanelInput}
-              onPointerDownCapture={claimPanelInput}
-            >
-              <ModelCanvas
-                layers={layers}
-                model={model}
-                onFocusRoom={modelViewport.focusRoom}
-                onPointerDown={modelViewport.handlePointerDown}
-                onPointerMove={modelViewport.handlePointerMove}
-                onResetView={modelViewport.resetView}
-                onSelect={setSelection}
-                onStopDragging={modelViewport.stopDragging}
-                onWheel={modelViewport.handleWheel}
-                onZoomIn={() => modelViewport.adjustZoom(0.02)}
-                onZoomOut={() => modelViewport.adjustZoom(-0.02)}
-                playerSnapshot={previewControls.playerSnapshot}
-                svgRef={modelViewport.svgRef}
-                transform={modelViewport.transform}
-                view={modelViewport.view}
-                worldRef={modelViewport.worldRef}
-              />
-            </div>
-          )}
+          <div className="relative h-full min-h-0 min-w-0">
+            {hasPreviewMounted ? (
+              <div className="absolute inset-0">
+                <RidgeRuntimePreview
+                  inputOwner={previewInputOwner}
+                  isActive={activeView === 'preview'}
+                  onClaimGameInput={claimGameInput}
+                  previewZoom={previewControls.previewZoom}
+                  ridgeDevControls={previewControls.ridgeDevControls}
+                />
+              </div>
+            ) : null}
+            {activeView === 'model' ? (
+              <div
+                className="absolute inset-0 h-full min-h-0 min-w-0"
+                onFocusCapture={claimPanelInput}
+                onPointerDownCapture={claimPanelInput}
+              >
+                <ModelCanvas
+                  layers={layers}
+                  model={model}
+                  onFocusRoom={modelViewport.focusRoom}
+                  onPointerDown={modelViewport.handlePointerDown}
+                  onPointerMove={modelViewport.handlePointerMove}
+                  onResetView={modelViewport.resetView}
+                  onSelect={setSelection}
+                  onStopDragging={modelViewport.stopDragging}
+                  onWheel={modelViewport.handleWheel}
+                  onZoomIn={() => modelViewport.adjustZoom(0.02)}
+                  onZoomOut={() => modelViewport.adjustZoom(-0.02)}
+                  playerSnapshot={previewControls.playerSnapshot}
+                  svgRef={modelViewport.svgRef}
+                  transform={modelViewport.transform}
+                  view={modelViewport.view}
+                  worldRef={modelViewport.worldRef}
+                />
+              </div>
+            ) : null}
+          </div>
 
           <aside
             className="min-h-0 min-w-0 overflow-y-auto overflow-x-hidden border-4 border-[#1a1a1a] bg-[#fbfbf9] p-4 shadow-[7px_7px_0_rgba(26,26,26,1)]"

--- a/src/dev/ridgeBlockoutViewer/RidgeRuntimePreview.tsx
+++ b/src/dev/ridgeBlockoutViewer/RidgeRuntimePreview.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import Game from '@/game/shell/Game';
 import { bridgeActions, useBridgeState } from '@/game/bridge/store';
 import { RIDGE_SCENE_ID } from '@/game/scenes/sceneIds';
@@ -6,14 +6,24 @@ import type { RidgeDevControls } from '@/game/scenes/ridge/runtime/ridgeDevContr
 
 function ignorePreviewSceneClose(): void {}
 
+export type RidgePreviewInputOwner = 'game' | 'panel';
+
 export function RidgeRuntimePreview({
+  inputOwner,
+  onClaimGameInput,
   previewZoom,
   ridgeDevControls
 }: {
+  inputOwner: RidgePreviewInputOwner;
+  onClaimGameInput: () => void;
   previewZoom: number;
   ridgeDevControls: RidgeDevControls;
 }) {
   const bridge = useBridgeState();
+  const previewRef = useRef<HTMLElement | null>(null);
+  const isInputPaused = bridge.isPaused || bridge.loadingSceneId !== null || inputOwner === 'panel';
+  const pauseReason = inputOwner === 'panel' ? 'Panel focus' : 'Runtime paused';
+  const showPausedOverlay = isInputPaused && bridge.loadingSceneId === null;
 
   useEffect(function bootRidgePreviewScene() {
     bridgeActions.closeOverlay();
@@ -30,29 +40,80 @@ export function RidgeRuntimePreview({
     };
   }, []);
 
+  function claimGameInput(): void {
+    onClaimGameInput();
+    previewRef.current?.focus({ preventScroll: true });
+  }
+
   return (
     <section
+      aria-label="Ridge runtime preview game input area"
       className="relative min-h-0 min-w-0 overflow-hidden border-4 border-[#1a1a1a] bg-[#fbfbf9] shadow-[7px_7px_0_rgba(26,26,26,1)]"
       data-testid="ridge-runtime-preview"
+      onFocus={(event) => {
+        if (event.target === event.currentTarget) {
+          onClaimGameInput();
+        }
+      }}
+      onPointerDown={(event) => {
+        if ((event.target as HTMLElement).closest('[data-ridge-preview-focus-button]')) return;
+        claimGameInput();
+      }}
+      ref={previewRef}
+      tabIndex={0}
     >
-      <div className="absolute left-3 top-3 z-20 border-2 border-[#1a1a1a] bg-[#fbfbf9]/92 px-3 py-2 shadow-[4px_4px_0_rgba(26,26,26,1)]">
+      <div className="absolute left-2 top-2 z-20 max-w-[min(16rem,calc(100%-1rem))] border-2 border-[#1a1a1a] bg-[#fbfbf9]/88 px-2 py-1.5 shadow-[3px_3px_0_rgba(26,26,26,1)]">
         <p className="font-mono text-[10px] font-black uppercase tracking-widest text-[#5a554f]">
-          Phaser Preview
+          Live Ridge
         </p>
-        <p className="text-xs font-black uppercase tracking-wider text-[#1a1a1a]">
-          Actual Ridge runtime - {Math.round(previewZoom * 100)}%
+        <p className="text-[11px] font-black uppercase tracking-wider text-[#1a1a1a]">
+          Camera zoom {Math.round(previewZoom * 100)}%
         </p>
+        <div className="mt-1.5 flex flex-wrap items-center gap-2">
+          <span
+            className={[
+              'border-2 border-[#1a1a1a] px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest',
+              isInputPaused ? 'bg-[#f3df8b]' : 'bg-[#d7f2d1]'
+            ].join(' ')}
+            data-testid="ridge-preview-input-status"
+          >
+            {isInputPaused ? 'Panel focus' : 'Game input'}
+          </span>
+        </div>
       </div>
       <Game
         activeSceneId={bridge.activeSceneId}
         chrome="bare"
-        isPaused={bridge.isPaused || bridge.loadingSceneId !== null}
+        isPaused={isInputPaused}
         onEnterScene={bridgeActions.enterScene}
         onOpenOverlay={bridgeActions.openOverlay}
         onReturnToOverworld={ignorePreviewSceneClose}
         presentationMode="portrait-cover"
         ridgeDevControls={ridgeDevControls}
       />
+      {showPausedOverlay ? (
+        <div
+          className="absolute inset-0 z-10 flex items-center justify-center bg-[#fbfbf9]/42 backdrop-blur-[2px]"
+          data-testid="ridge-preview-paused-overlay"
+        >
+          <div className="max-w-[min(17rem,calc(100%-2rem))] border-2 border-[#1a1a1a] bg-[#fbfbf9]/95 px-4 py-3 text-center shadow-[5px_5px_0_rgba(26,26,26,1)]">
+            <p className="text-base font-black uppercase tracking-wider text-[#1a1a1a]">
+              Paused
+            </p>
+            <p className="mt-1 font-mono text-[10px] font-black uppercase tracking-widest text-[#5a554f]">
+              {pauseReason}
+            </p>
+            <button
+              className="mt-3 min-h-9 border-2 border-[#1a1a1a] bg-[#fbfbf9] px-3 py-1 text-[10px] font-black uppercase tracking-widest transition-colors hover:bg-[#1a1a1a] hover:text-[#fbfbf9] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1a1a1a]"
+              data-ridge-preview-focus-button=""
+              onClick={claimGameInput}
+              type="button"
+            >
+              Focus game
+            </button>
+          </div>
+        </div>
+      ) : null}
       {bridge.loadingSceneId ? (
         <div className="absolute inset-0 z-30 flex items-center justify-center bg-[#1a1a1a]/35">
           <p className="border-2 border-[#1a1a1a] bg-[#fbfbf9] px-4 py-2 text-xs font-black uppercase tracking-widest shadow-[4px_4px_0_rgba(26,26,26,1)]">

--- a/src/dev/ridgeBlockoutViewer/RidgeRuntimePreview.tsx
+++ b/src/dev/ridgeBlockoutViewer/RidgeRuntimePreview.tsx
@@ -13,26 +13,35 @@ export type RidgePreviewInputOwner = 'game' | 'panel';
 
 export function RidgeRuntimePreview({
   inputOwner,
+  isActive,
   onClaimGameInput,
   previewZoom,
   ridgeDevControls
 }: {
   inputOwner: RidgePreviewInputOwner;
+  isActive: boolean;
   onClaimGameInput: () => void;
   previewZoom: number;
   ridgeDevControls: RidgeDevControls;
 }) {
   const bridge = useBridgeState();
   const previewRef = useRef<HTMLElement | null>(null);
-  const isInputPaused = bridge.isPaused || bridge.loadingSceneId !== null || inputOwner === 'panel';
-  const inputStatusLabel = inputOwner === 'panel'
-    ? 'Panel focus'
-    : bridge.isPaused || bridge.loadingSceneId !== null
-      ? 'Runtime paused'
-      : 'Game input';
-  const pauseReason = inputOwner === 'panel' ? 'Panel focus' : 'Runtime paused';
+  const isInputPaused =
+    !isActive || bridge.isPaused || bridge.loadingSceneId !== null || inputOwner === 'panel';
+  const inputStatusLabel = !isActive
+    ? 'Model view'
+    : inputOwner === 'panel'
+      ? 'Panel focus'
+      : bridge.isPaused || bridge.loadingSceneId !== null
+        ? 'Runtime paused'
+        : 'Game input';
+  const pauseReason = !isActive
+    ? 'Model view'
+    : inputOwner === 'panel'
+      ? 'Panel focus'
+      : 'Runtime paused';
   const showPausedOverlay =
-    isInputPaused && bridge.loadingSceneId === null && bridge.activeOverlayId === null;
+    isActive && isInputPaused && bridge.loadingSceneId === null && bridge.activeOverlayId === null;
   const presentationMode = getPhaserScenePresentationMode(bridge.activeSceneId);
   const isRidgeSceneActive = bridge.activeSceneId === RIDGE_SCENE_ID;
 
@@ -52,6 +61,7 @@ export function RidgeRuntimePreview({
   }, []);
 
   function claimGameInput(): void {
+    if (!isActive) return;
     onClaimGameInput();
     previewRef.current?.focus({ preventScroll: true });
   }
@@ -71,19 +81,24 @@ export function RidgeRuntimePreview({
   return (
     <section
       aria-label="Ridge runtime preview game input area"
-      className="relative min-h-0 min-w-0 overflow-hidden border-4 border-[#1a1a1a] bg-[#fbfbf9] shadow-[7px_7px_0_rgba(26,26,26,1)]"
+      aria-hidden={!isActive}
+      className={[
+        'relative h-full min-h-0 min-w-0 overflow-hidden border-4 border-[#1a1a1a] bg-[#fbfbf9] shadow-[7px_7px_0_rgba(26,26,26,1)]',
+        isActive ? '' : 'invisible pointer-events-none'
+      ].join(' ')}
       data-testid="ridge-runtime-preview"
       onFocus={(event) => {
-        if (event.target === event.currentTarget) {
+        if (isActive && event.target === event.currentTarget) {
           onClaimGameInput();
         }
       }}
       onPointerDown={(event) => {
+        if (!isActive) return;
         if ((event.target as HTMLElement).closest('[data-ridge-preview-focus-button]')) return;
         claimGameInput();
       }}
       ref={previewRef}
-      tabIndex={0}
+      tabIndex={isActive ? 0 : -1}
     >
       <div className="absolute left-2 top-2 z-20 max-w-[min(16rem,calc(100%-1rem))] border-2 border-[#1a1a1a] bg-[#fbfbf9]/88 px-2 py-1.5 shadow-[3px_3px_0_rgba(26,26,26,1)]">
         <p className="font-mono text-[10px] font-black uppercase tracking-widest text-[#5a554f]">

--- a/src/dev/ridgeBlockoutViewer/RidgeRuntimePreview.tsx
+++ b/src/dev/ridgeBlockoutViewer/RidgeRuntimePreview.tsx
@@ -4,6 +4,8 @@ import { bridgeActions, useBridgeState } from '@/game/bridge/store';
 import { RIDGE_SCENE_ID } from '@/game/scenes/sceneIds';
 import type { RidgeDevControls } from '@/game/scenes/ridge/runtime/ridgeDevControls';
 
+function ignorePreviewSceneClose(): void {}
+
 export function RidgeRuntimePreview({
   previewZoom,
   ridgeDevControls
@@ -47,7 +49,7 @@ export function RidgeRuntimePreview({
         isPaused={bridge.isPaused || bridge.loadingSceneId !== null}
         onEnterScene={bridgeActions.enterScene}
         onOpenOverlay={bridgeActions.openOverlay}
-        onReturnToOverworld={bridgeActions.returnToOverworld}
+        onReturnToOverworld={ignorePreviewSceneClose}
         presentationMode="portrait-cover"
         ridgeDevControls={ridgeDevControls}
       />

--- a/src/dev/ridgeBlockoutViewer/RidgeRuntimePreview.tsx
+++ b/src/dev/ridgeBlockoutViewer/RidgeRuntimePreview.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useRef } from 'react';
 import Game from '@/game/shell/Game';
 import { bridgeActions, useBridgeState } from '@/game/bridge/store';
-import { RIDGE_SCENE_ID } from '@/game/scenes/sceneIds';
+import { OverlayHost } from '@/game/overlays/OverlayHost';
+import { SceneUiHost } from '@/game/sceneUi/SceneUiHost';
+import { getPhaserScenePresentationMode } from '@/game/sharedSceneRuntime/phaserScenePresentation';
+import { RIDGE_SCENE_ID, type SceneId } from '@/game/scenes/sceneIds';
 import type { RidgeDevControls } from '@/game/scenes/ridge/runtime/ridgeDevControls';
 
 function ignorePreviewSceneClose(): void {}
@@ -22,8 +25,16 @@ export function RidgeRuntimePreview({
   const bridge = useBridgeState();
   const previewRef = useRef<HTMLElement | null>(null);
   const isInputPaused = bridge.isPaused || bridge.loadingSceneId !== null || inputOwner === 'panel';
+  const inputStatusLabel = inputOwner === 'panel'
+    ? 'Panel focus'
+    : bridge.isPaused || bridge.loadingSceneId !== null
+      ? 'Runtime paused'
+      : 'Game input';
   const pauseReason = inputOwner === 'panel' ? 'Panel focus' : 'Runtime paused';
-  const showPausedOverlay = isInputPaused && bridge.loadingSceneId === null;
+  const showPausedOverlay =
+    isInputPaused && bridge.loadingSceneId === null && bridge.activeOverlayId === null;
+  const presentationMode = getPhaserScenePresentationMode(bridge.activeSceneId);
+  const isRidgeSceneActive = bridge.activeSceneId === RIDGE_SCENE_ID;
 
   useEffect(function bootRidgePreviewScene() {
     bridgeActions.closeOverlay();
@@ -43,6 +54,18 @@ export function RidgeRuntimePreview({
   function claimGameInput(): void {
     onClaimGameInput();
     previewRef.current?.focus({ preventScroll: true });
+  }
+
+  function enterPreviewScene(sceneId: SceneId): void {
+    bridgeActions.enterScene(sceneId);
+    onClaimGameInput();
+    requestAnimationFrame(() => {
+      previewRef.current?.focus({ preventScroll: true });
+    });
+  }
+
+  function returnToRidgePreview(): void {
+    enterPreviewScene(RIDGE_SCENE_ID);
   }
 
   return (
@@ -77,20 +100,43 @@ export function RidgeRuntimePreview({
             ].join(' ')}
             data-testid="ridge-preview-input-status"
           >
-            {isInputPaused ? 'Panel focus' : 'Game input'}
+            {inputStatusLabel}
           </span>
+          {!isRidgeSceneActive ? (
+            <button
+              className="border-2 border-[#1a1a1a] bg-[#fbfbf9] px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest transition-colors hover:bg-[#1a1a1a] hover:text-[#fbfbf9] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1a1a1a]"
+              data-ridge-preview-focus-button=""
+              onClick={returnToRidgePreview}
+              type="button"
+            >
+              Back to Ridge
+            </button>
+          ) : null}
         </div>
       </div>
       <Game
         activeSceneId={bridge.activeSceneId}
         chrome="bare"
         isPaused={isInputPaused}
-        onEnterScene={bridgeActions.enterScene}
+        onEnterScene={enterPreviewScene}
         onOpenOverlay={bridgeActions.openOverlay}
         onReturnToOverworld={ignorePreviewSceneClose}
-        presentationMode="portrait-cover"
+        presentationMode={presentationMode}
         ridgeDevControls={ridgeDevControls}
       />
+      <div className="pointer-events-none absolute inset-0 z-[15]">
+        <div className="pointer-events-auto">
+          <SceneUiHost placement="panel" />
+        </div>
+      </div>
+      {bridge.sceneUi.status ? (
+        <div className="pointer-events-none absolute bottom-2 left-2 right-2 z-20 flex justify-center">
+          <div className="pointer-events-auto w-[min(28rem,100%)]">
+            <SceneUiHost placement="status" />
+          </div>
+        </div>
+      ) : null}
+      <OverlayHost enterScene={enterPreviewScene} />
       {showPausedOverlay ? (
         <div
           className="absolute inset-0 z-10 flex items-center justify-center bg-[#fbfbf9]/42 backdrop-blur-[2px]"

--- a/src/dev/ridgeBlockoutViewer/RidgeViewerHeader.tsx
+++ b/src/dev/ridgeBlockoutViewer/RidgeViewerHeader.tsx
@@ -25,13 +25,23 @@ export function RidgeViewerHeader({
           {model.title}
         </span>
         <span
+          aria-label={
+            model.validationErrors.length === 0
+              ? 'Generated Ridge blockout validation status: map valid'
+              : 'Generated Ridge blockout validation status: map errors'
+          }
           className={[
             'border-2 border-[#1a1a1a] px-2 py-0.5 font-mono text-[10px] font-black uppercase tracking-widest',
             model.validationErrors.length === 0 ? 'bg-[#d7f2d1]' : 'bg-[#ffd6d1]'
           ].join(' ')}
           data-testid="ridge-viewer-header-validation-status"
+          title={
+            model.validationErrors.length === 0
+              ? 'Generated Ridge blockout validation passed'
+              : `${model.validationErrors.length} generated Ridge blockout validation errors`
+          }
         >
-          {model.validationErrors.length === 0 ? 'Clean' : 'Errors'}
+          {model.validationErrors.length === 0 ? 'Map valid' : 'Map errors'}
         </span>
       </div>
       <div className="flex border-2 border-[#1a1a1a] bg-[#e7dfcf] p-1" aria-label="Ridge viewer view">

--- a/src/dev/ridgeBlockoutViewer/hooks/useRidgePreviewControls.ts
+++ b/src/dev/ridgeBlockoutViewer/hooks/useRidgePreviewControls.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   RidgeDevControls,
+  RidgeDevDebugSettings,
   RidgeDevPlayerSnapshot,
+  RidgeDevResetRequest,
   RidgeDevTeleportRequest
 } from '@/game/scenes/ridge/runtime/ridgeDevControls';
 import {
@@ -14,9 +16,19 @@ import { getTeleportAnchorLabel } from '../teleportTargets';
 
 export function useRidgePreviewControls() {
   const [previewZoom, setPreviewZoom] = useState(INITIAL_PREVIEW_ZOOM);
+  const [debugSettings, setDebugSettings] = useState<RidgeDevDebugSettings>({
+    graybox: false,
+    showColliders: false,
+    showPlayerBody: false,
+    showInteractZones: false,
+    showTraversalAssists: false
+  });
   const [lastTeleportLabel, setLastTeleportLabel] = useState<string | null>(null);
   const [playerSnapshot, setPlayerSnapshot] = useState<RidgeDevPlayerSnapshot | null>(null);
   const previewZoomRef = useRef(INITIAL_PREVIEW_ZOOM);
+  const debugSettingsRef = useRef(debugSettings);
+  const resetRequestRef = useRef<RidgeDevResetRequest | null>(null);
+  const resetSequenceRef = useRef(0);
   const teleportRequestRef = useRef<RidgeDevTeleportRequest | null>(null);
   const teleportSequenceRef = useRef(0);
   const lastPlayerSnapshotRenderAtRef = useRef(0);
@@ -25,8 +37,18 @@ export function useRidgePreviewControls() {
     previewZoomRef.current = previewZoom;
   }, [previewZoom]);
 
+  useEffect(function syncDebugSettingsRef() {
+    debugSettingsRef.current = debugSettings;
+  }, [debugSettings]);
+
   const ridgeDevControls = useMemo<RidgeDevControls>(() => ({
     resolveCameraZoom: () => previewZoomRef.current,
+    resolveDebugSettings: () => debugSettingsRef.current,
+    consumeResetRequest: () => {
+      const request = resetRequestRef.current;
+      resetRequestRef.current = null;
+      return request;
+    },
     consumeTeleportRequest: () => {
       const request = teleportRequestRef.current;
       teleportRequestRef.current = null;
@@ -48,6 +70,22 @@ export function useRidgePreviewControls() {
     setPreviewZoom(clampPreviewZoom(zoom));
   }, []);
 
+  const toggleDebugSetting = useCallback((setting: keyof RidgeDevDebugSettings) => {
+    setDebugSettings((current) => ({
+      ...current,
+      [setting]: !current[setting]
+    }));
+  }, []);
+
+  const requestPlayerReset = useCallback(() => {
+    const request = {
+      sequence: ++resetSequenceRef.current,
+      label: 'start'
+    };
+    resetRequestRef.current = request;
+    setLastTeleportLabel(`reset ${request.label}`);
+  }, []);
+
   const requestTeleport = useCallback((anchor: RidgeViewerAnchor) => {
     const request = {
       sequence: ++teleportSequenceRef.current,
@@ -62,11 +100,14 @@ export function useRidgePreviewControls() {
 
   return {
     adjustPreviewZoom,
+    debugSettings,
     lastTeleportLabel,
     playerSnapshot,
     previewZoom,
+    requestPlayerReset,
     requestTeleport,
     ridgeDevControls,
-    setPreviewZoomLevel
+    setPreviewZoomLevel,
+    toggleDebugSetting
   };
 }

--- a/src/dev/ridgeBlockoutViewer/modelViewport.ts
+++ b/src/dev/ridgeBlockoutViewer/modelViewport.ts
@@ -17,6 +17,19 @@ export function getWorldTransform(view: ModelViewport): string {
   return `translate(${view.panX} ${view.panY}) scale(${view.zoom})`;
 }
 
+export function findViewerRoomForPoint(
+  rooms: readonly RidgeViewerRoom[],
+  point: { x: number; y: number }
+): RidgeViewerRoom | undefined {
+  return rooms.find((room) => isPointInsideRoom(room, point)) ??
+    rooms.reduce<{ room: RidgeViewerRoom; distanceSquared: number } | undefined>((best, room) => {
+      const distanceSquared = getDistanceSquaredToRoom(room, point);
+      return !best || distanceSquared < best.distanceSquared
+        ? { room, distanceSquared }
+        : best;
+    }, undefined)?.room;
+}
+
 export function fitRoomToViewport({
   padding = 180,
   room,
@@ -40,4 +53,33 @@ export function fitRoomToViewport({
     panX: roundForTransform(viewportWidth / 2 - (room.x + room.width / 2) * zoom),
     panY: roundForTransform(viewportHeight / 2 - (room.y + room.height / 2) * zoom)
   };
+}
+
+function isPointInsideRoom(
+  room: RidgeViewerRoom,
+  point: { x: number; y: number }
+): boolean {
+  return (
+    point.x >= room.x &&
+    point.x <= room.x + room.width &&
+    point.y >= room.y &&
+    point.y <= room.y + room.height
+  );
+}
+
+function getDistanceSquaredToRoom(
+  room: RidgeViewerRoom,
+  point: { x: number; y: number }
+): number {
+  const dx = point.x < room.x
+    ? room.x - point.x
+    : point.x > room.x + room.width
+      ? point.x - (room.x + room.width)
+      : 0;
+  const dy = point.y < room.y
+    ? room.y - point.y
+    : point.y > room.y + room.height
+      ? point.y - (room.y + room.height)
+      : 0;
+  return dx * dx + dy * dy;
 }

--- a/src/dev/ridgeBlockoutViewer/panels/PreviewPanel.tsx
+++ b/src/dev/ridgeBlockoutViewer/panels/PreviewPanel.tsx
@@ -66,8 +66,7 @@ export function PreviewPanel({
               <Plus className="h-4 w-4" aria-hidden />
             </IconButton>
           </div>
-          <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-xs">
-            <Detail label="Camera" value={`${Math.round(previewZoom * 100)}%`} />
+          <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 text-xs">
             <Detail
               label="Player"
               value={playerSnapshot

--- a/src/dev/ridgeBlockoutViewer/panels/PreviewPanel.tsx
+++ b/src/dev/ridgeBlockoutViewer/panels/PreviewPanel.tsx
@@ -1,5 +1,8 @@
-import { LocateFixed, Minus, Plus } from 'lucide-react';
-import type { RidgeDevPlayerSnapshot } from '@/game/scenes/ridge/runtime/ridgeDevControls';
+import { LocateFixed, Minus, Plus, RotateCcw } from 'lucide-react';
+import type {
+  RidgeDevDebugSettings,
+  RidgeDevPlayerSnapshot
+} from '@/game/scenes/ridge/runtime/ridgeDevControls';
 import { PREVIEW_ZOOM_OPTIONS } from '../constants';
 import type { RidgeViewerAnchor } from '../model';
 import { IconButton } from '../components/IconButton';
@@ -8,19 +11,25 @@ import type { TeleportGroup } from '../teleportTargets';
 import { getTeleportAnchorLabel } from '../teleportTargets';
 
 export function PreviewPanel({
+  debugSettings,
   lastTeleportLabel,
   onPreviewZoomChange,
   onPreviewZoomIn,
   onPreviewZoomOut,
+  onResetPlayer,
+  onToggleDebugSetting,
   onTeleport,
   playerSnapshot,
   previewZoom,
   teleportGroups
 }: {
+  debugSettings: RidgeDevDebugSettings;
   lastTeleportLabel: string | null;
   onPreviewZoomChange: (zoom: number) => void;
   onPreviewZoomIn: () => void;
   onPreviewZoomOut: () => void;
+  onResetPlayer: () => void;
+  onToggleDebugSetting: (setting: keyof RidgeDevDebugSettings) => void;
   onTeleport: (anchor: RidgeViewerAnchor) => void;
   playerSnapshot: RidgeDevPlayerSnapshot | null;
   previewZoom: number;
@@ -66,6 +75,44 @@ export function PreviewPanel({
                 : 'waiting'}
             />
           </dl>
+          <button
+            className="flex min-h-9 items-center justify-center gap-2 border-2 border-[#1a1a1a] bg-[#fbfbf9] px-2 py-1 text-xs font-black uppercase tracking-wider transition-colors hover:bg-[#1a1a1a] hover:text-[#fbfbf9] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1a1a1a]"
+            onClick={onResetPlayer}
+            type="button"
+          >
+            <RotateCcw className="h-4 w-4" aria-hidden />
+            Reset player
+          </button>
+        </div>
+      </section>
+      <section className="border-b-2 border-[#1a1a1a] py-4">
+        <h2 className="text-lg font-black">Debug</h2>
+        <div className="mt-3 grid gap-2">
+          <DebugToggle
+            checked={debugSettings.graybox}
+            label="Graybox geometry"
+            onChange={() => onToggleDebugSetting('graybox')}
+          />
+          <DebugToggle
+            checked={debugSettings.showColliders}
+            label="Colliders"
+            onChange={() => onToggleDebugSetting('showColliders')}
+          />
+          <DebugToggle
+            checked={debugSettings.showPlayerBody}
+            label="Player body"
+            onChange={() => onToggleDebugSetting('showPlayerBody')}
+          />
+          <DebugToggle
+            checked={debugSettings.showInteractZones}
+            label="Interact zones"
+            onChange={() => onToggleDebugSetting('showInteractZones')}
+          />
+          <DebugToggle
+            checked={debugSettings.showTraversalAssists}
+            label="Traversal assists"
+            onChange={() => onToggleDebugSetting('showTraversalAssists')}
+          />
         </div>
       </section>
       <section className="py-4">
@@ -102,5 +149,27 @@ export function PreviewPanel({
         </div>
       </section>
     </>
+  );
+}
+
+function DebugToggle({
+  checked,
+  label,
+  onChange
+}: {
+  checked: boolean;
+  label: string;
+  onChange: () => void;
+}) {
+  return (
+    <label className="flex min-h-9 items-center gap-2 border-2 border-[#1a1a1a] bg-[#fbfbf9] px-2 py-1 text-xs font-black uppercase tracking-wider">
+      <input
+        checked={checked}
+        className="h-4 w-4 accent-[#1a1a1a]"
+        onChange={onChange}
+        type="checkbox"
+      />
+      <span className="min-w-0">{label}</span>
+    </label>
   );
 }

--- a/src/dev/ridgeBlockoutViewer/panels/SummaryPanel.tsx
+++ b/src/dev/ridgeBlockoutViewer/panels/SummaryPanel.tsx
@@ -18,7 +18,7 @@ export function SummaryPanel({ model }: { model: RidgeBlockoutViewerModel }) {
         data-testid="ridge-viewer-validation-status"
       >
         {model.validationErrors.length === 0
-          ? 'Validation clean'
+          ? 'Map valid'
           : `${model.validationErrors.length} validation errors`}
       </p>
     </section>

--- a/src/game/overlays/OverlayHost.test.tsx
+++ b/src/game/overlays/OverlayHost.test.tsx
@@ -17,11 +17,13 @@ vi.mock('./overlayRegistry', async () => {
       component: ({
         params,
         close,
+        enterScene,
         titleId,
         descriptionId
       }: {
         params?: unknown;
         close: () => void;
+        enterScene: (sceneId: string) => void;
         titleId: string;
         descriptionId: string;
       }) => {
@@ -34,7 +36,12 @@ vi.mock('./overlayRegistry', async () => {
             onClose: close,
             titleId,
             descriptionId,
-            children: React.createElement('button', { onClick: close }, 'Child close')
+            children: React.createElement(
+              React.Fragment,
+              null,
+              React.createElement('button', { onClick: close }, 'Child close'),
+              React.createElement('button', { onClick: () => enterScene('ridge') }, 'Child enter')
+            )
           }
         );
       }
@@ -68,6 +75,18 @@ describe('OverlayHost', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /child close/i }));
     await waitFor(() => expect(bridgeStore.getState().activeOverlay).toBeNull());
+  });
+
+  it('passes injected scene entry to active overlays', async () => {
+    const enterScene = vi.fn();
+    bridgeActions.openOverlay('profile');
+
+    render(<OverlayHost enterScene={enterScene} />);
+
+    expect(await screen.findByRole('dialog', { name: /mock profile/i })).toBeDefined();
+    await userEvent.click(screen.getByRole('button', { name: /child enter/i }));
+
+    expect(enterScene).toHaveBeenCalledWith('ridge');
   });
 
   it('closes on Escape by default', async () => {

--- a/src/game/overlays/OverlayHost.tsx
+++ b/src/game/overlays/OverlayHost.tsx
@@ -1,8 +1,15 @@
 import { useBridgeState, bridgeActions } from '@/game/bridge/store';
 import { ModalShell } from '@/shared/ui';
 import { getOverlayDefinition } from './overlayRegistry';
+import type { SceneId } from '@/game/scenes/sceneIds';
 
-export function OverlayHost() {
+interface OverlayHostProps {
+  enterScene?: (sceneId: SceneId) => void;
+}
+
+export function OverlayHost({
+  enterScene = bridgeActions.enterScene
+}: OverlayHostProps = {}) {
   const { activeOverlay } = useBridgeState();
   const ActiveOverlayComponent = activeOverlay ? getOverlayDefinition(activeOverlay.id).component : null;
 
@@ -20,6 +27,7 @@ export function OverlayHost() {
         <ActiveOverlayComponent
           params={activeOverlay.params}
           close={closeOverlay}
+          enterScene={enterScene}
           openOverlay={bridgeActions.openOverlay}
           titleId={titleId}
           descriptionId={descriptionId}

--- a/src/game/overlays/lazyOverlay.test.tsx
+++ b/src/game/overlays/lazyOverlay.test.tsx
@@ -8,6 +8,7 @@ afterEach(cleanup);
 
 const controllerProps: OverlayControllerProps = {
   close: vi.fn(),
+  enterScene: vi.fn(),
   openOverlay: vi.fn(),
   titleId: 'title',
   descriptionId: 'description'

--- a/src/game/overlays/manualPage/ManualPageOverlay.test.tsx
+++ b/src/game/overlays/manualPage/ManualPageOverlay.test.tsx
@@ -21,6 +21,7 @@ describe('ManualPageOverlay', () => {
       <ManualPageOverlay
         params={params}
         close={vi.fn()}
+        enterScene={vi.fn()}
         openOverlay={vi.fn()}
         titleId="manual-title"
         descriptionId="manual-description"
@@ -38,6 +39,7 @@ describe('ManualPageOverlay', () => {
       <ManualPageOverlay
         params={params}
         close={close}
+        enterScene={vi.fn()}
         openOverlay={vi.fn()}
         titleId="manual-title"
         descriptionId="manual-description"

--- a/src/game/overlays/trailCard/TrailCardOverlay.test.tsx
+++ b/src/game/overlays/trailCard/TrailCardOverlay.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TrailCardOverlay from './TrailCardOverlay';
 import type { TrailCardOverlayParams } from './types';
@@ -26,6 +26,7 @@ describe('TrailCardOverlay', () => {
       <TrailCardOverlay
         params={params}
         close={vi.fn()}
+        enterScene={vi.fn()}
         openOverlay={vi.fn()}
         titleId="trail-title"
         descriptionId="trail-description"
@@ -48,10 +49,12 @@ describe('TrailCardOverlay', () => {
       rewardPreview: 'Stamp + glide pip',
       enterSceneId: 'stampedeSketch'
     };
+    const enterScene = vi.fn();
     render(
       <TrailCardOverlay
         params={enabledParams}
         close={vi.fn()}
+        enterScene={enterScene}
         openOverlay={vi.fn()}
         titleId="trail-title"
         descriptionId="trail-description"
@@ -63,9 +66,8 @@ describe('TrailCardOverlay', () => {
 
     await userEvent.click(enter);
 
-    await waitFor(() => {
-      expect(bridgeStore.getState().activeSceneId).toBe('stampedeSketch');
-    });
+    expect(enterScene).toHaveBeenCalledWith('stampedeSketch');
+    expect(bridgeStore.getState().activeSceneId).not.toBe('stampedeSketch');
   });
 
   it('closes through the back action', async () => {
@@ -74,6 +76,7 @@ describe('TrailCardOverlay', () => {
       <TrailCardOverlay
         params={params}
         close={close}
+        enterScene={vi.fn()}
         openOverlay={vi.fn()}
         titleId="trail-title"
         descriptionId="trail-description"

--- a/src/game/overlays/trailCard/TrailCardOverlay.tsx
+++ b/src/game/overlays/trailCard/TrailCardOverlay.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@/shared/ui';
 import { getMessages } from '@/shared/i18n';
-import { bridgeActions } from '@/game/bridge/store';
 import { isSceneId } from '@/game/scenes/sceneIds';
 import { OverlayDialogFrame } from '@/game/overlays/OverlayDialogFrame';
 import type { OverlayControllerProps } from '@/game/overlays/types';
@@ -22,6 +21,7 @@ function isTrailCardOverlayParams(params: unknown): params is TrailCardOverlayPa
 export default function TrailCardOverlay({
   params,
   close,
+  enterScene,
   titleId,
   descriptionId
 }: OverlayControllerProps) {
@@ -39,7 +39,7 @@ export default function TrailCardOverlay({
   const canEnter = !trailCard.unavailableReason && enterSceneId !== undefined;
   const enterTrail = () => {
     if (!canEnter || !enterSceneId) return;
-    bridgeActions.enterScene(enterSceneId);
+    enterScene(enterSceneId);
   };
 
   return (

--- a/src/game/overlays/types.ts
+++ b/src/game/overlays/types.ts
@@ -1,10 +1,12 @@
 import type { ComponentType } from 'react';
 import type { OpenOverlayOptions } from '@/game/bridge/store';
 import type { OverlayId } from './overlayIds';
+import type { SceneId } from '@/game/scenes/sceneIds';
 
 export interface OverlayControllerProps {
   params?: unknown;
   close: () => void;
+  enterScene: (sceneId: SceneId) => void;
   openOverlay: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   titleId: string;
   descriptionId: string;

--- a/src/game/sceneLifecycle/SceneManager.test.ts
+++ b/src/game/sceneLifecycle/SceneManager.test.ts
@@ -89,7 +89,8 @@ describe('SceneManager', () => {
 
   it('starts the target context from a cold boot with scene start data', async () => {
     const adapter = makeFakeAdapter();
-    const manager = new SceneManager(adapter);
+    const onSceneStarted = vi.fn();
+    const manager = new SceneManager(adapter, { onSceneStarted });
     manager.registerContext(context('main'));
 
     await manager.exitTo('main');
@@ -97,6 +98,7 @@ describe('SceneManager', () => {
     expect(adapter.stopScene).not.toHaveBeenCalled();
     expect(adapter.startScene).toHaveBeenCalledWith('main', { id: 'main' });
     expect(adapter.activeScenes()).toEqual(['main']);
+    expect(onSceneStarted).toHaveBeenCalledTimes(1);
   });
 
   it('does not restart a context that is already active', async () => {
@@ -109,6 +111,18 @@ describe('SceneManager', () => {
 
     expect(adapter.stopScene).not.toHaveBeenCalled();
     expect(adapter.startScene).not.toHaveBeenCalled();
+  });
+
+  it('notifies after entering a newly started context', async () => {
+    const adapter = makeFakeAdapter(['main']);
+    const onSceneStarted = vi.fn();
+    const manager = new SceneManager(adapter, { onSceneStarted });
+    manager.registerContext(context('main'));
+    manager.registerContext(context('hobbies'));
+
+    await manager.enter('hobbies');
+
+    expect(onSceneStarted).toHaveBeenCalledTimes(1);
   });
 
   it('loads and registers a lazy context before starting it', async () => {

--- a/src/game/sceneLifecycle/SceneManager.ts
+++ b/src/game/sceneLifecycle/SceneManager.ts
@@ -13,6 +13,7 @@ export interface SceneRuntimeAdapter {
 
 interface SceneManagerOptions {
   onSceneLoadingChange?: (contextId: ContextId | null) => void;
+  onSceneStarted?: () => void;
 }
 
 export interface SceneTransitionGuard {
@@ -55,6 +56,7 @@ export class SceneManager {
 
     this.adapter.startScene(target.sceneKey, target.getStartData());
     target.onEnter?.();
+    this.options.onSceneStarted?.();
   }
 
   async exitTo(contextId: ContextId, guard?: SceneTransitionGuard): Promise<void> {
@@ -82,6 +84,7 @@ export class SceneManager {
     if (!this.adapter.isSceneActive(target.sceneKey)) {
       this.adapter.startScene(target.sceneKey, target.getStartData());
       target.onEnter?.();
+      this.options.onSceneStarted?.();
     }
   }
 

--- a/src/game/scenes/ridge/blockout/geometry.test.ts
+++ b/src/game/scenes/ridge/blockout/geometry.test.ts
@@ -53,9 +53,64 @@ describe('ridge blockout geometry', () => {
       expect(connector.colliders.length).toBeGreaterThan(0);
       expect(connector.colliders.length).toBeLessThanOrEqual(2);
     });
-    expect(geometry.routeConnectors.some((connector) =>
-      connector.movement === 'ramp' && connector.colliders.length > 2
-    )).toBe(false);
+  });
+
+  it('backs ramp traversal connectors with physical bridge strips and one assist zone', () => {
+    const geometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT);
+    const rampConnectors = geometry.routeConnectors.filter(
+      (connector) => connector.movement === 'ramp'
+    );
+
+    expect(rampConnectors.length).toBeGreaterThan(0);
+    rampConnectors.forEach((connector) => {
+      expect(connector.assistZones).toHaveLength(1);
+      expect(connector.assistZones[0]?.kind).toBe('ramp');
+      expect(connector.colliders.length).toBeGreaterThan(0);
+      expect(connector.colliders.every((collider) =>
+        collider.kind === 'route-connector' &&
+        collider.movement === 'ramp' &&
+        collider.routeId === 'first_walk'
+      )).toBe(true);
+    });
+  });
+
+  it('keeps generated ramp bridge strips on the authored ramp line outside solid blockers', () => {
+    const geometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT);
+    const solidBlockers = geometry.gridColliders.filter((collider) => collider.kind === 'solid');
+    const rampConnectors = geometry.routeConnectors.filter(
+      (connector) => connector.movement === 'ramp'
+    );
+
+    rampConnectors.forEach((connector) => {
+      const rampZone = connector.assistZones[0];
+      connector.colliders.forEach((strip) => {
+        const surfaceY = rampZone
+          ? getSegmentYAtX(rampZone.from, rampZone.to, strip.x)
+          : undefined;
+        expect(surfaceY).toBeDefined();
+        expect(getColliderTop(strip)).toBeGreaterThanOrEqual(surfaceY ?? 0);
+        expect(getColliderTop(strip) - (surfaceY ?? 0)).toBeLessThanOrEqual(1);
+        expect(solidBlockers.some((solid) => collidersOverlap(strip, solid))).toBe(false);
+      });
+    });
+  });
+
+  it('gives the Outskirts to Cicka Home ramp a collider-backed handoff', () => {
+    const geometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT);
+    const connector = geometry.routeConnectors.find(
+      (candidate) => candidate.id === 'route:first_walk:outskirts:cicka_home'
+    );
+    const solidBlockers = geometry.gridColliders.filter((collider) => collider.kind === 'solid');
+
+    expect(connector?.movement).toBe('ramp');
+    expect(connector?.colliders.length).toBeGreaterThan(3);
+    connector?.colliders.forEach((strip) => {
+      expect(solidBlockers.some((solid) => collidersOverlap(strip, solid))).toBe(false);
+    });
+    const cickaHomeLeftEdgeX = 36 * RIDGE_BLOCKOUT.cell;
+    expect(
+      Math.max(...(connector?.colliders.map((collider) => collider.x + collider.width / 2) ?? []))
+    ).toBeGreaterThanOrEqual(cickaHomeLeftEdgeX - 1);
   });
 
   it('does not generate collider platforms for future routes', () => {
@@ -185,3 +240,30 @@ describe('ridge blockout geometry', () => {
     expect(cickaToWork?.colliders).toEqual([]);
   });
 });
+
+function getColliderTop(collider: { y: number; height: number }): number {
+  return collider.y - collider.height / 2;
+}
+
+function getSegmentYAtX(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  x: number
+): number | undefined {
+  const minX = Math.min(from.x, to.x);
+  const maxX = Math.max(from.x, to.x);
+  if (x < minX || x > maxX) return undefined;
+  const dx = to.x - from.x;
+  if (Math.abs(dx) < 0.001) return Math.min(from.y, to.y);
+  return from.y + (to.y - from.y) * ((x - from.x) / dx);
+}
+
+function collidersOverlap(
+  left: { x: number; y: number; width: number; height: number },
+  right: { x: number; y: number; width: number; height: number }
+): boolean {
+  return (
+    Math.abs(left.x - right.x) * 2 < left.width + right.width &&
+    Math.abs(left.y - right.y) * 2 < left.height + right.height
+  );
+}

--- a/src/game/scenes/ridge/blockout/geometry.ts
+++ b/src/game/scenes/ridge/blockout/geometry.ts
@@ -136,9 +136,10 @@ export function deriveRidgeBlockoutGeometry(
   options: RidgeBlockoutGeometryOptions = {}
 ): RidgeBlockoutGeometry {
   const gridColliders = deriveGridColliders(map);
-  const routeConnectors = deriveFirstWalkRouteConnectors(map);
+  const solidBlockers = gridColliders.filter((collider) => collider.kind === 'solid');
+  const routeConnectors = deriveFirstWalkRouteConnectors(map, solidBlockers);
   const routeColliders = routeConnectors.flatMap((connection) => connection.colliders);
-  const shortcutConnections = deriveShortcutConnections(map, options);
+  const shortcutConnections = deriveShortcutConnections(map, options, solidBlockers);
   const shortcutColliders = shortcutConnections.flatMap((connection) => connection.colliders);
   const assistZones = [
     ...routeConnectors.flatMap((connection) => connection.assistZones),
@@ -288,7 +289,8 @@ function deriveGridColliders(map: RidgeBlockoutMap): readonly RidgeBlockoutColli
 }
 
 function deriveFirstWalkRouteConnectors(
-  map: RidgeBlockoutMap
+  map: RidgeBlockoutMap,
+  solidBlockers: readonly RidgeBlockoutCollider[]
 ): readonly RidgeBlockoutTraversalConnector[] {
   const firstWalk = map.routes.find((route) => route.id === 'first_walk');
   if (!firstWalk) return [];
@@ -318,6 +320,7 @@ function deriveFirstWalkRouteConnectors(
       start: from.point,
       end: to.point,
       movement,
+      solidBlockers,
       assistStart: ladderSegment?.start,
       assistEnd: ladderSegment?.end
     })];
@@ -326,7 +329,8 @@ function deriveFirstWalkRouteConnectors(
 
 function deriveShortcutConnections(
   map: RidgeBlockoutMap,
-  options: RidgeBlockoutGeometryOptions
+  options: RidgeBlockoutGeometryOptions,
+  solidBlockers: readonly RidgeBlockoutCollider[]
 ): readonly RidgeBlockoutShortcutConnection[] {
   return map.shortcuts.flatMap((shortcut) => {
     const sourceRoom = findRidgeBlockoutRoom(map, shortcut.fromRoomId);
@@ -354,7 +358,8 @@ function deriveShortcutConnections(
         shortcutId: shortcut.id,
         start: from,
         end: target,
-        movement
+        movement,
+        solidBlockers
       })
       : createEmptyTraversalConnector({
         idPrefix: `shortcut:${shortcut.id}`,
@@ -434,6 +439,7 @@ function createTraversalConnector({
   start,
   end,
   movement,
+  solidBlockers,
   assistStart,
   assistEnd
 }: {
@@ -445,6 +451,7 @@ function createTraversalConnector({
   start: { x: number; y: number };
   end: { x: number; y: number };
   movement: RidgeTraversalMovement;
+  solidBlockers?: readonly RidgeBlockoutCollider[];
   assistStart?: { x: number; y: number };
   assistEnd?: { x: number; y: number };
 }): RidgeBlockoutTraversalConnector {
@@ -469,6 +476,8 @@ function createTraversalConnector({
     };
   }
 
+  const surfaceStart = assistStart ?? toSurfacePoint(start, cell, movement);
+  const surfaceEnd = assistEnd ?? toSurfacePoint(end, cell, movement);
   const zoneKind = movement === 'ramp'
     ? 'ramp'
     : movement === 'climb'
@@ -481,7 +490,18 @@ function createTraversalConnector({
     shortcutId,
     from: start as RidgeBlockoutAnchorPoint,
     to: end,
-    colliders: [],
+    colliders: movement === 'ramp'
+      ? createRampBridgePlatforms({
+        cell,
+        idPrefix,
+        kind: colliderKind,
+        routeId,
+        shortcutId,
+        start: surfaceStart,
+        end: surfaceEnd,
+        solidBlockers: solidBlockers ?? []
+      })
+      : [],
     assistZones: [createAssistZone({
       cell,
       id: idPrefix,
@@ -489,8 +509,8 @@ function createTraversalConnector({
       movement,
       routeId,
       shortcutId,
-      start: assistStart ?? toSurfacePoint(start, cell, movement),
-      end: assistEnd ?? toSurfacePoint(end, cell, movement)
+      start: surfaceStart,
+      end: surfaceEnd
     })]
   };
 }
@@ -603,6 +623,65 @@ function createJumpPlatforms({
   });
 }
 
+function createRampBridgePlatforms({
+  cell,
+  idPrefix,
+  kind,
+  routeId,
+  shortcutId,
+  start,
+  end,
+  solidBlockers
+}: {
+  cell: number;
+  idPrefix: string;
+  kind: Extract<RidgeBlockoutColliderKind, 'route-connector' | 'shortcut-connector'>;
+  routeId?: string;
+  shortcutId?: string;
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+  solidBlockers: readonly RidgeBlockoutCollider[];
+}): readonly RidgeBlockoutCollider[] {
+  const distanceX = Math.abs(end.x - start.x);
+  const distanceY = Math.abs(end.y - start.y);
+  if (distanceX < 0.001 && distanceY < 0.001) return [];
+
+  const stripCount = Math.max(
+    2,
+    Math.ceil(Math.max(distanceX / (cell * 0.9), distanceY / (cell * 0.3)))
+  );
+  const width = Math.max(
+    Math.round(cell * 1.2),
+    Math.round(distanceX / stripCount + cell * 0.72)
+  );
+  const height = Math.max(12, Math.round(cell * 0.24));
+  const catchOffsetY = 0;
+
+  return Array.from({ length: stripCount }, (_, index) => {
+    const t = (index + 0.5) / stripCount;
+    const surfaceY = lerp(start.y, end.y, t);
+    return {
+      id: `${idPrefix}:ramp:${index + 1}`,
+      kind,
+      movement: 'ramp' as const,
+      routeId,
+      shortcutId,
+      x: lerp(start.x, end.x, t),
+      y: surfaceY + catchOffsetY + height / 2,
+      width,
+      height
+    };
+  })
+    .map((collider) => trimColliderAgainstSolidBlockers(collider, solidBlockers, cell))
+    .map((collider) => collider
+      ? {
+        ...collider,
+        y: getSegmentYAtX(start, end, collider.x) + catchOffsetY + height / 2
+      }
+      : undefined)
+    .filter((collider): collider is RidgeBlockoutCollider => collider !== undefined);
+}
+
 function createAssistZone({
   cell,
   id,
@@ -680,4 +759,53 @@ function toSurfacePoint(
 
 function lerp(start: number, end: number, t: number): number {
   return start + (end - start) * t;
+}
+
+function getSegmentYAtX(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  x: number
+): number {
+  const dx = to.x - from.x;
+  if (Math.abs(dx) < 0.001) return Math.min(from.y, to.y);
+  return lerp(from.y, to.y, (x - from.x) / dx);
+}
+
+function trimColliderAgainstSolidBlockers(
+  collider: RidgeBlockoutCollider,
+  solidBlockers: readonly RidgeBlockoutCollider[],
+  cell: number
+): RidgeBlockoutCollider | undefined {
+  const clearance = 0.5;
+  let left = collider.x - collider.width / 2;
+  let right = collider.x + collider.width / 2;
+  const top = collider.y - collider.height / 2;
+  const bottom = collider.y + collider.height / 2;
+
+  solidBlockers.forEach((solid) => {
+    const solidLeft = solid.x - solid.width / 2;
+    const solidRight = solid.x + solid.width / 2;
+    const solidTop = solid.y - solid.height / 2;
+    const solidBottom = solid.y + solid.height / 2;
+    const overlapsVertically = top < solidBottom && bottom > solidTop;
+    const overlapsHorizontally = left < solidRight && right > solidLeft;
+    if (!overlapsVertically || !overlapsHorizontally) return;
+
+    if (collider.x < solid.x) {
+      right = Math.min(right, solidLeft - clearance);
+    } else if (collider.x > solid.x) {
+      left = Math.max(left, solidRight + clearance);
+    } else {
+      left = right;
+    }
+  });
+
+  const width = right - left;
+  if (width < cell * 0.45) return undefined;
+
+  return {
+    ...collider,
+    x: (left + right) / 2,
+    width
+  };
 }

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -34,8 +34,7 @@ import {
 } from '../blockout';
 import { getRidgeWorldMemories } from '../worldMemory';
 import {
-  shouldShowCickaInteractionPrompt,
-  type CickaInteractionCopy
+  shouldShowCickaInteractionPrompt
 } from '../cicka/interaction';
 import {
   createCickaAnimations,
@@ -51,14 +50,20 @@ import {
   applyRidgeDevTeleportToPlayer,
   RIDGE_DEFAULT_CAMERA_ZOOM,
   RIDGE_PLAYER_SPAWN_OFFSET_Y,
+  resolveRidgeDevDebugSettings,
   resolveRidgeDevCameraZoom,
   type RidgeDevControls
 } from './ridgeDevControls';
 import { createRidgeBlockoutPresentation } from './ridgeBlockoutPresentation';
 import { createRidgeLandmarkPresentation } from './ridgeLandmarkPresentation';
 import {
+  createRidgeDebugOverlay,
+  type RidgeDebugOverlay
+} from './ridgeDebugOverlay';
+import {
   createRidgeInteractionTargets,
   type RidgeInteractionEffect,
+  type RidgeInteractionTarget,
   type RidgeInteractionTargetId
 } from './ridgeInteractionTargets';
 
@@ -88,6 +93,9 @@ export class RidgeScene extends Phaser.Scene {
   private resumePosition?: { x: number; y: number };
   private ridgeDevControls?: RidgeDevControls;
   private currentGeometry?: RidgeBlockoutGeometry;
+  private ridgeInteractionTargets: RidgeInteractionTarget[] = [];
+  private ridgeDebugOverlay?: RidgeDebugOverlay;
+  private ridgeSpawnPosition?: { x: number; y: number };
   private lastCameraZoom = RIDGE_DEFAULT_CAMERA_ZOOM;
 
   constructor() {
@@ -131,6 +139,9 @@ export class RidgeScene extends Phaser.Scene {
       stampIds: ridgeProgress.stampIds
     });
     this.currentGeometry = geometry;
+    this.ridgeInteractionTargets = [];
+    this.ridgeDebugOverlay?.destroy();
+    this.ridgeDebugOverlay = undefined;
     const facts = compileRidgeBlockoutFacts(blockout, {
       geometry
     });
@@ -167,13 +178,16 @@ export class RidgeScene extends Phaser.Scene {
     });
     this.cickaPerch = landmarkPresentation.cickaPerch;
     this.createPlayer(blockoutPresentation.platforms, facts, geometry);
-    this.createRidgeInteractions(
-      messages.navigation.interact,
-      messages.scenes.ridge.cicka.interaction,
-      facts
-    );
+    this.ridgeInteractionTargets = createRidgeInteractionTargets({
+      facts,
+      cickaPerch: this.cickaPerch,
+      cickaInteractionCopy: messages.scenes.ridge.cicka.interaction,
+      getWorldMemories: () => getRidgeWorldMemories(bridgeStore.getState().progress.ridge)
+    });
+    this.createRidgeInteractions(messages.navigation.interact, this.ridgeInteractionTargets);
     this.setPaused(this.isPaused);
     this.playerRuntime?.syncAppearance();
+    this.syncDevRuntimeState();
   }
 
   update(_time: number, delta: number): void {
@@ -184,12 +198,12 @@ export class RidgeScene extends Phaser.Scene {
     }
     const playerUpdate = this.playerRuntime?.update();
     if (!playerUpdate || playerUpdate.paused) {
-      this.publishDevPlayerSnapshot();
+      this.syncDevRuntimeState();
       return;
     }
 
     if (playerUpdate.commands.exitContext) {
-      this.publishDevPlayerSnapshot();
+      this.syncDevRuntimeState();
       this.onClose();
       return;
     }
@@ -217,7 +231,7 @@ export class RidgeScene extends Phaser.Scene {
 
     if (!interaction) {
       this.interactPrompt?.setVisible(false);
-      this.publishDevPlayerSnapshot();
+      this.syncDevRuntimeState();
       return;
     }
 
@@ -238,12 +252,12 @@ export class RidgeScene extends Phaser.Scene {
       })
     ) {
       this.interactPrompt?.setVisible(false);
-      this.publishDevPlayerSnapshot();
+      this.syncDevRuntimeState();
       return;
     }
 
     this.interactPrompt?.setPosition(interaction.prompt.x, interaction.prompt.y).setVisible(true);
-    this.publishDevPlayerSnapshot();
+    this.syncDevRuntimeState();
   }
 
   private createPlayer(
@@ -252,12 +266,13 @@ export class RidgeScene extends Phaser.Scene {
     geometry: RidgeBlockoutGeometry
   ): void {
     const spawn = facts.spawn;
+    this.ridgeSpawnPosition = {
+      x: spawn.x,
+      y: spawn.y + RIDGE_PLAYER_SPAWN_OFFSET_Y
+    };
     const playerRuntime = createSideViewPlayerRuntime({
       scene: this,
-      start: {
-        x: spawn.x,
-        y: spawn.y + RIDGE_PLAYER_SPAWN_OFFSET_Y
-      },
+      start: this.ridgeSpawnPosition,
       resumePosition: this.resumePosition,
       resumeClamp: {
         minX: geometry.bounds.x + RIDGE_PLAYER_EDGE_PADDING,
@@ -312,8 +327,7 @@ export class RidgeScene extends Phaser.Scene {
 
   private createRidgeInteractions(
     promptText: string,
-    cickaInteractionCopy: CickaInteractionCopy,
-    facts: RidgeBlockoutFacts
+    targets: RidgeInteractionTarget[]
   ): void {
     this.interactPrompt?.destroy();
 
@@ -330,12 +344,7 @@ export class RidgeScene extends Phaser.Scene {
     >({
       interactRadius: 72,
       exitEffect: { kind: 'close' },
-      targets: createRidgeInteractionTargets({
-        facts,
-        cickaPerch: this.cickaPerch,
-        cickaInteractionCopy,
-        getWorldMemories: () => getRidgeWorldMemories(bridgeStore.getState().progress.ridge)
-      })
+      targets
     });
   }
 
@@ -352,10 +361,36 @@ export class RidgeScene extends Phaser.Scene {
       this.playerRuntime?.cameraRuntime?.refresh();
     }
 
+    const resetRequest = this.ridgeDevControls.consumeResetRequest?.();
+    if (!this.player) return;
+
+    if (resetRequest && this.ridgeSpawnPosition) {
+      this.movePlayerForDev({
+        x: this.ridgeSpawnPosition.x,
+        y: this.ridgeSpawnPosition.y
+      });
+      return;
+    }
+
     const request = this.ridgeDevControls.consumeTeleportRequest?.();
-    if (!request || !this.player) return;
+    if (!request) return;
 
     const position = applyRidgeDevTeleportToPlayer(this.player, request);
+    this.refreshTraversalRuntimeSafePosition(position);
+    this.playerRuntime?.cameraRuntime?.refresh();
+  }
+
+  private movePlayerForDev(position: { x: number; y: number }): void {
+    if (!this.player) return;
+    this.player.setPosition(position.x, position.y);
+    this.player.setVelocityX(0);
+    this.player.setVelocityY(0);
+    this.player.body.setAllowGravity(true);
+    this.refreshTraversalRuntimeSafePosition(position);
+    this.playerRuntime?.cameraRuntime?.refresh();
+  }
+
+  private refreshTraversalRuntimeSafePosition(position: { x: number; y: number }): void {
     if (this.currentGeometry) {
       this.traversalRuntime = createRidgeTraversalRuntime({
         geometry: this.currentGeometry,
@@ -364,11 +399,28 @@ export class RidgeScene extends Phaser.Scene {
     }
   }
 
-  private publishDevPlayerSnapshot(): void {
-    if (!import.meta.env.DEV || !this.ridgeDevControls || !this.player) return;
-    this.ridgeDevControls.publishPlayerSnapshot?.({
-      x: this.player.x,
-      y: this.player.y
+  private syncDevRuntimeState(): void {
+    if (!import.meta.env.DEV || !this.ridgeDevControls) return;
+    if (this.player) {
+      this.ridgeDevControls.publishPlayerSnapshot?.({
+        x: this.player.x,
+        y: this.player.y
+      });
+    }
+    this.renderDevDebugOverlay();
+  }
+
+  private renderDevDebugOverlay(): void {
+    if (!import.meta.env.DEV || !this.ridgeDevControls || !this.currentGeometry) return;
+    this.ridgeDebugOverlay ??= createRidgeDebugOverlay(this);
+    this.ridgeDebugOverlay.render({
+      geometry: this.currentGeometry,
+      interactionTargets: this.ridgeInteractionTargets,
+      player: this.player,
+      settings: resolveRidgeDevDebugSettings(
+        this.ridgeDevControls.resolveDebugSettings?.()
+      ),
+      traversalState: this.traversalRuntime?.getState()
     });
   }
 }

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -361,9 +361,9 @@ export class RidgeScene extends Phaser.Scene {
       this.playerRuntime?.cameraRuntime?.refresh();
     }
 
-    const resetRequest = this.ridgeDevControls.consumeResetRequest?.();
     if (!this.player) return;
 
+    const resetRequest = this.ridgeDevControls.consumeResetRequest?.();
     if (resetRequest && this.ridgeSpawnPosition) {
       this.movePlayerForDev({
         x: this.ridgeSpawnPosition.x,

--- a/src/game/scenes/ridge/runtime/ridgeBlockoutPresentation.ts
+++ b/src/game/scenes/ridge/runtime/ridgeBlockoutPresentation.ts
@@ -209,8 +209,23 @@ function addBlockoutColliders(
     addColliderVisual(scene, collider);
     const zone = scene.add.zone(collider.x, collider.y, collider.width, collider.height);
     scene.physics.add.existing(zone, true);
+    configureColliderBody(zone, collider);
     return zone;
   });
+}
+
+function configureColliderBody(
+  zone: Phaser.GameObjects.Zone,
+  collider: RidgeBlockoutCollider
+): void {
+  if (collider.kind !== 'route-connector' || collider.movement !== 'ramp') return;
+  const body = zone.body as Phaser.Physics.Arcade.StaticBody | undefined;
+  if (!body) return;
+
+  body.checkCollision.left = false;
+  body.checkCollision.right = false;
+  body.checkCollision.down = false;
+  body.checkCollision.up = true;
 }
 
 function addColliderVisual(scene: Phaser.Scene, collider: RidgeBlockoutCollider): void {

--- a/src/game/scenes/ridge/runtime/ridgeBlockoutPresentation.ts
+++ b/src/game/scenes/ridge/runtime/ridgeBlockoutPresentation.ts
@@ -218,7 +218,7 @@ function configureColliderBody(
   zone: Phaser.GameObjects.Zone,
   collider: RidgeBlockoutCollider
 ): void {
-  if (collider.kind !== 'route-connector' || collider.movement !== 'ramp') return;
+  if (collider.movement !== 'ramp') return;
   const body = zone.body as Phaser.Physics.Arcade.StaticBody | undefined;
   if (!body) return;
 

--- a/src/game/scenes/ridge/runtime/ridgeDebugOverlay.test.ts
+++ b/src/game/scenes/ridge/runtime/ridgeDebugOverlay.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RIDGE_BLOCKOUT,
+  compileRidgeBlockoutFacts,
+  deriveRidgeBlockoutGeometry
+} from '../blockout';
+import type { CickaInteractionCopy } from '../cicka/interaction';
+import { createRidgeInteractionTargets } from './ridgeInteractionTargets';
+import { createRidgeDebugDrawCommands } from './ridgeDebugOverlay';
+
+const cickaCopy: CickaInteractionCopy = {
+  fresh: 'fresh',
+  stampedeMemory: 'memory'
+};
+
+const debugOff = {
+  graybox: false,
+  showColliders: false,
+  showPlayerBody: false,
+  showInteractZones: false,
+  showTraversalAssists: false
+};
+
+describe('ridge debug overlay draw commands', () => {
+  it('returns no commands when all debug settings are disabled', () => {
+    const geometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT);
+
+    expect(createRidgeDebugDrawCommands({
+      geometry,
+      interactionTargets: [],
+      settings: debugOff
+    })).toEqual([]);
+  });
+
+  it('creates source-backed collider, player, interaction, and traversal commands', () => {
+    const geometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT);
+    const facts = compileRidgeBlockoutFacts(RIDGE_BLOCKOUT, { geometry });
+    const interactionTargets = createRidgeInteractionTargets({
+      facts,
+      cickaInteractionCopy: cickaCopy,
+      getWorldMemories: () => []
+    });
+
+    const commands = createRidgeDebugDrawCommands({
+      geometry,
+      interactionTargets,
+      player: {
+        x: 300,
+        y: 400,
+        body: {
+          x: 280,
+          y: 350,
+          width: 40,
+          height: 90
+        }
+      },
+      settings: {
+        graybox: false,
+        showColliders: true,
+        showPlayerBody: true,
+        showInteractZones: true,
+        showTraversalAssists: true
+      }
+    });
+
+    expect(commands.some((command) => command.id.startsWith('collider:'))).toBe(true);
+    expect(commands.some((command) => command.id === 'player-body')).toBe(true);
+    expect(commands.some((command) => command.id.startsWith('interact:'))).toBe(true);
+    expect(commands.some((command) => command.id.startsWith('assist-line:'))).toBe(true);
+  });
+
+  it('treats graybox mode as a composite geometry overlay', () => {
+    const geometry = deriveRidgeBlockoutGeometry(RIDGE_BLOCKOUT);
+
+    const commands = createRidgeDebugDrawCommands({
+      geometry,
+      interactionTargets: [],
+      player: {
+        x: 300,
+        y: 400,
+        body: {
+          x: 280,
+          y: 350,
+          width: 40,
+          height: 90
+        }
+      },
+      settings: {
+        ...debugOff,
+        graybox: true
+      }
+    });
+
+    expect(commands.some((command) => command.id === 'graybox-wash')).toBe(true);
+    expect(commands.some((command) => command.id.startsWith('room:'))).toBe(true);
+    expect(commands.some((command) => command.id.startsWith('anchor:'))).toBe(true);
+    expect(commands.some((command) => command.id.startsWith('collider:'))).toBe(true);
+    expect(commands.some((command) => command.id === 'player-body')).toBe(true);
+  });
+});

--- a/src/game/scenes/ridge/runtime/ridgeDebugOverlay.ts
+++ b/src/game/scenes/ridge/runtime/ridgeDebugOverlay.ts
@@ -1,0 +1,384 @@
+import type * as Phaser from 'phaser';
+import type {
+  RidgeBlockoutGeometry,
+  RidgeBlockoutAssistZone,
+  RidgeBlockoutCollider
+} from '../blockout';
+import type { RidgeDevDebugSettings } from './ridgeDevControls';
+import type { RidgeInteractionTarget } from './ridgeInteractionTargets';
+import type { RidgeTraversalRuntimeState } from './ridgeTraversalRuntime';
+
+export interface RidgeDebugOverlayPlayer {
+  x: number;
+  y: number;
+  body?: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+}
+
+export type RidgeDebugDrawCommand =
+  | {
+    kind: 'rect';
+    id: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    fillColor: number;
+    fillAlpha: number;
+    strokeColor: number;
+    strokeAlpha: number;
+    lineWidth: number;
+  }
+  | {
+    kind: 'circle';
+    id: string;
+    x: number;
+    y: number;
+    radius: number;
+    fillColor: number;
+    fillAlpha: number;
+    strokeColor: number;
+    strokeAlpha: number;
+    lineWidth: number;
+  }
+  | {
+    kind: 'line';
+    id: string;
+    from: { x: number; y: number };
+    to: { x: number; y: number };
+    strokeColor: number;
+    strokeAlpha: number;
+    lineWidth: number;
+  };
+
+export interface RidgeDebugDrawCommandOptions {
+  geometry: RidgeBlockoutGeometry;
+  interactionTargets: readonly RidgeInteractionTarget[];
+  player?: RidgeDebugOverlayPlayer;
+  settings: RidgeDevDebugSettings;
+  traversalState?: RidgeTraversalRuntimeState;
+  defaultInteractRadius?: number;
+}
+
+export type RidgeDebugOverlayFrame = RidgeDebugDrawCommandOptions;
+
+export interface RidgeDebugOverlay {
+  render(frame: RidgeDebugOverlayFrame): void;
+  destroy(): void;
+}
+
+const RIDGE_DEBUG_OVERLAY_DEPTH = 500;
+const DEFAULT_INTERACT_RADIUS = 72;
+
+export function createRidgeDebugDrawCommands(
+  options: RidgeDebugDrawCommandOptions
+): RidgeDebugDrawCommand[] {
+  const commands: RidgeDebugDrawCommand[] = [];
+  const enabled = getEffectiveDebugSettings(options.settings);
+  if (!isAnyDebugSettingEnabled(enabled)) return commands;
+
+  if (options.settings.graybox) {
+    commands.push(createGrayboxWash(options.geometry));
+    options.geometry.roomBounds.forEach((room) => {
+      commands.push({
+        kind: 'rect',
+        id: `room:${room.roomId}`,
+        x: room.x + room.width / 2,
+        y: room.y + room.height / 2,
+        width: room.width,
+        height: room.height,
+        fillColor: 0xfbfbf9,
+        fillAlpha: 0.04,
+        strokeColor: 0x1a1a1a,
+        strokeAlpha: 0.24,
+        lineWidth: 3
+      });
+    });
+    options.geometry.anchorPoints.forEach((anchor) => {
+      commands.push({
+        kind: 'circle',
+        id: `anchor:${anchor.roomId}:${anchor.symbol}:${anchor.attrs.id ?? anchor.kind}`,
+        x: anchor.x,
+        y: anchor.y,
+        radius: 11,
+        fillColor: 0xfbfbf9,
+        fillAlpha: 0.45,
+        strokeColor: 0x1a1a1a,
+        strokeAlpha: 0.62,
+        lineWidth: 2
+      });
+    });
+  }
+
+  if (enabled.showColliders) {
+    options.geometry.colliders.forEach((collider) => {
+      commands.push(createColliderCommand(collider));
+    });
+  }
+
+  if (enabled.showTraversalAssists) {
+    options.geometry.assistZones.forEach((zone) => {
+      commands.push(createAssistZoneLineCommand(zone, options.traversalState));
+      commands.push(createAssistZoneBoundsCommand(zone, options.traversalState));
+    });
+  }
+
+  if (enabled.showInteractZones) {
+    const defaultRadius = options.defaultInteractRadius ?? DEFAULT_INTERACT_RADIUS;
+    options.interactionTargets.forEach((target) => {
+      const radius = target.interactRadius ?? defaultRadius;
+      commands.push({
+        kind: 'circle',
+        id: `interact:${target.id}`,
+        x: target.x,
+        y: target.distanceAnchorY,
+        radius,
+        fillColor: 0xf0d35f,
+        fillAlpha: 0.08,
+        strokeColor: 0xb85f5a,
+        strokeAlpha: 0.72,
+        lineWidth: 3
+      });
+      commands.push({
+        kind: 'rect',
+        id: `interact-prompt:${target.id}`,
+        x: target.prompt.x,
+        y: target.prompt.y,
+        width: 18,
+        height: 18,
+        fillColor: 0xb85f5a,
+        fillAlpha: 0.24,
+        strokeColor: 0x1a1a1a,
+        strokeAlpha: 0.55,
+        lineWidth: 2
+      });
+    });
+  }
+
+  if (enabled.showPlayerBody && options.player?.body) {
+    const body = options.player.body;
+    commands.push({
+      kind: 'rect',
+      id: 'player-body',
+      x: body.x + body.width / 2,
+      y: body.y + body.height / 2,
+      width: body.width,
+      height: body.height,
+      fillColor: 0x596f8f,
+      fillAlpha: 0.12,
+      strokeColor: 0x596f8f,
+      strokeAlpha: 0.92,
+      lineWidth: 3
+    });
+    commands.push({
+      kind: 'circle',
+      id: 'player-origin',
+      x: options.player.x,
+      y: options.player.y,
+      radius: 6,
+      fillColor: 0x596f8f,
+      fillAlpha: 0.65,
+      strokeColor: 0x1a1a1a,
+      strokeAlpha: 0.6,
+      lineWidth: 2
+    });
+  }
+
+  return commands;
+}
+
+export function createRidgeDebugOverlay(scene: Phaser.Scene): RidgeDebugOverlay {
+  const graphics = scene.add.graphics().setDepth(RIDGE_DEBUG_OVERLAY_DEPTH);
+
+  return {
+    render(frame) {
+      graphics.clear();
+      const commands = createRidgeDebugDrawCommands(frame);
+      graphics.setVisible(commands.length > 0);
+      commands.forEach((command) => drawCommand(graphics, command));
+    },
+    destroy() {
+      graphics.destroy();
+    }
+  };
+}
+
+function getEffectiveDebugSettings(settings: RidgeDevDebugSettings): RidgeDevDebugSettings {
+  if (!settings.graybox) return settings;
+  return {
+    ...settings,
+    showColliders: true,
+    showPlayerBody: true,
+    showInteractZones: true,
+    showTraversalAssists: true
+  };
+}
+
+function isAnyDebugSettingEnabled(settings: RidgeDevDebugSettings): boolean {
+  return settings.graybox ||
+    settings.showColliders ||
+    settings.showPlayerBody ||
+    settings.showInteractZones ||
+    settings.showTraversalAssists;
+}
+
+function createGrayboxWash(
+  geometry: RidgeBlockoutGeometry
+): RidgeDebugDrawCommand {
+  return {
+    kind: 'rect',
+    id: 'graybox-wash',
+    x: geometry.bounds.x + geometry.bounds.width / 2,
+    y: geometry.bounds.y + geometry.bounds.height / 2,
+    width: geometry.bounds.width,
+    height: geometry.bounds.height,
+    fillColor: 0xfbfbf9,
+    fillAlpha: 0.18,
+    strokeColor: 0x1a1a1a,
+    strokeAlpha: 0.08,
+    lineWidth: 2
+  };
+}
+
+function createColliderCommand(collider: RidgeBlockoutCollider): RidgeDebugDrawCommand {
+  const style = getColliderStyle(collider);
+  return {
+    kind: 'rect',
+    id: `collider:${collider.id}`,
+    x: collider.x,
+    y: collider.y,
+    width: collider.width,
+    height: collider.height,
+    ...style
+  };
+}
+
+function getColliderStyle(collider: RidgeBlockoutCollider): Omit<
+  Extract<RidgeDebugDrawCommand, { kind: 'rect' }>,
+  'kind' | 'id' | 'x' | 'y' | 'width' | 'height'
+> {
+  switch (collider.kind) {
+    case 'platform':
+      return {
+        fillColor: 0xf0d35f,
+        fillAlpha: 0.15,
+        strokeColor: 0xf0d35f,
+        strokeAlpha: 0.86,
+        lineWidth: 3
+      };
+    case 'route-connector':
+      return {
+        fillColor: 0x596f8f,
+        fillAlpha: 0.13,
+        strokeColor: 0x596f8f,
+        strokeAlpha: 0.84,
+        lineWidth: 3
+      };
+    case 'shortcut-connector':
+      return {
+        fillColor: 0xb85f5a,
+        fillAlpha: 0.13,
+        strokeColor: 0xb85f5a,
+        strokeAlpha: 0.84,
+        lineWidth: 3
+      };
+    case 'solid':
+      return {
+        fillColor: 0x1a1a1a,
+        fillAlpha: 0.12,
+        strokeColor: 0x1a1a1a,
+        strokeAlpha: 0.78,
+        lineWidth: 2
+      };
+  }
+}
+
+function createAssistZoneLineCommand(
+  zone: RidgeBlockoutAssistZone,
+  traversalState: RidgeTraversalRuntimeState | undefined
+): RidgeDebugDrawCommand {
+  const active = traversalState?.activeClimbZoneId === zone.id;
+  return {
+    kind: 'line',
+    id: `assist-line:${zone.id}`,
+    from: zone.from,
+    to: zone.to,
+    strokeColor: getAssistZoneColor(zone),
+    strokeAlpha: active ? 0.95 : 0.68,
+    lineWidth: active ? 8 : 5
+  };
+}
+
+function createAssistZoneBoundsCommand(
+  zone: RidgeBlockoutAssistZone,
+  traversalState: RidgeTraversalRuntimeState | undefined
+): RidgeDebugDrawCommand {
+  const active = traversalState?.activeClimbZoneId === zone.id;
+  return {
+    kind: 'rect',
+    id: `assist-bounds:${zone.id}`,
+    x: zone.x,
+    y: zone.y,
+    width: zone.width,
+    height: zone.height,
+    fillColor: getAssistZoneColor(zone),
+    fillAlpha: active ? 0.16 : 0.08,
+    strokeColor: getAssistZoneColor(zone),
+    strokeAlpha: active ? 0.82 : 0.46,
+    lineWidth: active ? 3 : 2
+  };
+}
+
+function getAssistZoneColor(zone: RidgeBlockoutAssistZone): number {
+  switch (zone.kind) {
+    case 'ramp':
+      return 0xd7c78f;
+    case 'climb':
+      return 0x596f8f;
+    case 'drop':
+      return 0xb85f5a;
+  }
+}
+
+function drawCommand(
+  graphics: Phaser.GameObjects.Graphics,
+  command: RidgeDebugDrawCommand
+): void {
+  switch (command.kind) {
+    case 'rect':
+      graphics.fillStyle(command.fillColor, command.fillAlpha);
+      graphics.fillRect(
+        command.x - command.width / 2,
+        command.y - command.height / 2,
+        command.width,
+        command.height
+      );
+      graphics.lineStyle(command.lineWidth, command.strokeColor, command.strokeAlpha);
+      graphics.strokeRect(
+        command.x - command.width / 2,
+        command.y - command.height / 2,
+        command.width,
+        command.height
+      );
+      return;
+    case 'circle':
+      graphics.fillStyle(command.fillColor, command.fillAlpha);
+      graphics.fillCircle(command.x, command.y, command.radius);
+      graphics.lineStyle(command.lineWidth, command.strokeColor, command.strokeAlpha);
+      graphics.strokeCircle(command.x, command.y, command.radius);
+      return;
+    case 'line':
+      graphics.lineStyle(command.lineWidth, command.strokeColor, command.strokeAlpha);
+      graphics.strokeLineShape({
+        x1: command.from.x,
+        y1: command.from.y,
+        x2: command.to.x,
+        y2: command.to.y
+      } as Phaser.Geom.Line);
+      return;
+  }
+}

--- a/src/game/scenes/ridge/runtime/ridgeDevControls.test.ts
+++ b/src/game/scenes/ridge/runtime/ridgeDevControls.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   applyRidgeDevTeleportToPlayer,
+  resolveRidgeDevDebugSettings,
   resolveRidgeDevCameraZoom,
   resolveRidgeDevTeleportPosition,
   RIDGE_PLAYER_SPAWN_OFFSET_Y
@@ -12,6 +13,27 @@ describe('ridgeDevControls', () => {
     expect(resolveRidgeDevCameraZoom(1.25)).toBe(1.25);
     expect(resolveRidgeDevCameraZoom(0.1)).toBe(0.65);
     expect(resolveRidgeDevCameraZoom(4)).toBe(1.6);
+  });
+
+  it('resolves debug settings with all overlays off by default', () => {
+    expect(resolveRidgeDevDebugSettings(undefined)).toEqual({
+      graybox: false,
+      showColliders: false,
+      showPlayerBody: false,
+      showInteractZones: false,
+      showTraversalAssists: false
+    });
+
+    expect(resolveRidgeDevDebugSettings({
+      showColliders: true,
+      showPlayerBody: true
+    })).toEqual({
+      graybox: false,
+      showColliders: true,
+      showPlayerBody: true,
+      showInteractZones: false,
+      showTraversalAssists: false
+    });
   });
 
   it('resolves teleport targets with the Ridge player spawn offset when requested', () => {

--- a/src/game/scenes/ridge/runtime/ridgeDevControls.ts
+++ b/src/game/scenes/ridge/runtime/ridgeDevControls.ts
@@ -6,13 +6,28 @@ export interface RidgeDevTeleportRequest {
   applySpawnOffset: boolean;
 }
 
+export interface RidgeDevResetRequest {
+  sequence: number;
+  label: string;
+}
+
 export interface RidgeDevPlayerSnapshot {
   x: number;
   y: number;
 }
 
+export interface RidgeDevDebugSettings {
+  graybox: boolean;
+  showColliders: boolean;
+  showPlayerBody: boolean;
+  showInteractZones: boolean;
+  showTraversalAssists: boolean;
+}
+
 export interface RidgeDevControls {
   resolveCameraZoom?: () => number | undefined;
+  resolveDebugSettings?: () => Partial<RidgeDevDebugSettings> | undefined;
+  consumeResetRequest?: () => RidgeDevResetRequest | null;
   consumeTeleportRequest?: () => RidgeDevTeleportRequest | null;
   publishPlayerSnapshot?: (snapshot: RidgeDevPlayerSnapshot) => void;
 }
@@ -33,12 +48,29 @@ export const RIDGE_DEFAULT_CAMERA_ZOOM = 1;
 export const RIDGE_DEV_MIN_CAMERA_ZOOM = 0.65;
 export const RIDGE_DEV_MAX_CAMERA_ZOOM = 1.6;
 
+export const RIDGE_DEV_DEFAULT_DEBUG_SETTINGS: RidgeDevDebugSettings = {
+  graybox: false,
+  showColliders: false,
+  showPlayerBody: false,
+  showInteractZones: false,
+  showTraversalAssists: false
+};
+
 export function resolveRidgeDevCameraZoom(value: number | undefined): number {
   if (!Number.isFinite(value)) return RIDGE_DEFAULT_CAMERA_ZOOM;
   return Math.min(
     RIDGE_DEV_MAX_CAMERA_ZOOM,
     Math.max(RIDGE_DEV_MIN_CAMERA_ZOOM, Math.round((value ?? RIDGE_DEFAULT_CAMERA_ZOOM) * 100) / 100)
   );
+}
+
+export function resolveRidgeDevDebugSettings(
+  value: Partial<RidgeDevDebugSettings> | undefined
+): RidgeDevDebugSettings {
+  return {
+    ...RIDGE_DEV_DEFAULT_DEBUG_SETTINGS,
+    ...value
+  };
 }
 
 export function resolveRidgeDevTeleportPosition(

--- a/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.test.ts
+++ b/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.test.ts
@@ -78,6 +78,39 @@ describe('Ridge traversal runtime', () => {
     expect(result.state.lastSafePosition).toEqual({ x: 50, y: 80 });
   });
 
+  it('allows small ramp step-ups without pulling from far below', () => {
+    const runtime = createRidgeTraversalRuntime({
+      geometry: makeGeometry({
+        assistZones: [
+          makeAssistZone({
+            id: 'paper-stair-ramp',
+            kind: 'ramp',
+            from: { x: 0, y: 100 },
+            to: { x: 100, y: 100 }
+          })
+        ]
+      })
+    });
+    const nearStep = makePlayer({ x: 50, y: 104, height: 40, velocityY: 20 });
+    const farBelow = makePlayer({ x: 50, y: 120, height: 40, velocityY: 20 });
+
+    const nearResult = runtime.update({
+      player: nearStep,
+      commands: command(),
+      deltaMs: 1000 / 60
+    });
+    const farResult = runtime.update({
+      player: farBelow,
+      commands: command(),
+      deltaMs: 1000 / 60
+    });
+
+    expect(nearResult.appliedAssists).toContain('ramp');
+    expect(nearStep.y).toBe(80);
+    expect(farResult.appliedAssists).not.toContain('ramp');
+    expect(farBelow.y).toBe(120);
+  });
+
   it('runs climb before other assists and releases attachment when climb intent ends', () => {
     const climb = makeAssistZone({
       id: 'cord-climb',

--- a/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.test.ts
+++ b/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.test.ts
@@ -284,6 +284,54 @@ describe('Ridge traversal runtime', () => {
     expect(player.body.velocity.y).toBe(0);
   });
 
+  it('does not capture world-bottom contact as the last safe position', () => {
+    const runtime = createRidgeTraversalRuntime({
+      geometry: makeGeometry()
+    });
+    const player = makePlayer({
+      x: 20,
+      y: 20,
+      touchingDown: true
+    });
+
+    const safeCaptureResult = runtime.update({
+      player,
+      commands: command(),
+      deltaMs: 1000 / 60
+    });
+    expect(safeCaptureResult.state.lastSafePosition).toEqual({ x: 20, y: 20 });
+
+    player.x = 300;
+    player.y = 940;
+    player.body.touching.down = true;
+    player.body.blocked.down = true;
+    player.body.velocity.y = 0;
+
+    const bottomContactResult = runtime.update({
+      player,
+      commands: command(),
+      deltaMs: 1000 / 60
+    });
+    expect(bottomContactResult.appliedAssists).not.toContain('fall-recovery');
+    expect(bottomContactResult.appliedAssists).not.toContain('safe-capture');
+    expect(bottomContactResult.state.lastSafePosition).toEqual({ x: 20, y: 20 });
+
+    player.y = 980;
+    player.body.touching.down = false;
+    player.body.blocked.down = false;
+    player.body.velocity.y = 300;
+
+    const recoveryResult = runtime.update({
+      player,
+      commands: command(),
+      deltaMs: 1000 / 60
+    });
+
+    expect(recoveryResult.appliedAssists).toContain('fall-recovery');
+    expect(player.x).toBe(20);
+    expect(player.y).toBe(20);
+  });
+
   it('keeps solid terrain out of mantle targets', () => {
     const runtime = createRidgeTraversalRuntime({
       geometry: makeGeometry({

--- a/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.ts
+++ b/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.ts
@@ -95,7 +95,7 @@ export interface RidgeTraversalRuntimeOptions {
 
 const RIDGE_RAMP_SNAP = {
   maxSnapDownY: 28,
-  maxSnapUpY: 150
+  maxSnapUpY: 32
 } as const;
 const RIDGE_CLIMB_ATTACH_DISTANCE = 22;
 const RIDGE_DROP_ATTACH_DISTANCE = 28;

--- a/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.ts
+++ b/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.ts
@@ -447,9 +447,9 @@ class RidgeTraversalRuntimeImpl implements RidgeTraversalRuntime {
     const bottomBandY = this.geometry.bounds.y +
       this.geometry.bounds.height -
       RIDGE_FALL_RECOVERY_THRESHOLD_Y;
-    if (player.y >= bottomBandY) return false;
-
     const bottomY = getPlayerBottomY(player);
+    if (bottomY >= bottomBandY) return false;
+
     const ramp = resolveWalkableRampSurfaceY(
       this.geometry.assistZones,
       { x: player.x, y: bottomY },

--- a/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.ts
+++ b/src/game/scenes/ridge/runtime/ridgeTraversalRuntime.ts
@@ -95,7 +95,7 @@ export interface RidgeTraversalRuntimeOptions {
 
 const RIDGE_RAMP_SNAP = {
   maxSnapDownY: 28,
-  maxSnapUpY: 8
+  maxSnapUpY: 150
 } as const;
 const RIDGE_CLIMB_ATTACH_DISTANCE = 22;
 const RIDGE_DROP_ATTACH_DISTANCE = 28;

--- a/src/game/shell/Game.tsx
+++ b/src/game/shell/Game.tsx
@@ -4,6 +4,7 @@ import { Circle, Hand } from 'lucide-react';
 import { useGameBridgeCallbacks } from './useGameBridgeCallbacks';
 import { useGameTouchControls } from './useGameTouchControls';
 import { usePhaserGameBoot } from './usePhaserGameBoot';
+import { usePhaserGamePauseSync } from './usePhaserGamePauseSync';
 import { usePhaserScaleRefresh } from './usePhaserScaleRefresh';
 import type { PhaserScenePresentationMode } from '@/game/sharedSceneRuntime/phaserScenePresentation';
 import type { SceneId } from '@/game/scenes/sceneIds';
@@ -58,6 +59,7 @@ export default function Game({
     stableOnOpenOverlay,
     stableOnReturnToOverworld
   });
+  usePhaserGamePauseSync({ activeSceneId, gameRef, isPaused });
 
   const frameClassName = chrome === 'framed'
     ? 'relative h-full w-full min-h-0 overflow-hidden rounded-lg border-4 border-neutral-800 bg-[#fbfbf9] shadow-[8px_8px_0px_0px_rgba(26,26,26,1)]'

--- a/src/game/shell/phaserGamePauseSync.test.ts
+++ b/src/game/shell/phaserGamePauseSync.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import { setPauseOnPausableScenes } from './phaserGamePauseSync';
+
+describe('setPauseOnPausableScenes', () => {
+  it('applies pause only to active scenes that implement the pausable contract', () => {
+    const setPaused = vi.fn();
+    const game = {
+      scene: {
+        getScenes: vi.fn(() => [
+          { scene: { key: 'ridge' }, setPaused },
+          { scene: { key: 'decorative-overlay' } }
+        ])
+      }
+    };
+
+    setPauseOnPausableScenes(game as never, true);
+
+    expect(game.scene.getScenes).toHaveBeenCalledWith(true);
+    expect(setPaused).toHaveBeenCalledWith(true);
+  });
+
+  it('ignores a missing Phaser game during boot and teardown', () => {
+    expect(() => setPauseOnPausableScenes(null, true)).not.toThrow();
+  });
+});

--- a/src/game/shell/phaserGamePauseSync.ts
+++ b/src/game/shell/phaserGamePauseSync.ts
@@ -1,0 +1,11 @@
+import type * as Phaser from 'phaser';
+import { isPausableScene } from '@/game/sharedSceneRuntime/sceneContracts';
+
+export function setPauseOnPausableScenes(game: Phaser.Game | null, paused: boolean): void {
+  if (!game) return;
+  game.scene.getScenes(true).forEach((scene) => {
+    if (isPausableScene(scene)) {
+      scene.setPaused(paused);
+    }
+  });
+}

--- a/src/game/shell/usePhaserGameBoot.ts
+++ b/src/game/shell/usePhaserGameBoot.ts
@@ -13,6 +13,7 @@ import { getGameConfig } from '@/game/sharedSceneRuntime/config';
 import { getSceneStartResume, prepareSceneStart } from '@/game/sharedSceneRuntime/sceneResumePolicy';
 import type { RidgeDevControls } from '@/game/scenes/ridge/runtime/ridgeDevControls';
 import { getDevRidgeProgressSeed } from './devRidgeProgressParams';
+import { setPauseOnPausableScenes } from './phaserGamePauseSync';
 
 interface UsePhaserGameBootOptions {
   bridgeRef: RefObject<{
@@ -71,6 +72,9 @@ export function usePhaserGameBoot({
     const sceneManager = new SceneManager(adapter, {
       onSceneLoadingChange: (contextId) => {
         bridgeActions.setSceneLoading(contextId && isSceneId(contextId) ? contextId : null);
+      },
+      onSceneStarted: () => {
+        setPauseOnPausableScenes(gameRef.current, bridgeRef.current.isPaused);
       }
     });
     const sceneContexts = createSceneContexts({

--- a/src/game/shell/usePhaserGamePauseSync.ts
+++ b/src/game/shell/usePhaserGamePauseSync.ts
@@ -1,0 +1,20 @@
+import { useEffect, type RefObject } from 'react';
+import type * as Phaser from 'phaser';
+import type { SceneId } from '@/game/scenes/sceneIds';
+import { setPauseOnPausableScenes } from './phaserGamePauseSync';
+
+interface UsePhaserGamePauseSyncOptions {
+  activeSceneId: SceneId;
+  gameRef: RefObject<Phaser.Game | null>;
+  isPaused: boolean;
+}
+
+export function usePhaserGamePauseSync({
+  activeSceneId,
+  gameRef,
+  isPaused
+}: UsePhaserGamePauseSyncOptions): void {
+  useEffect(function syncPausableScenesWithGamePauseProp() {
+    setPauseOnPausableScenes(gameRef.current, isPaused);
+  }, [activeSceneId, gameRef, isPaused]);
+}


### PR DESCRIPTION
## Summary
- Added Ridge-first dev debug controls in the blockout viewer for graybox emphasis, collider and hitbox overlays, interact zones, traversal assists, zoom, teleport, and player reset.
- Rendered runtime overlays and Stampede scene UI inside the Ridge preview so Trail Card and Stampede interactions no longer create a hidden paused state.
- Routed Trail Card scene entry through the preview host seam, and kept focus ownership between panel and game input explicit.
- Fixed Ridge traversal recovery and ramp behavior so bottom-boundary falls do not become new safe points, and ramp connectors behave like physical bridge surfaces.

## Testing
- Added and updated focused unit and React tests for the viewer, overlay host seam, Ridge dev controls, traversal recovery, and ramp geometry.
- Ran targeted Vitest suites, `pnpm typecheck`, `pnpm lint`, and local browser smoke checks in `?mode=ridge-blockout&view=preview` covering Stampede entry, overlay visibility, focus recovery, and return to Ridge.

## Known Follow-ups / Tech Debt

- **Shortcut and future-route readability:** Some shortcut/future-route guides may still imply paths through walls. This PR keeps runtime behavior consistent, but a later Ridge level-design pass should decide which shortcuts are real, preview-only, or need source-map redesign.
- **Traversal surface model:** Ridge ramps/stairs currently use Arcade AABB strips plus assist lines. This is a practical v1, but authored traversal surfaces should become more explicit if we keep expanding traversal mechanics.
- **Preview session shell:** The Ridge Blockout Viewer now behaves more like a full runtime preview shell, hosting overlays, scene UI, focus ownership, and model switching. If it grows further, we should extract a small preview-session layer to keep the React component from becoming too central.
- **Runtime dev facts:** The model view infers current room from the latest `{ x, y }` player snapshot. That is fine for this PR, but richer dev/debug facts should come from Ridge runtime if we need more precise state later.