### PR TITLE
Reframe Ridge docs for pre-production route reset

### DIFF
--- a/.agents/skills/architect/SKILL.md
+++ b/.agents/skills/architect/SKILL.md
@@ -7,7 +7,11 @@ description: Guides Sketchbook Ridge architecture planning, seam sequencing, bra
 
 ## Quick Start
 
-1. Read `CONTEXT.md`, relevant `docs/adr/`, `docs/runtime-architecture.md`, `docs/architecture-direction.md`, `.agents/rules/10-architecture.md`, and `docs/agents/sketchbook-ridge-team.md`.
+1. Read `CONTEXT.md`, relevant `docs/adr/`, `docs/runtime-architecture.md`,
+   `docs/architecture-direction.md`, `.agents/rules/10-architecture.md`, and
+   `docs/agents/sketchbook-ridge-team.md`. For Ridge work, also read
+   `docs/game-design/ridge/README.md` before choosing source-of-truth docs; for
+   area-local work, follow its pointer to `docs/game-design/ridge/areas/`.
 2. Start with the smallest safe change. Classify the request as `NO-CHANGE`, `SAFE-AFK`, `SAFE-WITH-SEQUENCE`, or `HITL`.
 3. Apply the anti-slop standards in `.agents/rules/10-architecture.md`.
 4. If unfamiliar, use `zoom-out` first. If refactoring or a new seam is proposed, use `improve-codebase-architecture` for theory before implementation planning.

--- a/.agents/skills/audio-designer/SKILL.md
+++ b/.agents/skills/audio-designer/SKILL.md
@@ -10,7 +10,10 @@ Advisory and drafting mode for making Sketchbook Ridge sound handmade, quiet, le
 ## Load First
 
 - `docs/agents/sketchbook-ridge-team.md`
+- `docs/game-design/ridge/README.md`
 - `docs/game-design/ridge/summit.md`
+- `docs/game-design/ridge/story-level-bible.md`
+- `docs/game-design/ridge/areas/README.md`
 - `docs/game-design/ridge/milestone-plan.md`
 - `docs/runtime-architecture.md`
 - `.agents/rules/40-audio-runtime.md`
@@ -34,7 +37,10 @@ Optional provenance only; do not load by default:
 ## Workflow
 
 1. Identify the artifact, player surface, and mode: `review`, `draft`, `palette`, `sfx-spec`, `timing-cue`, `asset-intake`, or `implementation`.
-2. Classify the surface: overworld, Cicka Home, UI/overlay, Potassium, Stampede, Telegraph Terrace, or future mini-game.
+2. Classify the surface: active Ridge route area, legacy Cicka Home prototype,
+   UI/overlay, Potassium, Stampede, Telegraph Terrace, or future mini-game.
+   For active Ridge route areas, also read the matching file under
+   `docs/game-design/ridge/areas/`.
 3. Draft or apply an Audio Card: emotional job, sound materials, trigger rules, cooldown/variation policy, mix notes, asset constraints, visual fallback, and "do not do" rules.
 4. Keep recommendations indie-scale: one Foley family, trigger matrix, visual redundancy pass, asset budget, or runtime seam is often enough.
 5. For implementation guidance, route through existing Phaser scene, shared scene runtime, adapter, bridge, and React overlay boundaries.

--- a/.agents/skills/audio-designer/SKILL.md
+++ b/.agents/skills/audio-designer/SKILL.md
@@ -11,13 +11,13 @@ Advisory and drafting mode for making Sketchbook Ridge sound handmade, quiet, le
 
 - `docs/agents/sketchbook-ridge-team.md`
 - `docs/game-design/ridge/README.md`
-- `docs/game-design/ridge/summit.md`
-- `docs/game-design/ridge/story-level-bible.md`
-- `docs/game-design/ridge/areas/README.md`
-- `docs/game-design/ridge/milestone-plan.md`
 - `docs/runtime-architecture.md`
 - `.agents/rules/40-audio-runtime.md`
 - The specific artifact being reviewed or drafted.
+
+Use the Ridge router source matrix to decide which active route, area,
+open-question, reference, or legacy prototype doc is relevant. Do not load the
+whole Ridge planning tree by default.
 
 Optional provenance only; do not load by default:
 
@@ -37,10 +37,9 @@ Optional provenance only; do not load by default:
 ## Workflow
 
 1. Identify the artifact, player surface, and mode: `review`, `draft`, `palette`, `sfx-spec`, `timing-cue`, `asset-intake`, or `implementation`.
-2. Classify the surface: active Ridge route area, legacy Cicka Home prototype,
-   UI/overlay, Potassium, Stampede, Telegraph Terrace, or future mini-game.
-   For active Ridge route areas, also read the matching file under
-   `docs/game-design/ridge/areas/`.
+2. Classify the surface: active Ridge route area, current legacy prototype
+   surface, UI/overlay, optional mini-game, or future mini-game. For active
+   Ridge route areas, follow the Ridge router to the matching area doc.
 3. Draft or apply an Audio Card: emotional job, sound materials, trigger rules, cooldown/variation policy, mix notes, asset constraints, visual fallback, and "do not do" rules.
 4. Keep recommendations indie-scale: one Foley family, trigger matrix, visual redundancy pass, asset budget, or runtime seam is often enough.
 5. For implementation guidance, route through existing Phaser scene, shared scene runtime, adapter, bridge, and React overlay boundaries.
@@ -91,6 +90,6 @@ Severity is `low`, `medium`, `high`, or `critical`. Use `critical` only when pro
 - Do not make timing, navigation, or progression depend on audio alone.
 - Do not use repetitive meows, cartoon animal barks, or explicit Cicka speech.
 - Do not turn every UI action into sound; the Ridge should have air in it.
-- Do not treat research docs as active design unless their idea survives the current Summit and milestone constraints.
+- Do not treat research docs as active design unless their idea survives the current pre-production route constraints.
 - Do not load provenance reports unless Danilo asks for source research, a disputed rationale, or a new audio-domain expansion.
 - Do not suggest cloud upload, microphone capture, speaker identification, or voice-likeness work without explicit user approval and a local-first fallback.

--- a/.agents/skills/level-design-reviewer/SKILL.md
+++ b/.agents/skills/level-design-reviewer/SKILL.md
@@ -11,8 +11,9 @@ Advisory-only reviewer for handcrafted indie levels and Sketchbook Ridge spaces.
 
 - Read the artifact being reviewed: brief, screenshot, blockout, map, sequence, interaction list, telemetry notes, or player-flow description.
 - For Sketchbook Ridge work, read `docs/game-design/ridge/README.md`,
-  `docs/game-design/ridge/areas/README.md`, `docs/design/style-guide.md`, and
-  the relevant area or `docs/game-design/` file before critique.
+  `docs/design/style-guide.md`, and the specific artifact. Follow the Ridge
+  router to the relevant active area, route, open-question, reference, or
+  legacy prototype doc before critique.
 - Use these research files as background when the review needs deeper theory:
   - `docs/research/summaries/design-theory/indie-2d-level-design.md`
   - `docs/research/provenance/agents/level-design-reviewer-deep-research-report.md`
@@ -47,7 +48,7 @@ Use only the modes relevant to the artifact:
 - `mechanic_onboarding_reviewer`: first exposure, safe practice, difficulty spikes, mechanic layering, and unfair combinations.
 - `notebook_storytelling_reviewer`: lived-in authenticity, narrative objects, asymmetry, emotional traces, and style-consistent environmental details.
 - `flow_and_rest_analyzer`: fatigue risk, quiet rooms, density, decompression, and interaction rhythm across a sequence.
-- `metroidvania_locksmith`: locks, keys, foreshadowing loops, backtracking burden, hub memory, shortcuts, and disconnected areas.
+- `route_locksmith`: locks, keys, foreshadowing loops, backtracking burden, route memory, shortcuts, and disconnected areas.
 
 ## Output Shape
 

--- a/.agents/skills/level-design-reviewer/SKILL.md
+++ b/.agents/skills/level-design-reviewer/SKILL.md
@@ -10,7 +10,9 @@ Advisory-only reviewer for handcrafted indie levels and Sketchbook Ridge spaces.
 ## Load First
 
 - Read the artifact being reviewed: brief, screenshot, blockout, map, sequence, interaction list, telemetry notes, or player-flow description.
-- For Sketchbook Ridge work, read `docs/design/style-guide.md` and the relevant `docs/game-design/` file before critique.
+- For Sketchbook Ridge work, read `docs/game-design/ridge/README.md`,
+  `docs/game-design/ridge/areas/README.md`, `docs/design/style-guide.md`, and
+  the relevant area or `docs/game-design/` file before critique.
 - Use these research files as background when the review needs deeper theory:
   - `docs/research/summaries/design-theory/indie-2d-level-design.md`
   - `docs/research/provenance/agents/level-design-reviewer-deep-research-report.md`

--- a/.agents/skills/playability-tester/SKILL.md
+++ b/.agents/skills/playability-tester/SKILL.md
@@ -18,7 +18,7 @@ is fun; this role owns whether the intended path survives the runtime.
 - `docs/runtime-architecture.md`
 - `.agents/rules/20-game-runtime.md`
 - The specific artifact, diff, issue, or route being tested.
-- For Ridge route work: `docs/game-design/ridge/current-level.md`,
+- For Ridge route work: `docs/game-design/ridge/ridge-snapshot.md`,
   `docs/game-design/ridge/map-language.md`,
   `src/game/scenes/ridge/blockout/maps/folded-desk-ridge.blockout.txt`, and
   relevant `src/game/scenes/ridge/` tests or runtime files.

--- a/.agents/skills/playability-tester/SKILL.md
+++ b/.agents/skills/playability-tester/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playability-tester
-description: Validates Sketchbook Ridge playable routes, scene transitions, mobile inputs, smoke paths, and regression evidence. Use when Danilo invokes the Playability Tester or QA Playtest Lead, asks for playability QA, smoke testing, route reachability, softlock checks, mobile playtests, or changes touch Ridge blockouts, traversal, scene lifecycle, overlay pause, shell input, or scene returns.
+description: Validates Sketchbook Ridge playable routes, scene transitions, mobile inputs, smoke paths, and regression evidence. Use when Danilo invokes the Playability Tester or QA Playtest Lead, asks for playability QA, smoke testing, route reachability, softlock checks, mobile playtests, or changes touch Ridge route implementation, blockouts, traversal, scene lifecycle, overlay pause, shell input, or scene returns.
 ---
 
 # Playability Tester
@@ -19,12 +19,10 @@ is fun; this role owns whether the intended path survives the runtime.
 - `docs/runtime-architecture.md`
 - `.agents/rules/20-game-runtime.md`
 - The specific artifact, diff, issue, or route being tested.
-- For Ridge route work: `docs/game-design/ridge/ridge-snapshot.md`,
-  `docs/game-design/ridge/story-level-bible.md`,
-  `docs/game-design/ridge/areas/README.md`,
-  `docs/game-design/ridge/map-language.md`,
-  `src/game/scenes/ridge/blockout/maps/folded-desk-ridge.blockout.txt`, and
-  relevant `src/game/scenes/ridge/` tests or runtime files.
+- For Ridge route work, follow the Ridge router source matrix to the relevant
+  active design docs, current prototype snapshot, runtime files, and tests.
+  Read prototype blockout files only when the task actually touches current
+  blockout implementation.
 - For deeper testing theory:
   `docs/research/summaries/design-theory/automated-2d-level-playability-testing.md`
   and
@@ -34,7 +32,7 @@ is fun; this role owns whether the intended path survives the runtime.
 
 Require a playability pass when work touches:
 
-- Ridge blockout topology, anchors, gates, shortcuts, generated colliders, or traversal metadata.
+- Ridge route implementation, blockout topology, anchors, gates, shortcuts, generated colliders, or traversal metadata.
 - Movement constants, traversal helpers, collision, spawn, resume, fall recovery, camera, or control mats.
 - Scene lifecycle, bridge state, overlay pause, scene-owned UI actions, or parent-scene returns.
 - Mobile/touch movement, jump, interact, drag, or viewport layout that affects playable input.
@@ -103,7 +101,7 @@ broken.
 
 ## Preferred Evidence Ladder
 
-1. **Static blockout checks:** parser validation, route references, anchors,
+1. **Static route/blockout checks:** parser validation, route references, anchors,
    gates, shortcut availability, generated connectors, overlap errors.
 2. **Deterministic runtime checks:** geometry, traversal comfort, fall recovery,
    scene return policy, bridge state, overlay pause, shell control event mapping.

--- a/.agents/skills/playability-tester/SKILL.md
+++ b/.agents/skills/playability-tester/SKILL.md
@@ -13,12 +13,15 @@ is fun; this role owns whether the intended path survives the runtime.
 ## Load First
 
 - `docs/agents/sketchbook-ridge-team.md`
+- `docs/game-design/ridge/README.md`
 - `docs/runtime-modes.md`
 - `docs/game-design/player-manual.md`
 - `docs/runtime-architecture.md`
 - `.agents/rules/20-game-runtime.md`
 - The specific artifact, diff, issue, or route being tested.
 - For Ridge route work: `docs/game-design/ridge/ridge-snapshot.md`,
+  `docs/game-design/ridge/story-level-bible.md`,
+  `docs/game-design/ridge/areas/README.md`,
   `docs/game-design/ridge/map-language.md`,
   `src/game/scenes/ridge/blockout/maps/folded-desk-ridge.blockout.txt`, and
   relevant `src/game/scenes/ridge/` tests or runtime files.

--- a/.agents/skills/producer/SKILL.md
+++ b/.agents/skills/producer/SKILL.md
@@ -1,29 +1,29 @@
 ---
 name: producer
-description: Coordinates Sketchbook Ridge Summit work as the producer and agent coordinator. Use when Danilo asks for the Producer, coordinator, next steps, delegation, issue planning, milestone status, hiring/firing team members, or updates to Ridge team roles/skills/rules.
+description: Coordinates Sketchbook Ridge pre-production and implementation work as the producer and agent coordinator. Use when Danilo asks for the Producer, coordinator, next steps, delegation, issue planning, milestone status, hiring/firing team members, or updates to Ridge team roles/skills/rules.
 ---
 
 # Producer
 
-You are the **Producer / Agent Coordinator** for Sketchbook Ridge Summit.
+You are the **Producer / Agent Coordinator** for the Sketchbook Ridge game
+rework.
 
 ## Load First
 
 Read or reference these before giving direction:
 
+- `AGENTS.md`
 - `docs/agents/sketchbook-ridge-team.md`
 - `docs/game-design/ridge/README.md`
-- `docs/game-design/ridge/summit.md`
-- `docs/game-design/ridge/story-level-bible.md`
-- `docs/game-design/ridge/areas/README.md`
-- `docs/game-design/ridge/ridge-snapshot.md`
-- `docs/game-design/ridge/milestone-plan.md`
-- `docs/runtime-architecture.md`
-- `docs/runtime-modes.md`
 - `.agents/rules/`
+- The specific issue, artifact, route beat, area, scene, or diff being planned.
 
 For issue planning, also read `docs/agents/issue-tracker.md` and
 `.agents/skills/to-issues/SKILL.md`.
+
+Use the Ridge router source matrix to decide which active design, prototype,
+runtime, reference, or legacy doc is actually needed. Do not load the whole
+Ridge planning tree by default.
 
 ## Default Response Shape
 
@@ -39,23 +39,18 @@ Keep the recommendation small. Favor the next useful slice over broad roadmaps.
 
 ## Operating Rules
 
-- Treat `ridge/summit.md` as the product vision.
 - Treat `ridge/README.md` as the Ridge source-of-truth router and status
   matrix.
-- Treat `ridge/story-level-bible.md` as the active Ridge story/route canon for
-  Bridge Area -> Concert Area -> Dance Festival Area -> Relay/Cicka ending.
-- Treat `ridge/areas/` as the local source of truth for area-specific Ridge
-  detail.
-- Treat `ridge/ridge-snapshot.md` as the current human-readable Ridge
-  snapshot.
-- Treat `ridge/milestone-plan.md` as the durable milestone and seam
-  map, not the live issue tracker.
+- Treat the Ridge router source matrix as the owner of which design doc to read
+  or update.
+- Treat the current Phaser Ridge as legacy prototype/reference unless the task
+  explicitly targets runtime behavior.
 - Treat GitHub Issues as the live home for PRDs, issue state, current backlog,
   and agent briefs.
 - Treat `docs/agents/sketchbook-ridge-team.md` as the role roster.
 - Treat `.agents/rules/` as hard coding rules.
 - Parallelize scene-owned internals; serialize shared seams.
-- Do not treat archived competition docs as active planning source of truth.
+- Do not treat legacy prototype docs as active planning source of truth.
 - Do not ask Danilo for implementation details agents can safely infer.
 - Ask Danilo for taste, priority, scope, and irreversible product decisions.
 - Only spawn subagents when Danilo explicitly asks for helpers, agents, delegation, or parallel work.
@@ -99,13 +94,9 @@ has a repeatable workflow, not merely a point of view.
 Use this split: `.agents/rules/` for hard engineering constraints;
 `docs/agents/sketchbook-ridge-team.md` for roles; `.agents/skills/*` for
 repeatable workflows; `ridge/README.md` for Ridge doc routing and source status;
-`ridge/summit.md` for product vision; `ridge/story-level-bible.md` for active
-story/route canon; `ridge/areas/` for area-specific design detail;
-`ridge/ridge-snapshot.md` for current Ridge snapshot reality;
-`ridge/milestone-plan.md` for milestone shape, ownership boundaries,
-and shared-seam/branch strategy; GitHub Issues for PRDs, implementation issues,
-triage state, current backlog, and agent briefs; and `player-manual.md` for
-shipped behavior only.
+the Ridge router source matrix for exact design-doc ownership; GitHub Issues
+for PRDs, implementation issues, triage state, current backlog, and agent
+briefs; and `player-manual.md` for shipped behavior only.
 
 Do not duplicate long guidance between these files. Add thin pointers instead.
 
@@ -113,7 +104,7 @@ Do not duplicate long guidance between these files. Add thin pointers instead.
 
 When Danilo asks to create issues:
 
-1. Use `ridge/README.md`, the milestone plan, and current Ridge docs as context,
+1. Use `ridge/README.md` to choose the relevant current Ridge docs as context,
    not as a live backlog to mirror.
 2. Draft tracer-bullet slices using `.agents/skills/to-issues/SKILL.md`.
 3. Confirm the proposed granularity, dependencies, and HITL/AFK split with

--- a/.agents/skills/producer/SKILL.md
+++ b/.agents/skills/producer/SKILL.md
@@ -13,7 +13,7 @@ Read or reference these before giving direction:
 
 - `docs/agents/sketchbook-ridge-team.md`
 - `docs/game-design/ridge/summit.md`
-- `docs/game-design/ridge/current-level.md`
+- `docs/game-design/ridge/ridge-snapshot.md`
 - `docs/game-design/ridge/milestone-plan.md`
 - `docs/runtime-architecture.md`
 - `docs/runtime-modes.md`
@@ -37,7 +37,7 @@ Keep the recommendation small. Favor the next useful slice over broad roadmaps.
 ## Operating Rules
 
 - Treat `ridge/summit.md` as the product vision.
-- Treat `ridge/current-level.md` as the current human-readable Ridge level
+- Treat `ridge/ridge-snapshot.md` as the current human-readable Ridge
   snapshot.
 - Treat `ridge/milestone-plan.md` as the durable milestone and seam
   map, not the live issue tracker.
@@ -90,7 +90,7 @@ has a repeatable workflow, not merely a point of view.
 Use this split: `.agents/rules/` for hard engineering constraints;
 `docs/agents/sketchbook-ridge-team.md` for roles; `.agents/skills/*` for
 repeatable workflows; `ridge/summit.md` for product vision;
-`ridge/current-level.md` for current Ridge level reality;
+`ridge/ridge-snapshot.md` for current Ridge snapshot reality;
 `ridge/milestone-plan.md` for milestone shape, ownership boundaries,
 and shared-seam/branch strategy; GitHub Issues for PRDs, implementation issues,
 triage state, current backlog, and agent briefs; and `player-manual.md` for

--- a/.agents/skills/producer/SKILL.md
+++ b/.agents/skills/producer/SKILL.md
@@ -12,7 +12,10 @@ You are the **Producer / Agent Coordinator** for Sketchbook Ridge Summit.
 Read or reference these before giving direction:
 
 - `docs/agents/sketchbook-ridge-team.md`
+- `docs/game-design/ridge/README.md`
 - `docs/game-design/ridge/summit.md`
+- `docs/game-design/ridge/story-level-bible.md`
+- `docs/game-design/ridge/areas/README.md`
 - `docs/game-design/ridge/ridge-snapshot.md`
 - `docs/game-design/ridge/milestone-plan.md`
 - `docs/runtime-architecture.md`
@@ -37,6 +40,12 @@ Keep the recommendation small. Favor the next useful slice over broad roadmaps.
 ## Operating Rules
 
 - Treat `ridge/summit.md` as the product vision.
+- Treat `ridge/README.md` as the Ridge source-of-truth router and status
+  matrix.
+- Treat `ridge/story-level-bible.md` as the active Ridge story/route canon for
+  Bridge Area -> Concert Area -> Dance Festival Area -> Relay/Cicka ending.
+- Treat `ridge/areas/` as the local source of truth for area-specific Ridge
+  detail.
 - Treat `ridge/ridge-snapshot.md` as the current human-readable Ridge
   snapshot.
 - Treat `ridge/milestone-plan.md` as the durable milestone and seam
@@ -89,7 +98,9 @@ has a repeatable workflow, not merely a point of view.
 
 Use this split: `.agents/rules/` for hard engineering constraints;
 `docs/agents/sketchbook-ridge-team.md` for roles; `.agents/skills/*` for
-repeatable workflows; `ridge/summit.md` for product vision;
+repeatable workflows; `ridge/README.md` for Ridge doc routing and source status;
+`ridge/summit.md` for product vision; `ridge/story-level-bible.md` for active
+story/route canon; `ridge/areas/` for area-specific design detail;
 `ridge/ridge-snapshot.md` for current Ridge snapshot reality;
 `ridge/milestone-plan.md` for milestone shape, ownership boundaries,
 and shared-seam/branch strategy; GitHub Issues for PRDs, implementation issues,
@@ -102,8 +113,8 @@ Do not duplicate long guidance between these files. Add thin pointers instead.
 
 When Danilo asks to create issues:
 
-1. Use the milestone plan and current Ridge docs as context, not as a live
-   backlog to mirror.
+1. Use `ridge/README.md`, the milestone plan, and current Ridge docs as context,
+   not as a live backlog to mirror.
 2. Draft tracer-bullet slices using `.agents/skills/to-issues/SKILL.md`.
 3. Confirm the proposed granularity, dependencies, and HITL/AFK split with
    Danilo unless he explicitly authorizes a first batch.

--- a/.agents/skills/story-tone-designer/SKILL.md
+++ b/.agents/skills/story-tone-designer/SKILL.md
@@ -11,12 +11,12 @@ Advisory and drafting mode for keeping Sketchbook Ridge warm, personal, funny-sa
 
 - `docs/agents/sketchbook-ridge-team.md`
 - `docs/game-design/ridge/README.md`
-- `docs/game-design/ridge/summit.md`
-- `docs/game-design/ridge/story-level-bible.md`
-- `docs/game-design/ridge/areas/README.md`
-- `docs/game-design/ridge/milestone-plan.md`
 - `docs/design/style-guide.md`
 - The specific artifact being reviewed or drafted.
+
+Use the Ridge router source matrix to decide which active route, area,
+open-question, reference, or legacy prototype doc is relevant. Do not load the
+whole Ridge planning tree by default.
 
 Use these research files as background when tone work needs deeper theory:
 
@@ -38,8 +38,7 @@ Use these research files as background when tone work needs deeper theory:
 ## Workflow
 
 1. Identify the artifact, audience, mode, and whether the task is `review`, `draft`, `rewrite`, or `tone-card`.
-   For area-local Ridge work, also read the matching file under
-   `docs/game-design/ridge/areas/`.
+   For area-local Ridge work, follow the Ridge router to the matching area doc.
 2. Name the intended emotional beat in one sentence.
 3. Extract or apply a compact Tone Card: voice, register, humor policy, emotional arc, imagery, pacing, and "do not do" rules.
 4. Preserve existing meaning and shipped behavior by default. Ask Danilo only when a choice changes tribute meaning, Cicka interpretation, ending tone, or public-facing identity.
@@ -90,5 +89,5 @@ Severity is `low`, `medium`, `high`, or `critical`. Use `critical` only when the
 - Do not add grief intensity just to make a beat feel important.
 - Do not make Cicka speak like a normal human; translated lines are affectionate guesses.
 - Do not expand tiny NPCs into dialogue trees unless Danilo explicitly changes scope.
-- Do not treat research docs as active design unless their idea survives the current Summit and milestone constraints.
+- Do not treat research docs as active design unless their idea survives the current pre-production route constraints.
 - Keep recommendations indie-scale and implementable in the current Ridge slice.

--- a/.agents/skills/story-tone-designer/SKILL.md
+++ b/.agents/skills/story-tone-designer/SKILL.md
@@ -10,7 +10,10 @@ Advisory and drafting mode for keeping Sketchbook Ridge warm, personal, funny-sa
 ## Load First
 
 - `docs/agents/sketchbook-ridge-team.md`
+- `docs/game-design/ridge/README.md`
 - `docs/game-design/ridge/summit.md`
+- `docs/game-design/ridge/story-level-bible.md`
+- `docs/game-design/ridge/areas/README.md`
 - `docs/game-design/ridge/milestone-plan.md`
 - `docs/design/style-guide.md`
 - The specific artifact being reviewed or drafted.
@@ -35,6 +38,8 @@ Use these research files as background when tone work needs deeper theory:
 ## Workflow
 
 1. Identify the artifact, audience, mode, and whether the task is `review`, `draft`, `rewrite`, or `tone-card`.
+   For area-local Ridge work, also read the matching file under
+   `docs/game-design/ridge/areas/`.
 2. Name the intended emotional beat in one sentence.
 3. Extract or apply a compact Tone Card: voice, register, humor policy, emotional arc, imagery, pacing, and "do not do" rules.
 4. Preserve existing meaning and shipped behavior by default. Ask Danilo only when a choice changes tribute meaning, Cicka interpretation, ending tone, or public-facing identity.

--- a/.agents/skills/visual-direction-artist/SKILL.md
+++ b/.agents/skills/visual-direction-artist/SKILL.md
@@ -12,6 +12,8 @@ Digital Sketchbook style; do not invent a new visual system.
 ## Load First
 
 - `docs/agents/sketchbook-ridge-team.md`
+- `docs/game-design/ridge/README.md`
+- `docs/game-design/ridge/areas/README.md`
 - `docs/design/style-guide.md`
 - `docs/runtime-architecture.md`
 - The scene, component, mockup, asset brief, or visual artifact being reviewed.
@@ -57,6 +59,8 @@ Ownership brackets:
 1. Identify the surface and mode: `review`, `draft`, `style-qa`, `asset-spec`,
    `character-package`, `motion-pass`, `component-polish`, or
    `implementation-guidance`.
+   For area-local Ridge work, also read the matching file under
+   `docs/game-design/ridge/areas/`.
 2. Name the visual job in one sentence: what the player should notice, feel, or
    understand first.
 3. Apply the source hierarchy: style guide, existing implementation, project

--- a/.agents/skills/visual-direction-artist/SKILL.md
+++ b/.agents/skills/visual-direction-artist/SKILL.md
@@ -13,10 +13,13 @@ Digital Sketchbook style; do not invent a new visual system.
 
 - `docs/agents/sketchbook-ridge-team.md`
 - `docs/game-design/ridge/README.md`
-- `docs/game-design/ridge/areas/README.md`
 - `docs/design/style-guide.md`
 - `docs/runtime-architecture.md`
 - The scene, component, mockup, asset brief, or visual artifact being reviewed.
+
+Use the Ridge router source matrix to decide which active route, area,
+open-question, reference, or legacy prototype doc is relevant. Do not load the
+whole Ridge planning tree by default.
 
 Optional provenance only; do not load by default:
 
@@ -31,7 +34,9 @@ is approved.
 
 ## Default Visual Card
 
-- Source of truth: current style guide and existing implementation first.
+- Source of truth: style guide plus active Ridge pre-production canon for target
+  design; existing implementation first only when the task targets current
+  runtime behavior.
 - Palette: off-white paper, black ink, monochrome accents, hatching, shadow
   mass, and line-weight contrast before new color.
 - Asset logic: reusable paper cutouts, stable anchors, small variants, thick
@@ -59,8 +64,7 @@ Ownership brackets:
 1. Identify the surface and mode: `review`, `draft`, `style-qa`, `asset-spec`,
    `character-package`, `motion-pass`, `component-polish`, or
    `implementation-guidance`.
-   For area-local Ridge work, also read the matching file under
-   `docs/game-design/ridge/areas/`.
+   For area-local Ridge work, follow the Ridge router to the matching area doc.
 2. Name the visual job in one sentence: what the player should notice, feel, or
    understand first.
 3. Apply the source hierarchy: style guide, existing implementation, project

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,4 +54,6 @@ When generating or converting sprite assets for Phaser scenes, use [`.agents/ski
 
 - [`README.md`](README.md) — project overview, development commands, deployment notes.
 - [`docs/game-design/`](docs/game-design/) — shipped player-facing behavior and future design notes.
+- [`docs/game-design/ridge/README.md`](docs/game-design/ridge/README.md) — first-read Ridge source-of-truth router, status matrix, and update protocol.
+- [`docs/game-design/ridge/areas/README.md`](docs/game-design/ridge/areas/README.md) — active Bridge, Concert, Dance Festival, and Relay Ending area docs.
 - [`src/README.md`](src/README.md) — source folder map.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ This is the high-level, tool-agnostic entrypoint for agents working on this gami
 - **Runtime modes:** [`docs/runtime-modes.md`](docs/runtime-modes.md) explains app mode transitions and parent-scene returns.
 - **Visual identity:** [`docs/design/style-guide.md`](docs/design/style-guide.md) is the source of truth for the "Digital Sketchbook" aesthetic.
 
+For Ridge design or planning, start with [`docs/game-design/ridge/README.md`](docs/game-design/ridge/README.md), then [`docs/game-design/ridge/story-level-bible.md`](docs/game-design/ridge/story-level-bible.md), then the matching file under [`docs/game-design/ridge/areas/`](docs/game-design/ridge/areas/README.md). Do not start from `legacy/`, `reference/`, research, or old map plans unless an active doc explicitly sends you there.
+
 If another AI tool needs its own entry file, keep it as a thin pointer back to this file and [`.agents/rules/`](.agents/rules/). Do not duplicate the scoped rules into tool-specific files.
 
 ## Agent skills
@@ -53,7 +55,7 @@ When generating or converting sprite assets for Phaser scenes, use [`.agents/ski
 ## Project docs
 
 - [`README.md`](README.md) — project overview, development commands, deployment notes.
-- [`docs/game-design/`](docs/game-design/) — shipped player-facing behavior and future design notes.
+- [`docs/game-design/`](docs/game-design/) — shipped player-facing behavior, active Ridge design, current prototype truth, reference packs, and legacy history.
 - [`docs/game-design/ridge/README.md`](docs/game-design/ridge/README.md) — first-read Ridge source-of-truth router, status matrix, and update protocol.
 - [`docs/game-design/ridge/areas/README.md`](docs/game-design/ridge/areas/README.md) — active Bridge, Concert, Dance Festival, and Relay Ending area docs.
 - [`src/README.md`](src/README.md) — source folder map.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This is the high-level, tool-agnostic entrypoint for agents working on this gami
 - **Runtime modes:** [`docs/runtime-modes.md`](docs/runtime-modes.md) explains app mode transitions and parent-scene returns.
 - **Visual identity:** [`docs/design/style-guide.md`](docs/design/style-guide.md) is the source of truth for the "Digital Sketchbook" aesthetic.
 
-For Ridge design or planning, start with [`docs/game-design/ridge/README.md`](docs/game-design/ridge/README.md), then [`docs/game-design/ridge/story-level-bible.md`](docs/game-design/ridge/story-level-bible.md), then the matching file under [`docs/game-design/ridge/areas/`](docs/game-design/ridge/areas/README.md). Do not start from `legacy/`, `reference/`, research, or old map plans unless an active doc explicitly sends you there.
+For Ridge design or planning, treat the project as **pre-production for the game rework**: start with [`docs/game-design/ridge/README.md`](docs/game-design/ridge/README.md), then follow its source matrix to the active route, area, open-question, or implementation doc. The existing Phaser Ridge is a legacy prototype/reference unless the task explicitly targets current runtime behavior. Do not start from `legacy/`, `reference/`, research, or old map plans unless an active doc explicitly sends you there.
 
 If another AI tool needs its own entry file, keep it as a thin pointer back to this file and [`.agents/rules/`](.agents/rules/). Do not duplicate the scoped rules into tool-specific files.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,9 +177,15 @@ operations such as shuttle questions, setup checks, volunteer handoffs, and
 service-road clearance calls.
 _Avoid_: DJ, song-table volunteer, generic festival helper, niche technician
 
+**Dance Teacher**:
+The Opening Dance facilitator who teaches the hill-shuttle driver one private
+step and covers the operations watch so the Last-Stop Operations Helper can
+enjoy the night dance.
+_Avoid_: romance target, competition judge, extra route gate, new protagonist
+
 **Operations Handoff Check**:
 A Readiness Favor where the player helps the Last-Stop Operations Helper prove
-the plaza setup is safe enough for another resident to watch while she enjoys
+the plaza setup is safe enough for the Dance Teacher to watch while she enjoys
 the night dance.
 _Avoid_: confidence speech, therapy puzzle, arbitrary item fetch
 
@@ -197,12 +203,15 @@ _Avoid_: love letter, public proposal, player-delivered confession
 
 **Setup Clearance Walkthrough**:
 The physical route solve in the Opening Dance Shuttle Beat where final visible
-festival setup details clear the service lane for the last daylight shuttle.
+festival setup details clear the service lane for the last daylight shuttle;
+default symbolic snaps are securing a lantern line, clearing or taping the
+service-lane obstruction, and flipping the shuttle sign to "Last daylight ride."
 _Avoid_: long chore list, black-screen-only solve, abstract emotional unlock
 
 **Prompt-Driven Playable Montage**:
 A compact presentation pattern where the player triggers a few authored
-interactions that snap through visible work and a time-of-day shift.
+interactions that snap through visible work and a time-of-day shift; the work
+can be symbolic one-action prep rather than literal manual labor.
 _Avoid_: pure cutscene, full manual chores, repeated object hauling
 
 **Short Threshold Transition**:
@@ -358,8 +367,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   **Last-Stop Operations Helper** as colleagues whose practical work and private
   nervousness both delay the last daylight ride.
 - The **Operations Handoff Check** is the Last-Stop Operations Helper's current
-  **Readiness Favor**; the dance teacher is the simple first candidate to cover
-  the operations watch, but the covering resident can remain flexible.
+  **Readiness Favor**; the **Dance Teacher** covers the operations watch after
+  setup is proven safe, keeping the cast small and letting the helper enjoy the
+  dance without implying someone else planned it better.
 - **One-Step Practice** is the hill-shuttle driver's current **Readiness Favor**;
   it gives him one private, imperfect step rather than turning dance into a
   public skill test.
@@ -372,8 +382,10 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   the romantic connector by making the service lane visibly ready for the last
   daylight shuttle.
 - The **Setup Clearance Walkthrough** should present as a **Prompt-Driven
-  Playable Montage**, with a few interaction snaps and a visible sky/plaza time
-  shift instead of full manual chores.
+  Playable Montage**, with three default symbolic snaps: secure the lantern
+  line, clear or tape the service-lane obstruction, and flip the shuttle sign to
+  "Last daylight ride." These can collapse further if implementation needs a
+  shorter transition, but they should not become full manual chores.
 - In the **Opening Dance Shuttle Beat**, **Cicka Field Presence** should read as
   a quiet threshold observer near the operations table or service gate; the
   **Unnamed Counterpart Cat** can add texture and imply future continuity, but
@@ -426,7 +438,10 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 > **Domain expert:** "No — she is the **Last-Stop Operations Helper**, a visible plaza worker whose setup checklist and service-road handoff make her role immediately readable."
 
 > **Dev:** "How do we help the shy operations helper without therapizing her?"
-> **Domain expert:** "Use the **Operations Handoff Check**: prove the setup is ready and let a trusted resident keep watch so she can enjoy the night."
+> **Domain expert:** "Use the **Operations Handoff Check**: prove the setup is ready and let the **Dance Teacher** keep watch so she can enjoy the night."
+
+> **Dev:** "Who covers the operations watch?"
+> **Domain expert:** "Use the **Dance Teacher**. They already belong in the beat as the gentle facilitator, so they can cover the watch without adding another resident role."
 
 > **Dev:** "How do we help the driver if he cannot dance?"
 > **Domain expert:** "Use **One-Step Practice**: he learns one tiny private step, enough to ask without pretending he is suddenly good."
@@ -445,6 +460,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 
 > **Dev:** "Do we make the player manually move every chair?"
 > **Domain expert:** "No — present the **Setup Clearance Walkthrough** as a **Prompt-Driven Playable Montage** with a few authored interaction snaps."
+
+> **Dev:** "Which setup snaps should the montage use?"
+> **Domain expert:** "Use three symbolic one-action snaps by default: lantern line, service-lane obstruction, and shuttle sign. They are story-readable, practical, and easy to collapse if the beat needs to be shorter."
 
 > **Dev:** "Can Cicka hang out with another cat during the dance setup?"
 > **Domain expert:** "Yes — use the **Unnamed Counterpart Cat** for implied continuity, but do not spend Micka before the post-ending return."

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -150,8 +150,9 @@ Each v0 spot should support two tiny visual states: before its area beat
 resolves, Cicka uses the spot to draw attention; after resolution, the spot
 settles immediately into a calmer pose, tiny mark, or changed prop. The Guitar
 Farewell montage can revisit these already-changed states, but should not be
-the first time the player sees them.
-_Avoid_: Cicka Home hub, quest board, required backtracking checkpoint, inventory stash, required affection system, v0 interaction node
+the first time the player sees them. Noticing or revisiting these changed states
+should be an optional emotional reward, never a progression requirement.
+_Avoid_: Cicka Home hub, quest board, required backtracking checkpoint, inventory stash, required affection system, v0 interaction node, checklist gate
 
 **Bridge Resting Spot**:
 The Cicka Resting Spot in the Bridge Area, staged near the unsafe crossing,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,6 +4,13 @@ This context defines the game-design language for the gamified portfolio and its
 
 ## Language
 
+**Ridge Pre-Production Plan**:
+The active design target for the game rework: a linear emotional Ridge route
+through Bridge Area, Concert Area, Dance Festival Area, and Relay Spire. It can
+override legacy prototype plans, but it does not describe shipped behavior until
+implemented and reflected in the player manual.
+_Avoid_: current runtime, shipped game, legacy prototype
+
 **Typed Ridge Blockout Source**:
 A human- and agent-editable TypeScript source notation that describes Ridge
 topology, room blockouts, traversal primitives, shortcuts, anchors, tile
@@ -369,6 +376,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - The **Exploration Map** should read first as a **Sketchbook Neighborhood**,
   with shortcut relief supporting that fantasy instead of required precision
   platforming defining it.
+- The **Ridge Pre-Production Plan** is the current target for the desired game
+  rework; the existing Phaser Ridge is a legacy prototype/reference unless a
+  task explicitly targets current runtime behavior.
 - The **Sketchbook Neighborhood** should obey **Lived-In Causality** even when
   its art direction is sketchbook-like: a route change can be whimsical in
   presentation, but its blocker, helper, and resolution should feel practical

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,6 +80,14 @@ where the player moves toward the Relay Spire by helping tiny residents and
 seeing routes change.
 _Avoid_: metroidvania platforming map, portfolio theme park, static building row
 
+**Lived-In Causality**:
+A design rule for the Sketchbook Neighborhood: route blockers and world changes
+should have practical in-world causes, local context, and residents with
+believable reasons and means to help. A beat should answer where it belongs,
+what physically blocks progress, and why the character involved can affect that
+blocker.
+_Avoid_: purely magical unlock, abstract emotional gate, quest-giver robot
+
 **Exploration Traversal**:
 The common forgiving movement model for the Exploration Map, centered on
 walking and authored traversal interactions such as climb, descend, drop, lift,
@@ -138,6 +146,25 @@ An authored Room Beat centered on one required resident problem, its local
 characters, possible solutions, Cicka field presence, and visible route change.
 _Avoid_: Phaser scene, isolated quest room, dialogue hub
 
+**Recoverable Conversation Choice**:
+A dialogue choice inside a Resident Room Beat that can change tone, trust,
+order, optional rewards, or temporary awkwardness without permanently blocking
+the first ending. A failed or clumsy choice should create an in-world recovery
+path rather than a dead end.
+_Avoid_: permanent fail state, gotcha dialogue, illusion-only choice
+
+**Practical Wayfinding Loop**:
+A Resident Room Beat discovery pattern where the player first learns a route
+problem through signs, blocked paths, local roles, and travel questions before
+uncovering the emotional or character layer underneath.
+_Avoid_: quest-giver monologue, immediate emotional exposition, objective popup
+
+**Triangulated Discovery Flow**:
+A conversation pattern where the player first receives incomplete but truthful
+answers from the directly involved residents, then learns the fuller social
+context by asking nearby locals who have partial observations.
+_Avoid_: omniscient NPC reveal, instant confession, hidden-state guessing
+
 **Living Proof Gate**:
 A quiet ending gate where the player can physically reach the Relay Spire, but
 the sketchbook cannot send until the route has created enough visible world
@@ -168,6 +195,10 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - The **Exploration Map** should read first as a **Sketchbook Neighborhood**,
   with shortcut relief supporting that fantasy instead of required precision
   platforming defining it.
+- The **Sketchbook Neighborhood** should obey **Lived-In Causality** even when
+  its art direction is sketchbook-like: a route change can be whimsical in
+  presentation, but its blocker, helper, and resolution should feel practical
+  and locally motivated.
 - The **Exploration Map** uses **Exploration Traversal**.
 - A mini-game may use its own **Mini-Game Movement System** instead of
   **Exploration Traversal**.
@@ -195,6 +226,13 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - A required **Resident Help Beat** usually belongs to one **Resident Room Beat**;
   that room beat can include multiple residents, optional interactions, and
   alternate solutions without becoming a separate Phaser scene.
+- **Resident Room Beats** can use **Recoverable Conversation Choices** to make
+  resident help feel authored and personal, but the main ending path should not
+  become permanently missable because of one dialogue choice.
+- A **Practical Wayfinding Loop** should introduce route blockers before
+  emotional stakes when a beat needs to feel lived-in and grounded.
+- A **Triangulated Discovery Flow** can reveal a resident relationship without
+  making the player or one NPC magically know private feelings.
 - The **Cicka Threshold Farewell** resolves Cicka's recurring field guidance
   without closing the **Sketchbook Neighborhood**; the Ridge remains replayable
   with Cicka's final mark or absence-shaped changes.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -131,10 +131,61 @@ The final shared Cicka moment where the player plays guitar for her at the Relay
 Spire, echoing an established comfort interaction from Cicka Home and the Ridge.
 _Avoid_: generic music mini-game, melodrama, one-off ending prop
 
+**Living Proof Montage**:
+A brief Guitar Farewell montage that wordlessly shows the resident help and
+world changes that made the sketchbook ready to send.
+_Avoid_: full recap, credits roll, visible checklist, objective summary
+
 **Concert Crossing Beat**:
 A mid-route Resident Room Beat where a blocked concert/traffic crossing becomes
 the way the player earns the guitar through a small music performance problem.
 _Avoid_: joke-only drunk musician, random item pickup, final-farewell skill gate
+
+**Opening Dance Shuttle Beat**:
+A final-route Resident Room Beat where afternoon festival setup blocks the Relay
+hill service road until the player helps prepare the night dance and catches the
+last daylight shuttle to the Relay Spire.
+_Avoid_: Last Dance, Final Shuttle Hold, after-festival closure gate
+
+**Last-Stop Operations Helper**:
+The shy colleague in the Opening Dance Shuttle Beat who handles visible plaza
+operations such as shuttle questions, setup checks, volunteer handoffs, and
+service-road clearance calls.
+_Avoid_: DJ, song-table volunteer, generic festival helper, niche technician
+
+**Operations Handoff Check**:
+A Readiness Favor where the player helps the Last-Stop Operations Helper prove
+the plaza setup is safe enough for another resident to watch while she enjoys
+the night dance.
+_Avoid_: confidence speech, therapy puzzle, arbitrary item fetch
+
+**One-Step Practice**:
+A Readiness Favor where the hill-shuttle driver privately learns one tiny dance
+step so he can offer shared rhythm without pretending to be a good dancer.
+_Avoid_: dance mastery, public embarrassment, required rhythm challenge
+
+**Folded Song Request**:
+The small paper invitation that lets the hill-shuttle driver ask the Last-Stop
+Operations Helper to dance without forcing a public confession.
+_Avoid_: love letter, public proposal, player-delivered confession
+
+**Setup Clearance Walkthrough**:
+The physical route solve in the Opening Dance Shuttle Beat where final visible
+festival setup details clear the service lane for the last daylight shuttle.
+_Avoid_: long chore list, black-screen-only solve, abstract emotional unlock
+
+**Prompt-Driven Playable Montage**:
+A compact presentation pattern where the player triggers a few authored
+interactions that snap through visible work and a time-of-day shift.
+_Avoid_: pure cutscene, full manual chores, repeated object hauling
+
+**Unnamed Counterpart Cat**:
+The non-Micka local cat who may quietly interact with Cicka during the Opening
+Dance Shuttle Beat as implied continuity foreshadowing.
+Use only silhouette/color specificity, such as a pale or light-ink contrast to
+Cicka.
+_Avoid_: Micka's dad, explicit parentage reveal, early Micka reveal, exposition,
+named dialogue
 
 **Resident Help Beat**:
 A small Sketchbook Neighborhood progression beat where the player helps a tiny
@@ -248,9 +299,36 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - The **Guitar Farewell** should be established before the ending as a repeatable
   comfort interaction, especially at Cicka Home, so the final Relay Spire use
   feels remembered rather than introduced for drama.
+- The **Guitar Farewell** can include a **Living Proof Montage**, but the montage
+  should stay brief and keep Cicka as the emotional focus.
 - The **Concert Crossing Beat** can teach the guitar through a small
   Guitar-Hero-like mini-game, but the **Guitar Farewell** itself should remain a
   cozy remembrance interaction rather than an arcade pass/fail challenge.
+- The **Opening Dance Shuttle Beat** keeps the dance festival as a night event,
+  but the required route action happens during daytime setup so the player can
+  reach the Relay Spire for the sunset **Guitar Farewell**.
+- The **Opening Dance Shuttle Beat** centers the hill-shuttle driver and the
+  **Last-Stop Operations Helper** as colleagues whose practical work and private
+  nervousness both delay the last daylight ride.
+- The **Operations Handoff Check** is the Last-Stop Operations Helper's current
+  **Readiness Favor**; the dance teacher is the simple first candidate to cover
+  the operations watch, but the covering resident can remain flexible.
+- **One-Step Practice** is the hill-shuttle driver's current **Readiness Favor**;
+  it gives him one private, imperfect step rather than turning dance into a
+  public skill test.
+- The **Folded Song Request** connects the two Readiness Favors by letting the
+  driver ask through a subtle operations-table object instead of direct public
+  matchmaking.
+- The **Setup Clearance Walkthrough** restores the practical route blocker after
+  the romantic connector by making the service lane visibly ready for the last
+  daylight shuttle.
+- The **Setup Clearance Walkthrough** should present as a **Prompt-Driven
+  Playable Montage**, with a few interaction snaps and a visible sky/plaza time
+  shift instead of full manual chores.
+- In the **Opening Dance Shuttle Beat**, **Cicka Field Presence** should read as
+  a quiet threshold observer near the operations table or service gate; the
+  **Unnamed Counterpart Cat** can add texture and imply future continuity, but
+  it should stay visual-only and should not be named or treated as Micka.
 - Required **Resident Room Beats** that contain arcade-like interactions should
   also have a non-arcade fallback through conversation, collection, practice, or
   a forgiving auto-resolve path.
@@ -283,8 +361,38 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 > **Dev:** "Can the final Cicka beat be the player playing guitar for her?"
 > **Domain expert:** "Yes — make it the **Guitar Farewell**, but establish guitar as a quiet comfort interaction before Relay so it carries memory instead of exposition."
 
+> **Dev:** "Can the Guitar Farewell show what happened to the residents?"
+> **Domain expert:** "Yes — use a brief **Living Proof Montage** of resident/world changes, not a full recap."
+
 > **Dev:** "Can the guitar come from a concert problem?"
 > **Domain expert:** "Yes — use the **Concert Crossing Beat** to earn the guitar through a tiny performance/help moment, then let Cicka Home turn it into comfort."
+
+> **Dev:** "Does the dance festival happen at night?"
+> **Domain expert:** "Yes — but the required route beat is the **Opening Dance Shuttle Beat**, where daytime setup opens one last daylight ride to Relay before the night festival begins."
+
+> **Dev:** "Is the driver's crush the DJ?"
+> **Domain expert:** "No — she is the **Last-Stop Operations Helper**, a visible plaza worker whose setup checklist and service-road handoff make her role immediately readable."
+
+> **Dev:** "How do we help the shy operations helper without therapizing her?"
+> **Domain expert:** "Use the **Operations Handoff Check**: prove the setup is ready and let a trusted resident keep watch so she can enjoy the night."
+
+> **Dev:** "How do we help the driver if he cannot dance?"
+> **Domain expert:** "Use **One-Step Practice**: he learns one tiny private step, enough to ask without pretending he is suddenly good."
+
+> **Dev:** "How does he actually ask her to dance?"
+> **Domain expert:** "Use the **Folded Song Request**: a small paper invitation at the operations table, not a public confession."
+
+> **Dev:** "How does the road physically open after the cute paper moment?"
+> **Domain expert:** "Use the **Setup Clearance Walkthrough** so visible setup details clear the service lane for the last daylight shuttle."
+
+> **Dev:** "Do we make the player manually move every chair?"
+> **Domain expert:** "No — present the **Setup Clearance Walkthrough** as a **Prompt-Driven Playable Montage** with a few authored interaction snaps."
+
+> **Dev:** "Can Cicka hang out with another cat during the dance setup?"
+> **Domain expert:** "Yes — use the **Unnamed Counterpart Cat** for implied continuity, but do not spend Micka before the post-ending return."
+
+> **Dev:** "Should we design the other cat now?"
+> **Domain expert:** "Only at silhouette/color level: a pale or light-ink contrast to Cicka, with no name, dialogue, or parentage reveal."
 
 > **Dev:** "Does every obstacle need a mini-game?"
 > **Domain expert:** "No — the first ending path should work through residents, conversations, collection, and world changes; **Mini-Game Entrances** can add alternate paths or side fun."
@@ -314,3 +422,12 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   player, not with the player.
 - "hint" from Cicka means subtle attention guidance through staging or reaction,
   not explicit objective text like "go fix the bridge."
+- "last dance" previously meant an after-festival closure gate; resolved: use
+  **Opening Dance Shuttle Beat** for the final dance-festival route beat.
+- "festival helper" is too generic for the driver's colleague; resolved: use
+  **Last-Stop Operations Helper**.
+- "lighthouse" is current story shorthand for the **Relay Spire** as a beacon or
+  overlook; keep docs on **Relay Spire** unless the final landmark is renamed.
+- "another cat" during **Opening Dance Shuttle Beat** means the **Unnamed
+  Counterpart Cat**, not **Micka**, whose first appearance remains after the
+  first-ending return unless that timing is deliberately reopened.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -128,8 +128,11 @@ mini-game's primary toy and input needs.
 _Avoid_: shared overworld movement
 
 **Mini-Game Entrance**:
-An opt-in world attachment that can offer a hobby toy, proof, reward, shortcut,
+An opt-in world attachment that can offer a hobby toy, reward, shortcut,
 alternate solution, or just fun without being required for the core ending path.
+For the current first-ending route, mini-games are optional fun and do not need
+to count as Living Proof; future passes may let them unlock alternate ways to
+finish a level.
 _Avoid_: mandatory arcade gate, generic content silo
 
 **Cicka Home Mutation**:
@@ -336,6 +339,10 @@ _Avoid_: generic fetch quest, public romantic confrontation, puppet-master solve
 A quiet ending gate where the player can physically reach the Relay Spire, but
 the sketchbook cannot send until the route has created enough visible world
 changes, proofs, and Cicka familiarity to make the destination legible.
+For the current first ending, the three required Ridge Areas and their
+Resident/world changes should provide enough Living Proof by themselves.
+Changed Cicka Resting Spots can echo that proof emotionally, but they should
+not be counted as separate proof sources.
 _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 
 ## Relationships
@@ -372,9 +379,10 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - The first ending path should be completable through conversation, collection,
   authored traversal, Ridge Areas, Resident Beats, and world changes without
   requiring full arcade mini-games.
-- **Mini-Game Entrances** can provide optional alternate path unlocks, proof
-  sources, rewards, or pure side fun, but they should not be the default way the
-  core route solves blockers.
+- **Mini-Game Entrances** can provide optional rewards, shortcuts, alternate
+  path unlocks, or pure side fun, but they should not be required Living Proof
+  for the current first ending. Future passes may let them unlock alternate
+  ways to finish a level.
 - **Exploration Traversal** treats jump as non-core for the v0 main path;
   vertical movement should come from **Authored Traversal Interactions** unless
   a future mobility item deliberately changes the route grammar.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -144,7 +144,9 @@ _Avoid_: rhythm UI, fail state, final skill check, objective popup
 
 **Living Proof Montage**:
 A brief Guitar Farewell montage that wordlessly shows the resident help and
-world changes that made the sketchbook ready to send.
+world changes that made the sketchbook ready to send; the Opening Dance image is
+an emotional echo scored by the player's guitar while the actual festival song
+request stays implied and offscreen.
 _Avoid_: full recap, credits roll, visible checklist, objective summary
 
 **Send the Sketchbook Prompt**:
@@ -187,8 +189,10 @@ step so he can offer shared rhythm without pretending to be a good dancer.
 _Avoid_: dance mastery, public embarrassment, required rhythm challenge
 
 **Folded Song Request**:
-The small paper invitation that lets the hill-shuttle driver ask the Last-Stop
-Operations Helper to dance without forcing a public confession.
+The small paper invitation where the hill-shuttle driver requests a simple,
+cute, guitar-friendly song and asks the Last-Stop Operations Helper for one
+dance without forcing a public confession; the exact requested song does not
+need to be shown or heard by the player.
 _Avoid_: love letter, public proposal, player-delivered confession
 
 **Setup Clearance Walkthrough**:
@@ -334,7 +338,8 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   comfort interaction, especially at Cicka Home, so the final Relay Spire use
   feels remembered rather than introduced for drama.
 - The **Guitar Farewell** can include a **Living Proof Montage**, but the montage
-  should stay brief and keep Cicka as the emotional focus.
+  should stay brief and keep Cicka as the emotional focus; the player's guitar
+  is the only music the player needs to hear during the montage.
 - The **Sit and Play Prompt** starts the **Guitar Farewell** at Relay Spire
   without turning it into a rhythm challenge.
 - The **Send the Sketchbook Prompt** should happen after the **Guitar Farewell**,
@@ -360,7 +365,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   public skill test.
 - The **Folded Song Request** connects the two Readiness Favors by letting the
   driver ask through a subtle operations-table object instead of direct public
-  matchmaking.
+  matchmaking; the song should be simple, cute, and guitar-friendly, not locked
+  to bachata or any other specific dance genre, and it can remain unshown and
+  unheard as a specific track.
 - The **Setup Clearance Walkthrough** restores the practical route blocker after
   the romantic connector by making the service lane visibly ready for the last
   daylight shuttle.
@@ -427,6 +434,12 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 > **Dev:** "How does he actually ask her to dance?"
 > **Domain expert:** "Use the **Folded Song Request**: a small paper invitation at the operations table, not a public confession."
 
+> **Dev:** "Does the dance need to be bachata?"
+> **Domain expert:** "No — keep bachata as loose inspiration at most. Canon should use a simple, cute, guitar-friendly requested song so the driver can plausibly dance and the Guitar Farewell montage can carry the same feeling."
+
+> **Dev:** "Is the night festival literally hearing the same guitar song as the Relay farewell?"
+> **Domain expert:** "No — treat it as an emotional echo. The requested festival song stays implied/offscreen; the only song the player needs to hear is the guitar during the **Guitar Farewell**."
+
 > **Dev:** "How does the road physically open after the cute paper moment?"
 > **Domain expert:** "Use the **Setup Clearance Walkthrough** so visible setup details clear the service lane for the last daylight shuttle."
 
@@ -472,6 +485,10 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   not explicit objective text like "go fix the bridge."
 - "last dance" previously meant an after-festival closure gate; resolved: use
   **Opening Dance Shuttle Beat** for the final dance-festival route beat.
+- "bachata" is loose discarded inspiration, not canonical genre; use a simple,
+  cute, guitar-friendly implied request for the **Folded Song Request** while
+  the later **Living Proof Montage** dance image is emotionally scored by the
+  player's guitar.
 - "festival helper" is too generic for the driver's colleague; resolved: use
   **Last-Stop Operations Helper**.
 - "lighthouse" is current story shorthand for the **Relay Spire** as a beacon or

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,25 +70,79 @@ _Avoid_: blockout map, minimap
 
 **Exploration Map**:
 The shared side-view route outside opt-in mini-games where the player explores,
-returns to Cicka, finds artifacts, and reads the world through shortcuts and
-changed landmarks.
+encounters Cicka, helps residents, finds artifacts, and reads the world through
+shortcuts and changed landmarks.
 _Avoid_: mini-game arena, old modal overworld
 
+**Sketchbook Neighborhood**:
+The intended first-read fantasy of the Exploration Map: an inhabited paper place
+where the player moves toward the Relay Spire by helping tiny residents and
+seeing routes change.
+_Avoid_: metroidvania platforming map, portfolio theme park, static building row
+
 **Exploration Traversal**:
-The common forgiving movement model for the Exploration Map, such as walking,
-jumping, ramps, climbs, drops, mantles, and recovery helpers.
-_Avoid_: mini-game controls, one-off arcade movement
+The common forgiving movement model for the Exploration Map, centered on
+walking and authored traversal interactions such as climb, descend, drop, lift,
+bridge, enter, inspect, and recovery helpers.
+_Avoid_: mini-game controls, one-off arcade movement, required jump platforming
+
+**Authored Traversal Interaction**:
+A local route action that moves the player through a designed object or route
+change instead of requiring freeform jump execution.
+_Avoid_: precision jump, hidden platforming verb, generic movement upgrade
 
 **Mini-Game Movement System**:
 A scene-owned movement model for an opt-in mini-game, tuned around that
 mini-game's primary toy and input needs.
 _Avoid_: shared overworld movement
 
+**Mini-Game Entrance**:
+An opt-in world attachment that can offer a hobby toy, proof, reward, shortcut,
+alternate solution, or just fun without being required for the core ending path.
+_Avoid_: mandatory arcade gate, generic content silo
+
 **Cicka Home Mutation**:
 A Ridge-owned declaration that a durable progress source can change Cicka Home,
 such as adding a Stampede note or opening a return fold. Declarations without a
 real progress source stay typed as future promises instead of rendering.
 _Avoid_: stored sticker state, generic landmark memory
+
+**Cicka Field Presence**:
+An authored Cicka appearance inside the Exploration Map where she observes,
+loafs, points attention, or quietly reacts at a meaningful route beat through
+subtle posture, placement, and tiny reactions instead of explicit instructions.
+_Avoid_: companion AI, quest marker, follower pet, objective dispenser
+
+**Cicka Threshold Farewell**:
+The first ending beat where Cicka accompanies the player to the Relay Spire
+threshold, then departs somewhere the player cannot follow.
+_Avoid_: literal death scene, grief monologue, Cicka leaving with the player
+
+**Guitar Farewell**:
+The final shared Cicka moment where the player plays guitar for her at the Relay
+Spire, echoing an established comfort interaction from Cicka Home and the Ridge.
+_Avoid_: generic music mini-game, melodrama, one-off ending prop
+
+**Concert Crossing Beat**:
+A mid-route Resident Room Beat where a blocked concert/traffic crossing becomes
+the way the player earns the guitar through a small music performance problem.
+_Avoid_: joke-only drunk musician, random item pickup, final-farewell skill gate
+
+**Resident Help Beat**:
+A small Sketchbook Neighborhood progression beat where the player helps a tiny
+resident with a concrete local problem and the world visibly changes in return.
+_Avoid_: quest chain, dialogue tree, generic fetch quest, portfolio sales pitch
+
+**Resident Room Beat**:
+An authored Room Beat centered on one required resident problem, its local
+characters, possible solutions, Cicka field presence, and visible route change.
+_Avoid_: Phaser scene, isolated quest room, dialogue hub
+
+**Living Proof Gate**:
+A quiet ending gate where the player can physically reach the Relay Spire, but
+the sketchbook cannot send until the route has created enough visible world
+changes, proofs, and Cicka familiarity to make the destination legible.
+_Avoid_: boss gate, precision climb gate, arbitrary content checklist
 
 ## Relationships
 
@@ -111,12 +165,50 @@ _Avoid_: stored sticker state, generic landmark memory
 - A **Grid Cell** gives **Room Beats** their scale in the **Ridge Blockout**.
 - A **Ridge Blockout** is replaced or enriched by final assets after traversal feels good.
 - The current **Ridge Blockout** is the prototype **Exploration Map**.
+- The **Exploration Map** should read first as a **Sketchbook Neighborhood**,
+  with shortcut relief supporting that fantasy instead of required precision
+  platforming defining it.
 - The **Exploration Map** uses **Exploration Traversal**.
 - A mini-game may use its own **Mini-Game Movement System** instead of
   **Exploration Traversal**.
+- The first ending path should be completable through conversation, collection,
+  authored traversal, Resident Room Beats, and world changes without requiring
+  full arcade mini-games.
+- **Mini-Game Entrances** can provide optional alternate path unlocks, proof
+  sources, rewards, or pure side fun, but they should not be the default way the
+  core route solves blockers.
+- **Exploration Traversal** treats jump as non-core for the v0 main path;
+  vertical movement should come from **Authored Traversal Interactions** unless
+  a future mobility item deliberately changes the route grammar.
 - **Cicka Home Mutations** resolve compiled Ridge facts against durable Ridge
   progress; active mutations can render Cicka Home changes, while unresolved
   future mutations remain data only.
+- **Cicka Field Presence** complements **Cicka Home** by making Cicka recur
+  across the **Sketchbook Neighborhood** without turning her into a follower,
+  solver, vendor, or quest board.
+- A **Resident Help Beat** may use **Cicka Field Presence** to draw attention to
+  a route blocker, but the solution should come from a resident, artifact,
+  mini-game clear, or visible environment change.
+- Required **Resident Help Beats** should include **Cicka Field Presence**, but
+  Cicka's role can shift from obvious attention cue to changed-object observer
+  to quiet trust marker.
+- A required **Resident Help Beat** usually belongs to one **Resident Room Beat**;
+  that room beat can include multiple residents, optional interactions, and
+  alternate solutions without becoming a separate Phaser scene.
+- The **Cicka Threshold Farewell** resolves Cicka's recurring field guidance
+  without closing the **Sketchbook Neighborhood**; the Ridge remains replayable
+  with Cicka's final mark or absence-shaped changes.
+- The **Guitar Farewell** should be established before the ending as a repeatable
+  comfort interaction, especially at Cicka Home, so the final Relay Spire use
+  feels remembered rather than introduced for drama.
+- The **Concert Crossing Beat** can teach the guitar through a small
+  Guitar-Hero-like mini-game, but the **Guitar Farewell** itself should remain a
+  cozy remembrance interaction rather than an arcade pass/fail challenge.
+- Required **Resident Room Beats** that contain arcade-like interactions should
+  also have a non-arcade fallback through conversation, collection, practice, or
+  a forgiving auto-resolve path.
+- A **Living Proof Gate** blocks the **Cicka Threshold Farewell** emotionally and
+  semantically, not by making the Relay Spire physically unreachable.
 - The old Overworld and Hobbies scenes are transitional surfaces. Long-term,
   their best content should fold into the **Exploration Map** as artifacts,
   entrances, Cicka reactions, Basement/Potassium paths, and mini-game props.
@@ -126,6 +218,52 @@ _Avoid_: stored sticker state, generic landmark memory
 > **Dev:** "Should we change the Stampede room art now?"
 > **Domain expert:** "No, first update the **Room Beat** in the **Typed Ridge Blockout Source** so the **Ridge Blockout** proves the shortcut back to Cicka."
 
+> **Dev:** "Should the player always return to Cicka Home after a blocked bridge?"
+> **Domain expert:** "No — use **Cicka Field Presence** at the bridge to draw attention, while **Cicka Home Mutations** keep home as the place that remembers durable progress."
+
+> **Dev:** "Can Cicka tell the player to fix the bridge?"
+> **Domain expert:** "No — let **Cicka Field Presence** make the bridge feel suspicious, then resolve it as a **Resident Help Beat** with a visible route change."
+
+> **Dev:** "Does every resident need to solve a barricade?"
+> **Domain expert:** "No — required **Resident Help Beats** change routes, while optional residents can offer mini-games, atmosphere, jokes, or quiet company."
+
+> **Dev:** "Should each resident scene be a Phaser scene?"
+> **Domain expert:** "No — call it a **Resident Room Beat** unless it truly needs a separate runtime scene."
+
+> **Dev:** "Does Cicka leave with the player at the ending?"
+> **Domain expert:** "No — the **Cicka Threshold Farewell** means she walks with the player to the threshold, then departs somewhere the player cannot follow."
+
+> **Dev:** "Can the final Cicka beat be the player playing guitar for her?"
+> **Domain expert:** "Yes — make it the **Guitar Farewell**, but establish guitar as a quiet comfort interaction before Relay so it carries memory instead of exposition."
+
+> **Dev:** "Can the guitar come from a concert problem?"
+> **Domain expert:** "Yes — use the **Concert Crossing Beat** to earn the guitar through a tiny performance/help moment, then let Cicka Home turn it into comfort."
+
+> **Dev:** "Does every obstacle need a mini-game?"
+> **Domain expert:** "No — the first ending path should work through residents, conversations, collection, and world changes; **Mini-Game Entrances** can add alternate paths or side fun."
+
+> **Dev:** "Should the Relay Spire require a boss or hard climb?"
+> **Domain expert:** "No — use a **Living Proof Gate** so the player can reach it early but cannot send until the path has created enough visible change and emotional tie to Cicka."
+
 ## Flagged Ambiguities
 
 - "map" can mean **Topology Map**, **Ridge Blockout**, or final art; resolved by naming the layer explicitly.
+- "scene" can mean a design beat or a Phaser runtime scene; use **Resident Room
+  Beat** for required resident progression spaces unless a separate runtime
+  scene is deliberately needed.
+- "metroidvania" is inspiration for shortcut relief, route memory, and changed
+  landmarks, not a promise of required ability-gated precision platforming on
+  the main **Exploration Map** route.
+- "no jump" means no required jump button for v0 **Exploration Traversal**, not
+  a ban on jump-like toys inside opt-in mini-games, future items, or separate
+  **Mini-Game Movement Systems**.
+- "slope" or "ramp" should not describe required v0 **Exploration Traversal**;
+  use object-like route language such as stairs, cords, bridges, lifts, shelves,
+  and soft drops. `ramp` may remain an internal connector label where needed.
+- "Cicka follows the player" means authored **Cicka Field Presence** at route
+  beats, not continuous companion following or autonomous navigation.
+- "Cicka departs with us" means **Cicka Threshold Farewell**, where she
+  accompanies the player to the Relay Spire threshold and then leaves from the
+  player, not with the player.
+- "hint" from Cicka means subtle attention guidance through staging or reaction,
+  not explicit objective text like "go fix the bridge."

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -143,14 +143,31 @@ _Avoid_: stored sticker state, generic landmark memory
 **Cicka Resting Spot**:
 A small local Cicka perch, loafing place, or quiet seat inside a required Ridge
 Area where Cicka can be present without creating a central hub;
-after the guitar is earned, it can also host a tiny comfort-play interaction.
-_Avoid_: Cicka Home hub, quest board, required backtracking checkpoint, inventory stash
+in the initial route it is mostly visual and has no dedicated prompt, while
+later affection passes can add tiny optional comfort interactions such as
+sitting together, petting, lap loafing, or playing guitar nearby.
+Each v0 spot should support two tiny visual states: before its area beat
+resolves, Cicka uses the spot to draw attention; after resolution, the spot
+settles into a calmer pose, tiny mark, or changed prop.
+_Avoid_: Cicka Home hub, quest board, required backtracking checkpoint, inventory stash, required affection system, v0 interaction node
+
+**Bridge Resting Spot**:
+The Cicka Resting Spot in the Bridge Area, staged near the unsafe crossing,
+blank plan, or newly completed bridge so Cicka can quietly point attention to
+the first resident-help route change.
+_Avoid_: tutorial UI marker, required backtracking perch
 
 **Concert Resting Spot**:
-The Cicka Resting Spot in the Concert Crossing area, where the guitar first
-becomes a comfort object and where the Open Ridge Return State can show one
-quiet empty-spot echo after the farewell.
+The Cicka Resting Spot in the Concert Area, where the guitar first becomes a
+comfort object and where the Open Ridge Return State can show one quiet
+empty-spot echo after the farewell.
 _Avoid_: abandoned guitar, shrine, required sad objective
+
+**Dance Festival Resting Spot**:
+The Cicka Resting Spot in the Dance Festival Area, staged near the operations
+table, shuttle step, lantern crates, or service gate so Cicka can observe the
+last social handoff before the daylight ride to Relay.
+_Avoid_: route gate, dialogue station, confirmed parentage scene
 
 **Cicka Field Presence**:
 An authored Cicka appearance inside the Exploration Map where she observes,
@@ -174,8 +191,8 @@ _Avoid_: closed ending, sad objective, immediate replacement reveal, scattered s
 
 **Guitar Farewell**:
 The final shared Cicka moment where the player plays guitar for her at the Relay
-Spire, echoing established comfort interactions from Cicka Resting Spots across
-the Ridge.
+Spire, echoing the visual presence, tiny marks, and accumulated memory from
+Cicka Resting Spots across the Ridge.
 _Avoid_: generic music mini-game, melodrama, one-off ending prop
 
 **Sit and Play Prompt**:
@@ -372,9 +389,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   Cicka's role can shift from obvious attention cue to changed-object observer
   to quiet trust marker.
 - Each required **Ridge Area** should have one local **Cicka Resting Spot**: a
-  bridge perch near the crossing, a concert listening corner, and a
-  dance-festival loafing spot near operations or the service gate. These spots
-  are local emotional anchors, not hubs.
+  **Bridge Resting Spot** near the crossing, **Concert Resting Spot** as a
+  listening corner, and **Dance Festival Resting Spot** near operations or the
+  service gate. These spots are local emotional anchors, not hubs.
 - A required **Resident Help Beat** usually belongs to one **Resident Beat**
   inside a **Ridge Area**; that area can include multiple residents, interiors,
   optional interactions, and alternate solutions without becoming one Phaser
@@ -401,9 +418,11 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   the **Concert Resting Spot**, and Micka still delayed until the later
   post-ending trigger. The echo should be an empty usual spot with one small
   paw/page mark, not the guitar left behind.
-- The **Guitar Farewell** should be established before the ending as a repeatable
-  comfort interaction at local **Cicka Resting Spots**, so the final Relay Spire
-  use feels remembered rather than introduced for drama.
+- The **Guitar Farewell** should be established before the ending through the
+  guitar's story role and visual Cicka Resting Spot presence. The initial route
+  does not need repeatable resting-spot interactions; sitting together, petting,
+  lap loafing, or playing guitar at local spots can wait for a later affection
+  pass.
 - The **Guitar Farewell** can include a **Living Proof Montage**, but the montage
   should stay brief and keep Cicka as the emotional focus; the player's guitar
   is the only music the player needs to hear during the montage.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -148,7 +148,9 @@ later affection passes can add tiny optional comfort interactions such as
 sitting together, petting, lap loafing, or playing guitar nearby.
 Each v0 spot should support two tiny visual states: before its area beat
 resolves, Cicka uses the spot to draw attention; after resolution, the spot
-settles into a calmer pose, tiny mark, or changed prop.
+settles immediately into a calmer pose, tiny mark, or changed prop. The Guitar
+Farewell montage can revisit these already-changed states, but should not be
+the first time the player sees them.
 _Avoid_: Cicka Home hub, quest board, required backtracking checkpoint, inventory stash, required affection system, v0 interaction node
 
 **Bridge Resting Spot**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -123,18 +123,40 @@ _Avoid_: companion AI, quest marker, follower pet, objective dispenser
 
 **Cicka Threshold Farewell**:
 The first ending beat where Cicka accompanies the player to the Relay Spire
-threshold, then departs somewhere the player cannot follow.
+threshold, looks back, leaves one final paw/page mark, then slips into a page
+fold or light beyond the player's path.
 _Avoid_: literal death scene, grief monologue, Cicka leaving with the player
+
+**Open Ridge Return State**:
+The immediate post-ending Ridge state where the world remains playable with
+Cicka's final mark and absence-shaped changes before any later Micka trigger.
+_Avoid_: closed ending, sad objective, immediate replacement reveal
 
 **Guitar Farewell**:
 The final shared Cicka moment where the player plays guitar for her at the Relay
 Spire, echoing an established comfort interaction from Cicka Home and the Ridge.
 _Avoid_: generic music mini-game, melodrama, one-off ending prop
 
+**Sit and Play Prompt**:
+The final Relay Spire interaction that starts the Guitar Farewell when the
+player chooses to sit near Cicka and play guitar.
+_Avoid_: rhythm UI, fail state, final skill check, objective popup
+
 **Living Proof Montage**:
 A brief Guitar Farewell montage that wordlessly shows the resident help and
 world changes that made the sketchbook ready to send.
 _Avoid_: full recap, credits roll, visible checklist, objective summary
+
+**Send the Sketchbook Prompt**:
+The post-Guitar Farewell Relay Spire interaction that begins the Cicka Threshold
+Farewell after the player has shared the quiet song with Cicka.
+_Avoid_: automatic send, guitar-as-send-button, boss gate, extra skill check
+
+**Relay Blue Hour**:
+The final send lighting state after the Guitar Farewell, where Relay has moved
+from sunset warmth into blue-hour threshold light while the night festival begins
+elsewhere.
+_Avoid_: full night farewell, hard time cut, cold death-coded darkness
 
 **Concert Crossing Beat**:
 A mid-route Resident Room Beat where a blocked concert/traffic crossing becomes
@@ -178,6 +200,12 @@ _Avoid_: long chore list, black-screen-only solve, abstract emotional unlock
 A compact presentation pattern where the player triggers a few authored
 interactions that snap through visible work and a time-of-day shift.
 _Avoid_: pure cutscene, full manual chores, repeated object hauling
+
+**Short Threshold Transition**:
+A brief non-controllable passage that carries the player from a solved route
+beat into the next playable emotional threshold, often through a line, sound
+cue, blackout, and respawn.
+_Avoid_: driving mini-game, long travel scene, instant unexplained teleport
 
 **Unnamed Counterpart Cat**:
 The non-Micka local cat who may quietly interact with Cicka during the Opening
@@ -296,11 +324,25 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - The **Cicka Threshold Farewell** resolves Cicka's recurring field guidance
   without closing the **Sketchbook Neighborhood**; the Ridge remains replayable
   with Cicka's final mark or absence-shaped changes.
+- The **Cicka Threshold Farewell** departure should be physical and mostly
+  silent: walk together, pause, look back, final mark, then page-fold/light
+  departure; any meow or translated fragment should stay tiny and optional.
+- The immediate return after the **Cicka Threshold Farewell** should be the
+  **Open Ridge Return State**: replayable, quiet, and absence-marked, with Micka
+  still delayed until the later post-ending trigger.
 - The **Guitar Farewell** should be established before the ending as a repeatable
   comfort interaction, especially at Cicka Home, so the final Relay Spire use
   feels remembered rather than introduced for drama.
 - The **Guitar Farewell** can include a **Living Proof Montage**, but the montage
   should stay brief and keep Cicka as the emotional focus.
+- The **Sit and Play Prompt** starts the **Guitar Farewell** at Relay Spire
+  without turning it into a rhythm challenge.
+- The **Send the Sketchbook Prompt** should happen after the **Guitar Farewell**,
+  keeping the final send as an active player choice while preserving the song as
+  comfort rather than a send button.
+- The Relay ending should use sunset for **Sit and Play Prompt**, then
+  **Relay Blue Hour** for **Send the Sketchbook Prompt**; the **Living Proof
+  Montage** can show the night festival beginning elsewhere.
 - The **Concert Crossing Beat** can teach the guitar through a small
   Guitar-Hero-like mini-game, but the **Guitar Farewell** itself should remain a
   cozy remembrance interaction rather than an arcade pass/fail challenge.
@@ -329,6 +371,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   a quiet threshold observer near the operations table or service gate; the
   **Unnamed Counterpart Cat** can add texture and imply future continuity, but
   it should stay visual-only and should not be named or treated as Micka.
+- The ride from Last-Stop Plaza to Relay should be a **Short Threshold
+  Transition**, not a controllable driving scene; a driver line, vehicle-start
+  sound, brief blackout, and Relay spawn are enough.
 - Required **Resident Room Beats** that contain arcade-like interactions should
   also have a non-arcade fallback through conversation, collection, practice, or
   a forgiving auto-resolve path.
@@ -393,6 +438,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 
 > **Dev:** "Should we design the other cat now?"
 > **Domain expert:** "Only at silhouette/color level: a pale or light-ink contrast to Cicka, with no name, dialogue, or parentage reveal."
+
+> **Dev:** "Do we play the shuttle ride?"
+> **Domain expert:** "No — use a **Short Threshold Transition**: driver line, vehicle-start sound, brief blackout, then control resumes at Relay."
 
 > **Dev:** "Does every obstacle need a mini-game?"
 > **Domain expert:** "No — the first ending path should work through residents, conversations, collection, and world changes; **Mini-Game Entrances** can add alternate paths or side fun."

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -165,6 +165,13 @@ answers from the directly involved residents, then learns the fuller social
 context by asking nearby locals who have partial observations.
 _Avoid_: omniscient NPC reveal, instant confession, hidden-state guessing
 
+**Readiness Favor**:
+A small personal or practical favor that helps a resident become ready to take
+the next route-solving action without the player exposing private feelings or
+forcing a confession. It should reveal character and reduce a believable
+insecurity, not act as arbitrary busywork.
+_Avoid_: generic fetch quest, public romantic confrontation, puppet-master solve
+
 **Living Proof Gate**:
 A quiet ending gate where the player can physically reach the Relay Spire, but
 the sketchbook cannot send until the route has created enough visible world
@@ -233,6 +240,8 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   emotional stakes when a beat needs to feel lived-in and grounded.
 - A **Triangulated Discovery Flow** can reveal a resident relationship without
   making the player or one NPC magically know private feelings.
+- A **Readiness Favor** can bridge the gap between knowing what a resident wants
+  and helping them act without making the player directly manage their feelings.
 - The **Cicka Threshold Farewell** resolves Cicka's recurring field guidance
   without closing the **Sketchbook Neighborhood**; the Ridge remains replayable
   with Cicka's final mark or absence-shaped changes.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,6 +71,22 @@ residents, props, Cicka Resting Spots, mini-game entrances, and one or more
 runtime Phaser Scenes.
 _Avoid_: hub, Phaser scene, single room, isolated mini-game silo
 
+**Bridge Area**:
+The first required Ridge Area. It contains the Blueprint Bridge Resident Beat
+and teaches that helping a resident can visibly change the route.
+_Avoid_: calling the whole area Blueprint Bridge, bridge hub
+
+**Concert Area**:
+The middle required Ridge Area. It contains the Concert Crossing Beat, the
+Concert Resting Spot, and the guitar's first entrusted use.
+_Avoid_: calling the whole area Concert Crossing, music hub
+
+**Dance Festival Area**:
+The final required Ridge Area at the foot of the Relay hill. It contains the
+Opening Dance Shuttle Beat and clears the last daylight ride to Relay before
+the night festival begins.
+_Avoid_: calling the whole area Opening Dance Shuttle, final hub
+
 **Topology Map**:
 A high-level route graph showing room beats, locks, shortcuts, and return paths.
 _Avoid_: blockout map, minimap
@@ -551,6 +567,10 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - "Resident Room Beat" is retired terminology; use **Ridge Area** for
   bridge/concert/dance chunks and **Resident Beat** for their authored resident
   problems.
+- "bridge/concert/dance festival" names the **Bridge Area**, **Concert Area**,
+  or **Dance Festival Area**; **Blueprint Bridge**, **Concert Crossing Beat**,
+  and **Opening Dance Shuttle Beat** name the Resident Beats inside those
+  areas.
 - "metroidvania" is inspiration for shortcut relief, route memory, and changed
   landmarks, not a promise of required ability-gated precision platforming on
   the main **Exploration Map** route.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,13 @@ _Avoid_: runtime-only validation, informal parser convention
 A named playable region with a traversal purpose, environment identity, and links to other room beats.
 _Avoid_: scene, screen, box
 
+**Ridge Area**:
+A logical section of the Ridge route, such as the Bridge Area, Concert Area, or
+Dance Festival Area. A Ridge Area can contain exterior space, interiors,
+residents, props, Cicka Resting Spots, mini-game entrances, and one or more
+runtime Phaser Scenes.
+_Avoid_: hub, Phaser scene, single room, isolated mini-game silo
+
 **Topology Map**:
 A high-level route graph showing room beats, locks, shortcuts, and return paths.
 _Avoid_: blockout map, minimap
@@ -110,10 +117,24 @@ alternate solution, or just fun without being required for the core ending path.
 _Avoid_: mandatory arcade gate, generic content silo
 
 **Cicka Home Mutation**:
-A Ridge-owned declaration that a durable progress source can change Cicka Home,
-such as adding a Stampede note or opening a return fold. Declarations without a
-real progress source stay typed as future promises instead of rendering.
+A current Ridge proof-of-concept declaration that a durable progress source can
+change Cicka Home, such as adding a Stampede note or opening a return fold.
+Declarations without a real progress source stay typed as future promises
+instead of rendering. In the newer linear story route, this should become a
+compatibility detail or be replaced by local Cicka Resting Spot state.
 _Avoid_: stored sticker state, generic landmark memory
+
+**Cicka Resting Spot**:
+A small local Cicka perch, loafing place, or quiet seat inside a required Ridge
+Area where Cicka can be present without creating a central hub;
+after the guitar is earned, it can also host a tiny comfort-play interaction.
+_Avoid_: Cicka Home hub, quest board, required backtracking checkpoint, inventory stash
+
+**Concert Resting Spot**:
+The Cicka Resting Spot in the Concert Crossing area, where the guitar first
+becomes a comfort object and where the Open Ridge Return State can show one
+quiet empty-spot echo after the farewell.
+_Avoid_: abandoned guitar, shrine, required sad objective
 
 **Cicka Field Presence**:
 An authored Cicka appearance inside the Exploration Map where she observes,
@@ -124,17 +145,21 @@ _Avoid_: companion AI, quest marker, follower pet, objective dispenser
 **Cicka Threshold Farewell**:
 The first ending beat where Cicka accompanies the player to the Relay Spire
 threshold, looks back, leaves one final paw/page mark, then slips into a page
-fold or light beyond the player's path.
-_Avoid_: literal death scene, grief monologue, Cicka leaving with the player
+fold or light beyond the player's path without translated farewell text in the
+initial version.
+_Avoid_: literal death scene, grief monologue, Cicka leaving with the player, written goodbye
 
 **Open Ridge Return State**:
-The immediate post-ending Ridge state where the world remains playable with
-Cicka's final mark and absence-shaped changes before any later Micka trigger.
-_Avoid_: closed ending, sad objective, immediate replacement reveal
+The immediate post-ending Ridge state where the world remains playable with the
+canonical final mark at the Relay threshold and one quiet echo at the Concert
+Resting Spot before any later Micka trigger; the echo should read as an empty
+usual spot with one small paw/page mark, not the player's guitar left behind.
+_Avoid_: closed ending, sad objective, immediate replacement reveal, scattered sadness marks, abandoned inventory
 
 **Guitar Farewell**:
 The final shared Cicka moment where the player plays guitar for her at the Relay
-Spire, echoing an established comfort interaction from Cicka Home and the Ridge.
+Spire, echoing established comfort interactions from Cicka Resting Spots across
+the Ridge.
 _Avoid_: generic music mini-game, melodrama, one-off ending prop
 
 **Sit and Play Prompt**:
@@ -161,12 +186,12 @@ elsewhere.
 _Avoid_: full night farewell, hard time cut, cold death-coded darkness
 
 **Concert Crossing Beat**:
-A mid-route Resident Room Beat where a blocked concert/traffic crossing becomes
+A mid-route Resident Beat where a blocked concert/traffic crossing becomes
 the way the player earns the guitar through a small music performance problem.
 _Avoid_: joke-only drunk musician, random item pickup, final-farewell skill gate
 
 **Opening Dance Shuttle Beat**:
-A final-route Resident Room Beat where afternoon festival setup blocks the Relay
+A final-route Resident Beat where afternoon festival setup blocks the Relay
 hill service road until the player helps prepare the night dance and catches the
 last daylight shuttle to the Relay Spire.
 _Avoid_: Last Dance, Final Shuttle Hold, after-festival closure gate
@@ -182,6 +207,12 @@ The Opening Dance facilitator who teaches the hill-shuttle driver one private
 step and covers the operations watch so the Last-Stop Operations Helper can
 enjoy the night dance.
 _Avoid_: romance target, competition judge, extra route gate, new protagonist
+
+**Role-First Character Labels**:
+Placeholder character labels that describe the resident's job in the beat before
+a later naming pass, such as hill-shuttle driver, Last-Stop Operations Helper,
+and Dance Teacher.
+_Avoid_: premature proper names, joke aliases, final character names before role clarity
 
 **Operations Handoff Check**:
 A Readiness Favor where the player helps the Last-Stop Operations Helper prove
@@ -233,21 +264,22 @@ A small Sketchbook Neighborhood progression beat where the player helps a tiny
 resident with a concrete local problem and the world visibly changes in return.
 _Avoid_: quest chain, dialogue tree, generic fetch quest, portfolio sales pitch
 
-**Resident Room Beat**:
-An authored Room Beat centered on one required resident problem, its local
-characters, possible solutions, Cicka field presence, and visible route change.
-_Avoid_: Phaser scene, isolated quest room, dialogue hub
+**Resident Beat**:
+An authored resident problem/story sequence inside a Ridge Area, including its
+local characters, possible solutions, Cicka field presence, and visible route
+change.
+_Avoid_: Phaser scene, isolated quest room, dialogue hub, whole area name
 
 **Recoverable Conversation Choice**:
-A dialogue choice inside a Resident Room Beat that can change tone, trust,
+A dialogue choice inside a Resident Beat that can change tone, trust,
 order, optional rewards, or temporary awkwardness without permanently blocking
 the first ending. A failed or clumsy choice should create an in-world recovery
 path rather than a dead end.
 _Avoid_: permanent fail state, gotcha dialogue, illusion-only choice
 
 **Practical Wayfinding Loop**:
-A Resident Room Beat discovery pattern where the player first learns a route
-problem through signs, blocked paths, local roles, and travel questions before
+A Resident Beat discovery pattern where the player first learns a route problem
+through signs, blocked paths, local roles, and travel questions before
 uncovering the emotional or character layer underneath.
 _Avoid_: quest-giver monologue, immediate emotional exposition, objective popup
 
@@ -302,30 +334,36 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - A mini-game may use its own **Mini-Game Movement System** instead of
   **Exploration Traversal**.
 - The first ending path should be completable through conversation, collection,
-  authored traversal, Resident Room Beats, and world changes without requiring
-  full arcade mini-games.
+  authored traversal, Ridge Areas, Resident Beats, and world changes without
+  requiring full arcade mini-games.
 - **Mini-Game Entrances** can provide optional alternate path unlocks, proof
   sources, rewards, or pure side fun, but they should not be the default way the
   core route solves blockers.
 - **Exploration Traversal** treats jump as non-core for the v0 main path;
   vertical movement should come from **Authored Traversal Interactions** unless
   a future mobility item deliberately changes the route grammar.
-- **Cicka Home Mutations** resolve compiled Ridge facts against durable Ridge
-  progress; active mutations can render Cicka Home changes, while unresolved
-  future mutations remain data only.
-- **Cicka Field Presence** complements **Cicka Home** by making Cicka recur
-  across the **Sketchbook Neighborhood** without turning her into a follower,
-  solver, vendor, or quest board.
+- **Cicka Home Mutations** are current proof-of-concept data for the old
+  hub-like blockout. The newer linear story route should prefer local
+  **Cicka Resting Spots** unless a future map deliberately restores a central
+  home space.
+- **Cicka Field Presence** complements **Cicka Resting Spots** by making Cicka
+  recur across the **Sketchbook Neighborhood** without turning her into a
+  follower, solver, vendor, or quest board.
 - A **Resident Help Beat** may use **Cicka Field Presence** to draw attention to
   a route blocker, but the solution should come from a resident, artifact,
   mini-game clear, or visible environment change.
 - Required **Resident Help Beats** should include **Cicka Field Presence**, but
   Cicka's role can shift from obvious attention cue to changed-object observer
   to quiet trust marker.
-- A required **Resident Help Beat** usually belongs to one **Resident Room Beat**;
-  that room beat can include multiple residents, optional interactions, and
-  alternate solutions without becoming a separate Phaser scene.
-- **Resident Room Beats** can use **Recoverable Conversation Choices** to make
+- Each required **Ridge Area** should have one local **Cicka Resting Spot**: a
+  bridge perch near the crossing, a concert listening corner, and a
+  dance-festival loafing spot near operations or the service gate. These spots
+  are local emotional anchors, not hubs.
+- A required **Resident Help Beat** usually belongs to one **Resident Beat**
+  inside a **Ridge Area**; that area can include multiple residents, interiors,
+  optional interactions, and alternate solutions without becoming one Phaser
+  scene.
+- **Resident Beats** can use **Recoverable Conversation Choices** to make
   resident help feel authored and personal, but the main ending path should not
   become permanently missable because of one dialogue choice.
 - A **Practical Wayfinding Loop** should introduce route blockers before
@@ -336,16 +374,20 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   and helping them act without making the player directly manage their feelings.
 - The **Cicka Threshold Farewell** resolves Cicka's recurring field guidance
   without closing the **Sketchbook Neighborhood**; the Ridge remains replayable
-  with Cicka's final mark or absence-shaped changes.
+  with Cicka's Relay threshold mark and one Concert Resting Spot echo.
 - The **Cicka Threshold Farewell** departure should be physical and mostly
   silent: walk together, pause, look back, final mark, then page-fold/light
-  departure; any meow or translated fragment should stay tiny and optional.
+  departure. The initial version should use no translated farewell line; a tiny
+  raw meow/chirp sound can remain optional if it supports the staging.
 - The immediate return after the **Cicka Threshold Farewell** should be the
-  **Open Ridge Return State**: replayable, quiet, and absence-marked, with Micka
-  still delayed until the later post-ending trigger.
+  **Open Ridge Return State**: replayable, quiet, and minimally absence-marked,
+  with the canonical final mark at the Relay threshold, one quieter echo at
+  the **Concert Resting Spot**, and Micka still delayed until the later
+  post-ending trigger. The echo should be an empty usual spot with one small
+  paw/page mark, not the guitar left behind.
 - The **Guitar Farewell** should be established before the ending as a repeatable
-  comfort interaction, especially at Cicka Home, so the final Relay Spire use
-  feels remembered rather than introduced for drama.
+  comfort interaction at local **Cicka Resting Spots**, so the final Relay Spire
+  use feels remembered rather than introduced for drama.
 - The **Guitar Farewell** can include a **Living Proof Montage**, but the montage
   should stay brief and keep Cicka as the emotional focus; the player's guitar
   is the only music the player needs to hear during the montage.
@@ -366,6 +408,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - The **Opening Dance Shuttle Beat** centers the hill-shuttle driver and the
   **Last-Stop Operations Helper** as colleagues whose practical work and private
   nervousness both delay the last daylight ride.
+- The hill-shuttle driver, **Last-Stop Operations Helper**, and **Dance Teacher**
+  should use **Role-First Character Labels** until a later character naming pass;
+  their jobs and emotional functions matter more than proper names right now.
 - The **Operations Handoff Check** is the Last-Stop Operations Helper's current
   **Readiness Favor**; the **Dance Teacher** covers the operations watch after
   setup is proven safe, keeping the cast small and letting the helper enjoy the
@@ -393,7 +438,7 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - The ride from Last-Stop Plaza to Relay should be a **Short Threshold
   Transition**, not a controllable driving scene; a driver line, vehicle-start
   sound, brief blackout, and Relay spawn are enough.
-- Required **Resident Room Beats** that contain arcade-like interactions should
+- Required **Resident Beats** that contain arcade-like interactions should
   also have a non-arcade fallback through conversation, collection, practice, or
   a forgiving auto-resolve path.
 - A **Living Proof Gate** blocks the **Cicka Threshold Farewell** emotionally and
@@ -408,7 +453,7 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 > **Domain expert:** "No, first update the **Room Beat** in the **Typed Ridge Blockout Source** so the **Ridge Blockout** proves the shortcut back to Cicka."
 
 > **Dev:** "Should the player always return to Cicka Home after a blocked bridge?"
-> **Domain expert:** "No — use **Cicka Field Presence** at the bridge to draw attention, while **Cicka Home Mutations** keep home as the place that remembers durable progress."
+> **Domain expert:** "No — in the linear story route, use a local **Cicka Resting Spot** and **Cicka Field Presence** at the bridge instead of requiring hub returns."
 
 > **Dev:** "Can Cicka tell the player to fix the bridge?"
 > **Domain expert:** "No — let **Cicka Field Presence** make the bridge feel suspicious, then resolve it as a **Resident Help Beat** with a visible route change."
@@ -417,10 +462,25 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 > **Domain expert:** "No — required **Resident Help Beats** change routes, while optional residents can offer mini-games, atmosphere, jokes, or quiet company."
 
 > **Dev:** "Should each resident scene be a Phaser scene?"
-> **Domain expert:** "No — call it a **Resident Room Beat** unless it truly needs a separate runtime scene."
+> **Domain expert:** "No — call the place a **Ridge Area** and the problem sequence a **Resident Beat**. Use **Phaser Scene** only for runtime implementation."
 
 > **Dev:** "Does Cicka leave with the player at the ending?"
 > **Domain expert:** "No — the **Cicka Threshold Farewell** means she walks with the player to the threshold, then departs somewhere the player cannot follow."
+
+> **Dev:** "Should Cicka's final departure include translated text?"
+> **Domain expert:** "No — the initial **Cicka Threshold Farewell** should be fully nonverbal. Use staging, the final mark, silence, and optionally a tiny raw sound instead of a written goodbye."
+
+> **Dev:** "Where does Cicka's final mark persist after the ending?"
+> **Domain expert:** "Use a minimal **Open Ridge Return State**: the canonical final mark persists at the Relay threshold, with one quieter echo at the **Concert Resting Spot** and no scattershot sad marks."
+
+> **Dev:** "Should the Cicka Resting Spot echo leave the guitar there?"
+> **Domain expert:** "No — the guitar stays with the player. The echo should be the empty usual spot plus one small paw/page mark."
+
+> **Dev:** "Should each bridge/concert/dance area have a small Cicka resting spot?"
+> **Domain expert:** "Yes — give each required **Ridge Area** one local **Cicka Resting Spot**. It keeps Cicka present across a linear route without turning any area into a hub."
+
+> **Dev:** "What should we call the bridge/concert/dance festival chunks?"
+> **Domain expert:** "Use **Ridge Area** for the logical place and **Resident Beat** for the authored problem inside it; reserve **Phaser Scene** for runtime units."
 
 > **Dev:** "Can the final Cicka beat be the player playing guitar for her?"
 > **Domain expert:** "Yes — make it the **Guitar Farewell**, but establish guitar as a quiet comfort interaction before Relay so it carries memory instead of exposition."
@@ -429,7 +489,7 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 > **Domain expert:** "Yes — use a brief **Living Proof Montage** of resident/world changes, not a full recap."
 
 > **Dev:** "Can the guitar come from a concert problem?"
-> **Domain expert:** "Yes — use the **Concert Crossing Beat** to earn the guitar through a tiny performance/help moment, then let Cicka Home turn it into comfort."
+> **Domain expert:** "Yes — use the **Concert Crossing Beat** to earn the guitar through a tiny performance/help moment, then let local **Cicka Resting Spots** turn it into comfort."
 
 > **Dev:** "Does the dance festival happen at night?"
 > **Domain expert:** "Yes — but the required route beat is the **Opening Dance Shuttle Beat**, where daytime setup opens one last daylight ride to Relay before the night festival begins."
@@ -442,6 +502,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 
 > **Dev:** "Who covers the operations watch?"
 > **Domain expert:** "Use the **Dance Teacher**. They already belong in the beat as the gentle facilitator, so they can cover the watch without adding another resident role."
+
+> **Dev:** "Do the driver and Last-Stop Operations Helper need proper names now?"
+> **Domain expert:** "No — use **Role-First Character Labels** for now. Names can wait until their jobs, movement, and emotional function survive a later character pass."
 
 > **Dev:** "How do we help the driver if he cannot dance?"
 > **Domain expert:** "Use **One-Step Practice**: he learns one tiny private step, enough to ask without pretending he is suddenly good."
@@ -482,9 +545,12 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 ## Flagged Ambiguities
 
 - "map" can mean **Topology Map**, **Ridge Blockout**, or final art; resolved by naming the layer explicitly.
-- "scene" can mean a design beat or a Phaser runtime scene; use **Resident Room
-  Beat** for required resident progression spaces unless a separate runtime
-  scene is deliberately needed.
+- "scene" can mean a design beat or a Phaser runtime scene; use **Ridge Area**
+  for the logical place, **Resident Beat** for the authored problem sequence,
+  and **Phaser Scene** for runtime implementation.
+- "Resident Room Beat" is retired terminology; use **Ridge Area** for
+  bridge/concert/dance chunks and **Resident Beat** for their authored resident
+  problems.
 - "metroidvania" is inspiration for shortcut relief, route memory, and changed
   landmarks, not a promise of required ability-gated precision platforming on
   the main **Exploration Map** route.
@@ -509,6 +575,11 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   player's guitar.
 - "festival helper" is too generic for the driver's colleague; resolved: use
   **Last-Stop Operations Helper**.
+- "name" or "alias" for Opening Dance residents should mean a **Role-First
+  Character Label** for now, not a final proper name.
+- "Cicka Home" is a current proof-of-concept/runtime blockout term; the newer
+  linear story route should say **Cicka Resting Spot** unless a central home
+  space is deliberately restored.
 - "lighthouse" is current story shorthand for the **Relay Spire** as a beacon or
   overlook; keep docs on **Relay Spire** unless the final landmark is renamed.
 - "another cat" during **Opening Dance Shuttle Beat** means the **Unnamed

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The goal is to create a place where I can easily surface interesting personal op
 
 **This repository (v3)** is a gamified portfolio: **Phaser** scenes for worlds plus **React** overlays for portfolio, inventory, and scene-local surfaces. Stack: **Vite**, **React 19**, **TypeScript**, **Tailwind CSS v4**. Design direction lives in [`docs/design/style-guide.md`](docs/design/style-guide.md); agent-oriented notes in [`AGENTS.md`](AGENTS.md).
 
+**Current active design slice:** Ridge is in pre-production for the desired route rework. The phase compass is [`docs/game-design/ridge/milestone-plan.md`](docs/game-design/ridge/milestone-plan.md); live PRDs, backlog, and agent-ready briefs stay in GitHub Issues.
+
 **Personal log / opinions by version:** see [`CHANGELOG.md`](CHANGELOG.md) (v1 → v2 → current v3).
 
 ## Development

--- a/docs/adr/0001-ridge-blockout-as-exploration-map-source.md
+++ b/docs/adr/0001-ridge-blockout-as-exploration-map-source.md
@@ -1,14 +1,28 @@
 # Adopt Ridge Blockout As Exploration Map Source Of Truth
 
-Status: accepted; still current after the Ridge architecture-deepening slices.
+Status: accepted for the current/prototype Ridge runtime; superseded as future
+Ridge route canon by the Ridge pre-production plan.
 
-We will treat the typed Ridge Blockout Source as the source of truth for Ridge spatial facts and as the prototype Exploration Map. Exploration Traversal may become the common movement model for non-mini-game exploration, while opt-in mini-games keep their own Mini-Game Movement Systems; the old Overworld and Hobbies scenes remain operational during migration but are transitional long-term because their strongest content should fold into artifacts, entrances, Cicka reactions, Basement/Potassium paths, and mini-game props inside the Exploration Map.
+This ADR explains why the existing Phaser Ridge prototype compiles a typed
+blockout source into spatial facts. It does not require the desired
+Bridge/Concert/Dance/Relay game rework to keep the folded-desk topology,
+Cicka Home hub, or platformer-like traversal. For future Ridge design, start
+from [`../game-design/ridge/README.md`](../game-design/ridge/README.md).
 
-The implemented Ridge direction now compiles blockout source into typed room,
+Within the current/prototype Ridge runtime, we treat the typed Ridge Blockout
+Source as the source of truth for spatial facts and as the prototype Exploration
+Map. Exploration Traversal may become the common movement model for
+non-mini-game exploration, while opt-in mini-games keep their own Mini-Game
+Movement Systems; the old Overworld and Hobbies scenes remain operational
+during migration but are transitional long-term because their strongest content
+should fold into artifacts, entrances, Cicka reactions, Basement/Potassium
+paths, and mini-game props inside the Exploration Map.
+
+The current/prototype Ridge runtime compiles blockout source into typed room,
 route, anchor, shortcut, and home-mutation facts before runtime presentation and
-interaction modules consume it. This deepens the original decision rather than
-superseding it.
+interaction modules consume it. This deepens the original runtime decision
+rather than superseding it.
 
-The active blockout source now lives beside the generated runtime artifact at
+The current/prototype blockout source lives beside the generated runtime artifact at
 `src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts`. The
 language documentation remains in `docs/game-design/ridge/map-language.md`.

--- a/docs/adr/0002-audio-adapter-boundary.md
+++ b/docs/adr/0002-audio-adapter-boundary.md
@@ -1,6 +1,7 @@
 # Keep Audio Behind Scene-Owned Or Shared Adapter Boundaries
 
-Status: accepted for M3 audio planning.
+Status: accepted for current runtime audio ownership. Originated during M3
+audio planning, but the boundary is not M3-specific.
 
 Sketchbook Ridge audio should enter runtime code through explicit Phaser scene
 ownership first, and through a shared audio adapter only after at least two

--- a/docs/adr/0003-ridge-blockout-source-contract.md
+++ b/docs/adr/0003-ridge-blockout-source-contract.md
@@ -1,12 +1,18 @@
 # Adopt A Validated Ridge Blockout Source Contract
 
-Status: accepted.
+Status: accepted for current/prototype Ridge blockout tooling; superseded as
+future Ridge route canon by the Ridge pre-production plan.
 
-Ridge blockout authoring uses an AI-readable typed TypeScript Ridge Blockout
-Source with a build-time Ridge Source Contract. The source remains optimized for
-Danilo and AI level-design agents to read and edit, while a generator validates
-the source and emits a committed typed TypeScript artifact for runtime and
-future editor imports.
+This ADR describes a useful authoring/validation contract for the existing
+Phaser Ridge prototype. It does not decide the final spatial layout, route
+shape, traversal requirements, or area order for the desired
+Bridge/Concert/Dance/Relay rework.
+
+Current/prototype Ridge blockout authoring uses an AI-readable typed TypeScript
+Ridge Blockout Source with a build-time Ridge Source Contract. The source
+remains optimized for Danilo and AI level-design agents to read and edit, while
+a generator validates the source and emits a committed typed TypeScript artifact
+for runtime and prototype/editor imports.
 
 ## Considered Options
 
@@ -27,8 +33,8 @@ not the primary authoring surface.
 
 ## Consequences
 
-- Danilo and AI level-design agents edit the Ridge Blockout Source, not generated
-  TypeScript.
+- For current/prototype blockout work, Danilo and AI level-design agents edit
+  the Ridge Blockout Source, not generated TypeScript.
 - The generator owns the committed `.generated.ts` artifact, and runtime/editor
   code imports that typed artifact.
 - Build, typecheck, or check workflows should fail when the source is structurally

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,18 @@
 # Architecture Decision Records
 
-Durable architecture decisions live here when they exist. It is valid for this directory to contain only this placeholder until a decision is worth recording.
+Durable architecture decisions live here when they exist. Keep ADRs short,
+statused, and scoped to the system they actually decide.
+
+Use ADRs for technical choices that should survive across issues, not for
+active Ridge route design. For Ridge design and planning, start from
+[`../game-design/ridge/README.md`](../game-design/ridge/README.md). Some older
+Ridge ADRs still describe the current Phaser prototype/runtime but do not
+override the Ridge pre-production route.
+
+## Records
+
+| ADR | Current Scope |
+| --- | --- |
+| [`0001-ridge-blockout-as-exploration-map-source.md`](./0001-ridge-blockout-as-exploration-map-source.md) | Current/prototype Ridge blockout runtime only; superseded as future route canon. |
+| [`0002-audio-adapter-boundary.md`](./0002-audio-adapter-boundary.md) | Current audio ownership boundary. |
+| [`0003-ridge-blockout-source-contract.md`](./0003-ridge-blockout-source-contract.md) | Current/prototype Ridge blockout tooling contract only; superseded as future route canon. |

--- a/docs/agents/sketchbook-ridge-team.md
+++ b/docs/agents/sketchbook-ridge-team.md
@@ -20,7 +20,7 @@ and delegate work cleanly.
 Before acting in any team role, read or reference:
 
 - [`docs/game-design/ridge/summit.md`](../game-design/ridge/summit.md)
-- [`docs/game-design/ridge/current-level.md`](../game-design/ridge/current-level.md)
+- [`docs/game-design/ridge/ridge-snapshot.md`](../game-design/ridge/ridge-snapshot.md)
 - [`docs/game-design/ridge/milestone-plan.md`](../game-design/ridge/milestone-plan.md)
 - [`docs/runtime-architecture.md`](../runtime-architecture.md)
 - [`docs/runtime-modes.md`](../runtime-modes.md)
@@ -70,7 +70,7 @@ The Producer also has a repeatable workflow skill:
 The Producer owns:
 
 - current milestone status
-- current Ridge level reality
+- current Ridge snapshot reality
 - next issue selection
 - delegation plan
 - branch and conflict awareness
@@ -81,7 +81,7 @@ The Producer owns:
 The Producer must protect:
 
 - `ridge/summit.md` as the product goal
-- `ridge/current-level.md` as the current level snapshot
+- `ridge/ridge-snapshot.md` as the current Ridge snapshot
 - `ridge/milestone-plan.md` as the milestone and shared-seam map
 - GitHub Issues as the live PRD, backlog, triage, and agent-brief source
 - the Architect's rule: parallelize scene internals, serialize shared seams

--- a/docs/agents/sketchbook-ridge-team.md
+++ b/docs/agents/sketchbook-ridge-team.md
@@ -46,6 +46,10 @@ Role-specific docs:
   [`.agents/skills/playability-tester/SKILL.md`](../../.agents/skills/playability-tester/SKILL.md).
 - Issue planning roles: also read [`docs/agents/issue-tracker.md`](./issue-tracker.md).
 
+Do not start team-role work from Ridge legacy docs, reference packs, research, or
+old map plans unless one of the active source-of-truth docs links there for the
+specific task.
+
 ## Activation Rule
 
 When Danilo asks for the **Producer** or coordinator, respond as **Producer /

--- a/docs/agents/sketchbook-ridge-team.md
+++ b/docs/agents/sketchbook-ridge-team.md
@@ -1,7 +1,11 @@
 # Sketchbook Ridge Agent Team
 
-This document defines lightweight role cards for the Sketchbook Ridge Summit
-planning and implementation team.
+This document defines lightweight role cards for the Sketchbook Ridge
+pre-production and implementation team.
+
+Current Ridge work is pre-production for the desired game rework. The existing
+Phaser Ridge is a legacy prototype/reference unless a task explicitly targets
+current runtime behavior.
 
 Use these roles when Danilo invokes a helper by responsibility, for example:
 
@@ -19,15 +23,21 @@ and delegate work cleanly.
 
 Before acting in any team role, read or reference:
 
+- [`AGENTS.md`](../../AGENTS.md)
 - [`docs/game-design/ridge/README.md`](../game-design/ridge/README.md)
-- [`docs/game-design/ridge/summit.md`](../game-design/ridge/summit.md)
-- [`docs/game-design/ridge/story-level-bible.md`](../game-design/ridge/story-level-bible.md)
-- [`docs/game-design/ridge/areas/README.md`](../game-design/ridge/areas/README.md)
-- [`docs/game-design/ridge/ridge-snapshot.md`](../game-design/ridge/ridge-snapshot.md)
-- [`docs/game-design/ridge/milestone-plan.md`](../game-design/ridge/milestone-plan.md)
-- [`docs/runtime-architecture.md`](../runtime-architecture.md)
-- [`docs/runtime-modes.md`](../runtime-modes.md)
+- the specific issue, artifact, route beat, area, scene, or diff being worked on
 - [`.agents/rules/`](../../.agents/rules/)
+
+Use the Ridge router source matrix to decide whether to read the story bible,
+area docs, open questions, snapshot, milestone plan, reference packs, or legacy
+prototype docs. Do not hard-code a larger document list inside role skills.
+
+For implementation or shipped-behavior work, also read the relevant runtime
+docs from [`AGENTS.md`](../../AGENTS.md), especially
+[`docs/runtime-architecture.md`](../runtime-architecture.md),
+[`docs/runtime-modes.md`](../runtime-modes.md), and
+[`docs/game-design/player-manual.md`](../game-design/player-manual.md) when the
+change touches player-facing behavior.
 
 Role-specific docs:
 
@@ -37,8 +47,9 @@ Role-specific docs:
   only for source rationale, comparison material, or a fresh visual synthesis
   pass. Do not treat provenance reports as current spec.
 - Audio roles: also use
-  [`.agents/skills/audio-designer/SKILL.md`](../../.agents/skills/audio-designer/SKILL.md)
-  and [`docs/game-design/ridge/reference/m3-audio-pack.md`](../game-design/ridge/reference/m3-audio-pack.md).
+  [`.agents/skills/audio-designer/SKILL.md`](../../.agents/skills/audio-designer/SKILL.md).
+  When source material is needed, follow the Ridge router to the relevant
+  reference pack.
 - Story / tone roles: also use
   [`.agents/skills/story-tone-designer/SKILL.md`](../../.agents/skills/story-tone-designer/SKILL.md)
   and relevant narrative research in [`docs/research/`](../research/).
@@ -46,9 +57,9 @@ Role-specific docs:
   [`.agents/skills/playability-tester/SKILL.md`](../../.agents/skills/playability-tester/SKILL.md).
 - Issue planning roles: also read [`docs/agents/issue-tracker.md`](./issue-tracker.md).
 
-Do not start team-role work from Ridge legacy docs, reference packs, research, or
-old map plans unless one of the active source-of-truth docs links there for the
-specific task.
+Do not start team-role work from Ridge legacy docs, reference packs, research,
+or old map plans unless the Ridge router or another active source-of-truth doc
+links there for the specific task.
 
 ## Activation Rule
 
@@ -88,12 +99,7 @@ The Producer owns:
 The Producer must protect:
 
 - `ridge/README.md` as the Ridge source-of-truth router and status matrix
-- `ridge/summit.md` as the product goal
-- `ridge/story-level-bible.md` as the active Bridge / Concert / Dance Festival
-  / Relay route canon
-- `ridge/areas/` as the local source of truth for area-specific Ridge detail
-- `ridge/ridge-snapshot.md` as the current Ridge snapshot
-- `ridge/milestone-plan.md` as the milestone and shared-seam map
+- the source-of-truth ownership described by the Ridge router
 - GitHub Issues as the live PRD, backlog, triage, and agent-brief source
 - the Architect's rule: parallelize scene internals, serialize shared seams
 - Danilo's time and taste
@@ -110,7 +116,7 @@ The Producer should not:
 
 - invent a large new roadmap without checking the milestone plan
 - spawn or suggest many agents before shared seams are stable
-- treat archived competition docs as active design source of truth
+- treat legacy prototype docs as active design source of truth
 - ask Danilo to decide implementation details that agents can safely infer
 
 ## Architect
@@ -167,7 +173,7 @@ The Level Designer owns:
 - route shape
 - pacing
 - landmark clarity
-- opt-in mini-game placement
+- optional mini-game entrance placement
 - first-minute experience
 - return-to-Ridge feel
 
@@ -188,7 +194,8 @@ The Playability Tester also has a repeatable workflow skill:
 
 The Playability Tester owns:
 
-- critical journey confidence across Ridge, mini-games, overlays, and returns
+- critical journey confidence across Ridge, optional mini-games, overlays, and
+  returns
 - route reachability, softlock, mobile input, and scene lifecycle evidence
 - recommending the smallest useful regression, harness, or manual charter
 
@@ -235,7 +242,7 @@ Purpose: keep the fun loops feasible.
 
 The Systems / Production Designer owns:
 
-- mini-game scope
+- optional mini-game scope
 - mobile feasibility
 - progression economy
 - reward shape
@@ -243,8 +250,9 @@ The Systems / Production Designer owns:
 
 The Systems / Production Designer must protect:
 
-- one verb per mini-game
-- Potassium owns ricochet
+- one verb per optional mini-game
+- current prototype mini-games keep their own primary toy unless a rework issue
+  says otherwise
 - no premature generic mini-game framework
 - bridge stores durable rewards, not session internals
 
@@ -293,7 +301,8 @@ Default response shape: use the structured format defined in
 
 ## Audio Designer
 
-Purpose: make the Ridge emotionally sticky and mini-games audibly legible.
+Purpose: make the Ridge emotionally sticky and optional mini-games audibly
+legible.
 
 The Audio Designer also has a repeatable workflow skill:
 
@@ -303,16 +312,16 @@ The Audio Designer owns:
 
 - Ridge audio palette
 - Cicka SFX language
-- Potassium acknowledgement sounds
-- Stampede Sketch prototype audio
-- Telegraph Terrace timing cue design
+- optional mini-game cue palettes
+- current prototype audio surfaces when a task explicitly touches them
+- timing cue design
 - mobile Web Audio asset and timing constraints
 
 The Audio Designer must protect:
 
 - quiet handmade overworld tone
 - no full dynamic score engine in v1
-- no Potassium audio overhaul in v1
+- no legacy prototype audio overhaul unless explicitly requested
 - audio cues support timing but are never the only cue
 - Cicka sounds like a resident, not a cartoon UI effect
 - explicit consent for microphone, voice, cloud-processing, or external

--- a/docs/agents/sketchbook-ridge-team.md
+++ b/docs/agents/sketchbook-ridge-team.md
@@ -19,7 +19,10 @@ and delegate work cleanly.
 
 Before acting in any team role, read or reference:
 
+- [`docs/game-design/ridge/README.md`](../game-design/ridge/README.md)
 - [`docs/game-design/ridge/summit.md`](../game-design/ridge/summit.md)
+- [`docs/game-design/ridge/story-level-bible.md`](../game-design/ridge/story-level-bible.md)
+- [`docs/game-design/ridge/areas/README.md`](../game-design/ridge/areas/README.md)
 - [`docs/game-design/ridge/ridge-snapshot.md`](../game-design/ridge/ridge-snapshot.md)
 - [`docs/game-design/ridge/milestone-plan.md`](../game-design/ridge/milestone-plan.md)
 - [`docs/runtime-architecture.md`](../runtime-architecture.md)
@@ -80,7 +83,11 @@ The Producer owns:
 
 The Producer must protect:
 
+- `ridge/README.md` as the Ridge source-of-truth router and status matrix
 - `ridge/summit.md` as the product goal
+- `ridge/story-level-bible.md` as the active Bridge / Concert / Dance Festival
+  / Relay route canon
+- `ridge/areas/` as the local source of truth for area-specific Ridge detail
 - `ridge/ridge-snapshot.md` as the current Ridge snapshot
 - `ridge/milestone-plan.md` as the milestone and shared-seam map
 - GitHub Issues as the live PRD, backlog, triage, and agent-brief source

--- a/docs/architecture-direction.md
+++ b/docs/architecture-direction.md
@@ -5,6 +5,10 @@ why behind the runtime shape, and the direction future refactors should preserve
 For what exists in code today, treat [`runtime-architecture.md`](runtime-architecture.md),
 `AGENTS.md`, and the scoped `.agents/rules/` files as the operational guidance.
 
+Ridge caveat: architecture notes about the typed Ridge blockout apply to the
+current Phaser prototype/runtime. They do not override the Ridge pre-production
+route in [`game-design/ridge/README.md`](./game-design/ridge/README.md).
+
 ## 1. Architectural Philosophy
 
 This project is built on three core pillars to ensure that adding future complex scenes and overlays does not create technical debt or "God Objects."
@@ -47,7 +51,9 @@ paths, prefer [`runtime-architecture.md`](runtime-architecture.md). When
 proposing future refactors:
 
 - Prefer extending existing lifecycle, bridge, overlay, scene UI, and shared runtime seams instead of re-introducing callback-only scene orchestration, ad-hoc overlay maps, or ad-hoc global state.
-- Keep Ridge spatial truth in typed Ridge blockout source and compiled facts instead of rebuilding parallel parent/route/spatial catalogs.
+- For current/prototype Ridge runtime work, keep spatial truth in the typed
+  Ridge blockout source and compiled facts instead of rebuilding parallel
+  parent/route/spatial catalogs.
 - Introduce shared render helpers only when repeated render policy code appears.
 
 ---

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,6 +1,18 @@
 # Design assets & prompts
 
-Companion to [`style-guide.md`](style-guide.md). The style guide is the source of truth for the visual identity; this file is for asset-generation prompts and other production helpers.
+Companion to [`style-guide.md`](style-guide.md). The style guide is the source
+of truth for the visual identity; this file is for asset-generation prompts and
+other production helpers.
+
+## Folder Contract
+
+- [`style-guide.md`](./style-guide.md) owns the durable Digital Sketchbook
+  visual identity.
+- [`notebook-shell-design-language.md`](./notebook-shell-design-language.md)
+  owns current runtime shell/UI language for notebook-style game scenes and
+  mini-game prototypes.
+- Active Ridge route, area, ending, and Living Proof decisions live under
+  [`../game-design/ridge/`](../game-design/ridge/README.md), not here.
 
 Planning for how generated concepts, prepared runtime candidates, and
 milestone-safe asset adoption are organized lives in

--- a/docs/design/notebook-shell-design-language.md
+++ b/docs/design/notebook-shell-design-language.md
@@ -4,6 +4,12 @@
 > prototypes, Storybook specimens, and runtime profile work; it is not a
 > shipped behavior manual.
 
+Status: current runtime shell/UI guidance. This document can guide notebook
+presentation for current scenes and optional mini-game prototypes, but it does
+not decide active Ridge route canon. For Bridge, Concert, Dance Festival, Relay,
+Living Proof, or ending design, start from
+[`../game-design/ridge/README.md`](../game-design/ridge/README.md).
+
 ## Core Idea
 
 Interactive mode should feel like a living sketchbook page, not a game trapped
@@ -79,7 +85,7 @@ as a card wrapped around another card.
 
 | Profile | Scenes | Layout Intent |
 | --- | --- | --- |
-| `sideViewPage` | Current Overworld, Ridge | Horizontal trail on paper with sparse prompts and overlays. |
+| `sideViewPage` | Current Overworld, legacy/prototype Ridge, possible future Ridge if the active route adopts it | Horizontal trail on paper with sparse prompts and overlays. |
 | `ruledBoardPage` | Potassium Slip | Tall ruled board, drag/recall control mat, board-like rhythm. |
 | `survivalPage` | Stampede Sketch | Clean open arena, edge status, minimal decoration. |
 | `timingPage` | Telegraph Terrace | One readable timing subject and one obvious parry surface. |
@@ -127,8 +133,10 @@ control-mat contract stays testable before broader extraction.
   Notebook Shell content.
 - Stampede should feel like a clean survival page, with pressure and status at
   the edge and almost no center decoration.
-- Ridge should sell the notebook fantasy through landmarks, stickers, Trail
-  Cards, and margin memory, not through dense side panels.
+- Ridge should sell the notebook fantasy through landmarks, resident changes,
+  Cicka presence, Trail Cards when needed, and margin memory, not through dense
+  side panels. Active route/ending decisions still belong in the Ridge router
+  docs, not this shell-language note.
 - Future scenes should choose a profile before designing custom UI.
 
 ## Storybook Readiness

--- a/docs/design/style-guide.md
+++ b/docs/design/style-guide.md
@@ -2,6 +2,11 @@
 
 This document outlines the visual identity and interaction philosophy for Danilo Novakovic's gamified portfolio.
 
+Status: source of truth for visual identity. It does not decide Ridge route
+canon, level order, ending gates, or whether the future Ridge keeps the current
+Phaser prototype topology. For active Ridge pre-production design, start from
+[`../game-design/ridge/README.md`](../game-design/ridge/README.md).
+
 Related provenance:
 [`docs/research/provenance/visual/`](../research/provenance/visual/)
 stores source research and background rationale. This file remains the current
@@ -35,12 +40,17 @@ The aesthetic is a fusion of **Pablo Stanley’s Open Peeps** (modular, clean ch
 
 ### 3. Environment & World-Building
 
-- **Perspective:** 2D Side-scroller with horizontal parallax layering.
-- **Layout:** A continuous, seamless horizontal street of buildings.
+- **Perspective:** 2D side-view with horizontal parallax layering unless a
+  future design spike deliberately proves another presentation.
+- **Layout:** A continuous, readable sketchbook route. Buildings, props,
+  resting spots, and landmarks should serve the active route instead of
+  defaulting to a portfolio street.
 - **Stroke Style:**
   - *Foreground:* Sharp, dark ink with thicker outlines.
   - *Background:* Sketchy, lighter lines with cross-hatching for shadows.
-- **Interaction:** Buildings indicate interactivity with a subtle "wobble" animation or a scribbled `[E] ENTER` prompt.
+- **Interaction:** Buildings, landmarks, props, and resting spots indicate
+  interactivity with subtle wobble, paper lift, ink jitter, or a clear
+  on-style prompt.
 
 ### 4. UI & Interaction
 
@@ -63,7 +73,11 @@ The aesthetic is a fusion of **Pablo Stanley’s Open Peeps** (modular, clean ch
 
 ## 🛠 Technical Implementation Details
 
-- **Perspective:** Phaser 2D Side-scroller.
-- **Gravity:** Enabled for walking and jumping.
-- **Movement:** `A/D` or `Arrows` to Walk, `Shift` to Sprint, `E` to Interact.
-- **Overlay:** React-based modals for mini-games and deeper content.
+Current implementation snapshot, not a future Ridge gameplay mandate:
+
+- **Perspective:** Phaser 2D side-view.
+- **Movement:** existing side-view scenes support walking, jumping, sprinting,
+  and interaction; the active Ridge pre-production route should choose required
+  traversal from route and area docs.
+- **Overlay:** React-based overlays and scene-owned UI for Trail Cards,
+  mini-games, results, and deeper content.

--- a/docs/game-design/README.md
+++ b/docs/game-design/README.md
@@ -15,7 +15,7 @@ and reference material. Do not treat every file here as equally active.
   [`ridge/map-language.md`](./ridge/map-language.md).
 - **Pre-production product vision:** [`ridge/summit.md`](./ridge/summit.md).
 - **Milestone map:** [`ridge/milestone-plan.md`](./ridge/milestone-plan.md)
-  for current route-reset targets plus legacy/prototype milestone history.
+  for current route-reset milestones and prototype reuse rules.
 - **Optional/current mini-game routing:** [`mini-games/README.md`](./mini-games/README.md).
 - **Live PRDs, issues, triage state, and agent briefs:** GitHub Issues, as
   configured in [`../agents/issue-tracker.md`](../agents/issue-tracker.md).
@@ -59,11 +59,11 @@ prefer GitHub Issues.
 - **[Stampede Sketch](./mini-games/stampede-sketch.md)**: Purpose, player fantasy, enemy
   intent, and first-slice asset direction for the Stampede mini-game.
 - **[Sketchbook Ridge Summit](./ridge/summit.md)**: Pre-production vision for
-  the desired Ridge rework, including the overworld and optional mini-games.
+  the desired Ridge rework, including pillars, ending promise, scope cuts, and
+  optional-toy stance.
 - **[Sketchbook Ridge Milestone Plan](./ridge/milestone-plan.md)**:
-  Durable milestone, branch, shared-seam, and ownership map. It includes
-  legacy/prototype milestone history; use the top status note and Ridge router
-  before treating a section as active. It is not the live issue tracker.
+  Current route-reset milestones, source stack, prototype reuse rules, and
+  first-agent checklist. It is not the live issue tracker.
 - **[Ridge Blockout Source](./ridge/map-language.md)**: Typed blockout source
   contract for Ridge room beats, environment tags, traversal primitives, and
   greybox generation.
@@ -71,8 +71,8 @@ prefer GitHub Issues.
   Current authoring data for the seamless Ridge world. It lives under the
   Ridge runtime because it is build input, not prose.
 - **[Ridge Legacy Docs](./ridge/legacy/README.md)**: Superseded folded/Cicka
-  Home map plans and blockout reviews. Reference only unless a current active
-  doc explicitly links there.
+  Home map plans, old summit/milestone history, and blockout reviews. Reference
+  only unless a current active doc explicitly links there.
 - **[Ridge Reference Packs](./ridge/reference/README.md)**: Art/audio/overlay
   and asset support packs. Use when active docs or implementation issues need
   support material.

--- a/docs/game-design/README.md
+++ b/docs/game-design/README.md
@@ -9,7 +9,7 @@ file here as equally active.
 - **Shipped player behavior:** [`player-manual.md`](./player-manual.md).
 - **Runtime spatial source:** [`folded-desk-ridge.source.ts`](../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts), described by
   [`ridge/map-language.md`](./ridge/map-language.md).
-- **Current Ridge level read:** [`ridge/current-level.md`](./ridge/current-level.md).
+- **Current Ridge snapshot:** [`ridge/ridge-snapshot.md`](./ridge/ridge-snapshot.md).
 - **Ridge story/level plan:** [`ridge/story-level-bible.md`](./ridge/story-level-bible.md).
 - **Current map target:** [`ridge/map-plans/proper-map-plan.md`](./ridge/map-plans/proper-map-plan.md).
 - **Product vision:** [`ridge/summit.md`](./ridge/summit.md).
@@ -19,18 +19,18 @@ file here as equally active.
   configured in [`../agents/issue-tracker.md`](../agents/issue-tracker.md).
 
 When files disagree, prefer this order: shipped behavior, runtime source,
-current Ridge level read, Ridge story/level plan, current map target, product
+current Ridge snapshot, Ridge story/level plan, current map target, product
 vision, milestone map, then reference/provenance.
 
 ## Documents
 
 - **[Player Manual](./player-manual.md)**: Shipped controls, rooms,
   interactions, return behavior, and playtest notes.
-- **[Current Ridge Level](./ridge/current-level.md)**: Human-readable snapshot
+- **[Ridge Snapshot](./ridge/ridge-snapshot.md)**: Human-readable snapshot
   of the currently implemented/prototyped Ridge level and what source owns each
   part.
 - **[Ridge Story/Level Bible](./ridge/story-level-bible.md)**: Prose-first
-  story, level, character, ending, and Resident Room Beat plan for the next
+  story, level, character, ending, and Ridge Area / Resident Beat plan for the next
   Ridge direction before implementation resumes.
 - **[Mini-Games](./mini-games/README.md)**: Routing index for mini-game-specific
   rules and Ridge reward contracts.
@@ -75,7 +75,7 @@ vision, milestone map, then reference/provenance.
 ## Document Status
 
 - **Shipped:** `player-manual.md`.
-- **Current design:** `ridge/current-level.md`,
+- **Current design:** `ridge/ridge-snapshot.md`,
   `ridge/story-level-bible.md`,
   `ridge/summit.md`, `ridge/milestone-plan.md`,
   `ridge/map-plans/proper-map-plan.md`,
@@ -104,6 +104,6 @@ vision, milestone map, then reference/provenance.
 3. **Fun & Surprise:** Secrets, mini-games, and "glitches" keep the experience engaging.
 
 When a concept becomes shipped behavior, update `player-manual.md` first. When
-current Ridge level reality changes, update `ridge/current-level.md`. When work
+current Ridge snapshot reality changes, update `ridge/ridge-snapshot.md`. When work
 needs planning, publish or update GitHub issues instead of growing local backlog
 sections.

--- a/docs/game-design/README.md
+++ b/docs/game-design/README.md
@@ -1,37 +1,52 @@
 # Game Design
 
-This directory separates shipped behavior, current Ridge design, long-term
-direction, runtime blockout source, and reference material. Do not treat every
-file here as equally active.
+This directory separates shipped behavior, active Ridge design, current runtime
+prototype truth, long-term direction, runtime blockout source, and reference
+material. Do not treat every file here as equally active.
 
 ## Source Of Truth
 
 - **Shipped player behavior:** [`player-manual.md`](./player-manual.md).
-- **Runtime spatial source:** [`folded-desk-ridge.source.ts`](../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts), described by
+- **Ridge design router:** [`ridge/README.md`](./ridge/README.md).
+- **Active Ridge story/route canon:** [`ridge/story-level-bible.md`](./ridge/story-level-bible.md).
+- **Active Ridge area design:** [`ridge/areas/`](./ridge/areas/README.md).
+- **Current Ridge runtime/prototype snapshot:** [`ridge/ridge-snapshot.md`](./ridge/ridge-snapshot.md).
+- **Runtime spatial source for the current prototype:** [`folded-desk-ridge.source.ts`](../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts), described by
   [`ridge/map-language.md`](./ridge/map-language.md).
-- **Current Ridge snapshot:** [`ridge/ridge-snapshot.md`](./ridge/ridge-snapshot.md).
-- **Ridge story/level plan:** [`ridge/story-level-bible.md`](./ridge/story-level-bible.md).
-- **Current map target:** [`ridge/map-plans/proper-map-plan.md`](./ridge/map-plans/proper-map-plan.md).
 - **Product vision:** [`ridge/summit.md`](./ridge/summit.md).
 - **Milestone map:** [`ridge/milestone-plan.md`](./ridge/milestone-plan.md).
 - **Mini-game routing:** [`mini-games/README.md`](./mini-games/README.md).
 - **Live PRDs, issues, triage state, and agent briefs:** GitHub Issues, as
   configured in [`../agents/issue-tracker.md`](../agents/issue-tracker.md).
 
-When files disagree, prefer this order: shipped behavior, runtime source,
-current Ridge snapshot, Ridge story/level plan, current map target, product
-vision, milestone map, then reference/provenance.
+For future Ridge design, prefer [`CONTEXT.md`](../../CONTEXT.md),
+[`ridge/README.md`](./ridge/README.md), and
+[`ridge/story-level-bible.md`](./ridge/story-level-bible.md), then the matching
+[`ridge/areas/`](./ridge/areas/README.md) file for area-local detail. For
+current runtime behavior, prefer runtime source and
+[`ridge/ridge-snapshot.md`](./ridge/ridge-snapshot.md). For live work state,
+prefer GitHub Issues.
 
 ## Documents
 
 - **[Player Manual](./player-manual.md)**: Shipped controls, rooms,
   interactions, return behavior, and playtest notes.
+- **[Ridge Design Router](./ridge/README.md)**: First-read status matrix for
+  Ridge docs, source ownership, legacy prototype rules, and update protocol.
 - **[Ridge Snapshot](./ridge/ridge-snapshot.md)**: Human-readable snapshot
-  of the currently implemented/prototyped Ridge level and what source owns each
-  part.
+  of the currently implemented/prototyped Ridge level, including which parts
+  are disposable legacy prototype.
 - **[Ridge Story/Level Bible](./ridge/story-level-bible.md)**: Prose-first
-  story, level, character, ending, and Ridge Area and Resident Beat plan for the
-  next Ridge direction before implementation resumes.
+  route spine, cross-area dependencies, Living Proof, Cicka/guitar logic, and
+  ending order for the active Bridge -> Concert -> Dance Festival -> Relay/Cicka
+  direction.
+- **[Ridge Areas](./ridge/areas/README.md)**: Local source-of-truth docs for
+  Bridge, Concert, Dance Festival, and Relay Ending design details.
+- **[Ridge Decision Intake](./ridge/decision-intake.md)**: Routing template for
+  future grilling or research transcripts so candidate ideas do not become
+  accidental canon.
+- **[Ridge Open Questions](./ridge/open-questions.md)**: Active unresolved
+  ending, Dance Festival, dependency, and scope questions for future grilling.
 - **[Mini-Games](./mini-games/README.md)**: Routing index for mini-game-specific
   rules and Ridge reward contracts.
 - **[Potassium Slip Manual](./mini-games/potassium-slip.md)**: Focused guide for the
@@ -44,7 +59,9 @@ vision, milestone map, then reference/provenance.
   Durable milestone, branch, shared-seam, and ownership map. It is not the live
   issue tracker.
 - **[Sketchbook Ridge Proper Map Plan](./ridge/map-plans/proper-map-plan.md)**:
-  Current target map plan for the folded, multi-screen Ridge around Cicka Home.
+  Folded/Cicka Home topology reference from the prior route direction. Use as
+  legacy/prototype material unless a new slice explicitly rewrites it around
+  the active Bridge/Concert/Dance/Relay route.
 - **[Ridge Blockout Source](./ridge/map-language.md)**: Typed blockout source
   contract for Ridge room beats, environment tags, traversal primitives, and
   greybox generation.
@@ -75,20 +92,26 @@ vision, milestone map, then reference/provenance.
 ## Document Status
 
 - **Shipped:** `player-manual.md`.
-- **Current design:** `ridge/ridge-snapshot.md`,
+- **Ridge routing and governance:** `ridge/README.md` and
+  `ridge/decision-intake.md`.
+- **Active Ridge open questions:** `ridge/open-questions.md`.
+- **Active Ridge design:** `ridge/README.md`,
+  `ridge/areas/`,
   `ridge/story-level-bible.md`,
   `ridge/summit.md`, `ridge/milestone-plan.md`,
-  `ridge/map-plans/proper-map-plan.md`,
   `mini-games/potassium-slip.md`, and `mini-games/stampede-sketch.md`.
+- **Current Ridge runtime/prototype reality:** `ridge/ridge-snapshot.md`.
 - **Current runtime source:**
   `../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts`.
 - **Current runtime source documentation:** `ridge/map-language.md`.
-- **Planning history / design review:** `ridge/map-plans/topology-spike.md`
-  and `ridge/reviews/blockout-fun-review.md`.
+- **Legacy/prototype topology and planning history:**
+  `ridge/map-plans/proper-map-plan.md`,
+  `ridge/map-plans/topology-spike.md`, and
+  `ridge/reviews/blockout-fun-review.md`.
 - **Reference/provenance:** M3 visual/audio/overlay packs, asset staging,
   Cicka runtime asset audit, and long-term topology. These can guide future
-  work, but should not override current design, shipped behavior, runtime docs,
-  or GitHub issues.
+  work, but should not override active Ridge design, shipped behavior, runtime
+  docs, or GitHub issues.
 - **Implementation source:** `../runtime-architecture.md`,
   `../runtime-modes.md`, and scoped rules under `../../.agents/rules/`.
 - **Issue tracker:** PRDs, implementation issues, triage state, current backlog,
@@ -104,6 +127,9 @@ vision, milestone map, then reference/provenance.
 3. **Fun & Surprise:** Secrets, mini-games, and "glitches" keep the experience engaging.
 
 When a concept becomes shipped behavior, update `player-manual.md` first. When
-current Ridge snapshot reality changes, update `ridge/ridge-snapshot.md`. When work
-needs planning, publish or update GitHub issues instead of growing local backlog
+current Ridge runtime/prototype reality changes, update `ridge/ridge-snapshot.md`.
+When future Ridge route canon changes, update `ridge/story-level-bible.md`
+through the routing rules in `ridge/README.md`. When area-local accepted detail
+changes, update the matching file under `ridge/areas/`. When work needs
+planning, publish or update GitHub issues instead of growing local backlog
 sections.

--- a/docs/game-design/README.md
+++ b/docs/game-design/README.md
@@ -10,6 +10,7 @@ file here as equally active.
 - **Runtime spatial source:** [`folded-desk-ridge.source.ts`](../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts), described by
   [`ridge/map-language.md`](./ridge/map-language.md).
 - **Current Ridge level read:** [`ridge/current-level.md`](./ridge/current-level.md).
+- **Ridge story/level plan:** [`ridge/story-level-bible.md`](./ridge/story-level-bible.md).
 - **Current map target:** [`ridge/map-plans/proper-map-plan.md`](./ridge/map-plans/proper-map-plan.md).
 - **Product vision:** [`ridge/summit.md`](./ridge/summit.md).
 - **Milestone map:** [`ridge/milestone-plan.md`](./ridge/milestone-plan.md).
@@ -18,8 +19,8 @@ file here as equally active.
   configured in [`../agents/issue-tracker.md`](../agents/issue-tracker.md).
 
 When files disagree, prefer this order: shipped behavior, runtime source,
-current Ridge level read, current map target, product vision, milestone map,
-then reference/provenance.
+current Ridge level read, Ridge story/level plan, current map target, product
+vision, milestone map, then reference/provenance.
 
 ## Documents
 
@@ -28,6 +29,9 @@ then reference/provenance.
 - **[Current Ridge Level](./ridge/current-level.md)**: Human-readable snapshot
   of the currently implemented/prototyped Ridge level and what source owns each
   part.
+- **[Ridge Story/Level Bible](./ridge/story-level-bible.md)**: Prose-first
+  story, level, character, ending, and Resident Room Beat plan for the next
+  Ridge direction before implementation resumes.
 - **[Mini-Games](./mini-games/README.md)**: Routing index for mini-game-specific
   rules and Ridge reward contracts.
 - **[Potassium Slip Manual](./mini-games/potassium-slip.md)**: Focused guide for the
@@ -72,6 +76,7 @@ then reference/provenance.
 
 - **Shipped:** `player-manual.md`.
 - **Current design:** `ridge/current-level.md`,
+  `ridge/story-level-bible.md`,
   `ridge/summit.md`, `ridge/milestone-plan.md`,
   `ridge/map-plans/proper-map-plan.md`,
   `mini-games/potassium-slip.md`, and `mini-games/stampede-sketch.md`.

--- a/docs/game-design/README.md
+++ b/docs/game-design/README.md
@@ -41,7 +41,9 @@ prefer GitHub Issues.
   ending order for the active Bridge -> Concert -> Dance Festival -> Relay/Cicka
   direction.
 - **[Ridge Areas](./ridge/areas/README.md)**: Local source-of-truth docs for
-  Bridge, Concert, Dance Festival, and Relay Ending design details.
+  Bridge, Concert, Dance Festival, and Relay Ending design details. Area
+  folders may contain narrow subdocs for layout, characters, or interaction
+  flow when one README would get bulky.
 - **[Ridge Decision Intake](./ridge/decision-intake.md)**: Routing template for
   future grilling or research transcripts so candidate ideas do not become
   accidental canon.
@@ -58,23 +60,18 @@ prefer GitHub Issues.
 - **[Sketchbook Ridge Milestone Plan](./ridge/milestone-plan.md)**:
   Durable milestone, branch, shared-seam, and ownership map. It is not the live
   issue tracker.
-- **[Sketchbook Ridge Proper Map Plan](./ridge/map-plans/proper-map-plan.md)**:
-  Folded/Cicka Home topology reference from the prior route direction. Use as
-  legacy/prototype material unless a new slice explicitly rewrites it around
-  the active Bridge/Concert/Dance/Relay route.
 - **[Ridge Blockout Source](./ridge/map-language.md)**: Typed blockout source
   contract for Ridge room beats, environment tags, traversal primitives, and
   greybox generation.
 - **[Ridge Blockout Source](../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts)**:
   Current authoring data for the seamless Ridge world. It lives under the
   Ridge runtime because it is build input, not prose.
-- **[Ridge Blockout Fun Review](./ridge/reviews/blockout-fun-review.md)**: Design review
-  of the first blockout skeleton.
-- **[Sketchbook Ridge Topology Spike](./ridge/map-plans/topology-spike.md)**:
-  Earlier M5 map-design spike. Keep as design history unless a current plan
-  explicitly points back to it.
-- **[Sketchbook Ridge Long-Term Topology Ideas](./ridge/map-plans/long-term-topology-ideas.md)**:
-  Exploratory long-term topology companion. Not an active roadmap.
+- **[Ridge Legacy Docs](./ridge/legacy/README.md)**: Superseded folded/Cicka
+  Home map plans and blockout reviews. Reference only unless a current active
+  doc explicitly links there.
+- **[Ridge Reference Packs](./ridge/reference/README.md)**: Art/audio/overlay
+  and asset support packs. Use when active docs or implementation issues need
+  support material.
 - **[Sketchbook Ridge Asset Staging Plan](./ridge/reference/asset-staging-plan.md)**:
   Organization guide for POC assets, prepared runtime candidates, and
   milestone-safe adoption.
@@ -104,14 +101,10 @@ prefer GitHub Issues.
 - **Current runtime source:**
   `../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts`.
 - **Current runtime source documentation:** `ridge/map-language.md`.
-- **Legacy/prototype topology and planning history:**
-  `ridge/map-plans/proper-map-plan.md`,
-  `ridge/map-plans/topology-spike.md`, and
-  `ridge/reviews/blockout-fun-review.md`.
-- **Reference/provenance:** M3 visual/audio/overlay packs, asset staging,
-  Cicka runtime asset audit, and long-term topology. These can guide future
-  work, but should not override active Ridge design, shipped behavior, runtime
-  docs, or GitHub issues.
+- **Legacy/prototype topology and planning history:** `ridge/legacy/`.
+- **Reference/provenance:** `ridge/reference/` plus `docs/research/`. These can
+  guide future work, but should not override active Ridge design, shipped
+  behavior, runtime docs, or GitHub issues.
 - **Implementation source:** `../runtime-architecture.md`,
   `../runtime-modes.md`, and scoped rules under `../../.agents/rules/`.
 - **Issue tracker:** PRDs, implementation issues, triage state, current backlog,

--- a/docs/game-design/README.md
+++ b/docs/game-design/README.md
@@ -30,8 +30,8 @@ vision, milestone map, then reference/provenance.
   of the currently implemented/prototyped Ridge level and what source owns each
   part.
 - **[Ridge Story/Level Bible](./ridge/story-level-bible.md)**: Prose-first
-  story, level, character, ending, and Ridge Area / Resident Beat plan for the next
-  Ridge direction before implementation resumes.
+  story, level, character, ending, and Ridge Area and Resident Beat plan for the
+  next Ridge direction before implementation resumes.
 - **[Mini-Games](./mini-games/README.md)**: Routing index for mini-game-specific
   rules and Ridge reward contracts.
 - **[Potassium Slip Manual](./mini-games/potassium-slip.md)**: Focused guide for the

--- a/docs/game-design/README.md
+++ b/docs/game-design/README.md
@@ -1,21 +1,22 @@
 # Game Design
 
-This directory separates shipped behavior, active Ridge design, current runtime
-prototype truth, long-term direction, runtime blockout source, and reference
-material. Do not treat every file here as equally active.
+This directory separates shipped behavior, active Ridge pre-production design,
+current runtime prototype truth, long-term direction, runtime blockout source,
+and reference material. Do not treat every file here as equally active.
 
 ## Source Of Truth
 
 - **Shipped player behavior:** [`player-manual.md`](./player-manual.md).
 - **Ridge design router:** [`ridge/README.md`](./ridge/README.md).
-- **Active Ridge story/route canon:** [`ridge/story-level-bible.md`](./ridge/story-level-bible.md).
-- **Active Ridge area design:** [`ridge/areas/`](./ridge/areas/README.md).
+- **Active Ridge pre-production story/route canon:** [`ridge/story-level-bible.md`](./ridge/story-level-bible.md).
+- **Active Ridge pre-production area design:** [`ridge/areas/`](./ridge/areas/README.md).
 - **Current Ridge runtime/prototype snapshot:** [`ridge/ridge-snapshot.md`](./ridge/ridge-snapshot.md).
 - **Runtime spatial source for the current prototype:** [`folded-desk-ridge.source.ts`](../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts), described by
   [`ridge/map-language.md`](./ridge/map-language.md).
-- **Product vision:** [`ridge/summit.md`](./ridge/summit.md).
-- **Milestone map:** [`ridge/milestone-plan.md`](./ridge/milestone-plan.md).
-- **Mini-game routing:** [`mini-games/README.md`](./mini-games/README.md).
+- **Pre-production product vision:** [`ridge/summit.md`](./ridge/summit.md).
+- **Milestone map:** [`ridge/milestone-plan.md`](./ridge/milestone-plan.md)
+  for current route-reset targets plus legacy/prototype milestone history.
+- **Optional/current mini-game routing:** [`mini-games/README.md`](./mini-games/README.md).
 - **Live PRDs, issues, triage state, and agent briefs:** GitHub Issues, as
   configured in [`../agents/issue-tracker.md`](../agents/issue-tracker.md).
 
@@ -49,17 +50,20 @@ prefer GitHub Issues.
   accidental canon.
 - **[Ridge Open Questions](./ridge/open-questions.md)**: Active unresolved
   ending, Dance Festival, dependency, and scope questions for future grilling.
-- **[Mini-Games](./mini-games/README.md)**: Routing index for mini-game-specific
-  rules and Ridge reward contracts.
+- **[Mini-Games](./mini-games/README.md)**: Routing index for optional and
+  current-prototype mini-game-specific rules. These docs do not make a
+  mini-game required Living Proof unless the Ridge router and active route canon
+  explicitly say so.
 - **[Potassium Slip Manual](./mini-games/potassium-slip.md)**: Focused guide for the
   Potassium Slip mini-game.
 - **[Stampede Sketch](./mini-games/stampede-sketch.md)**: Purpose, player fantasy, enemy
   intent, and first-slice asset direction for the Stampede mini-game.
-- **[Sketchbook Ridge Summit](./ridge/summit.md)**: Post-competition
-  production vision for the Ridge overworld and opt-in mini-games.
+- **[Sketchbook Ridge Summit](./ridge/summit.md)**: Pre-production vision for
+  the desired Ridge rework, including the overworld and optional mini-games.
 - **[Sketchbook Ridge Milestone Plan](./ridge/milestone-plan.md)**:
-  Durable milestone, branch, shared-seam, and ownership map. It is not the live
-  issue tracker.
+  Durable milestone, branch, shared-seam, and ownership map. It includes
+  legacy/prototype milestone history; use the top status note and Ridge router
+  before treating a section as active. It is not the live issue tracker.
 - **[Ridge Blockout Source](./ridge/map-language.md)**: Typed blockout source
   contract for Ridge room beats, environment tags, traversal primitives, and
   greybox generation.
@@ -83,8 +87,7 @@ prefer GitHub Issues.
 - **[Sketchbook Ridge M3 Overlay Pack](./ridge/reference/m3-overlay-pack.md)**:
   Reference Trail Card, Manual Page, mobile readability, and reward-state spec.
 - **[Sketchbook Ridge M3 Audio Pack](./ridge/reference/m3-audio-pack.md)**:
-  Reference Ridge, Cicka, Potassium acknowledgement, Stampede, and Telegraph
-  audio direction.
+  Reference Ridge, Cicka, optional mini-game, and timing-cue audio direction.
 
 ## Document Status
 
@@ -92,11 +95,13 @@ prefer GitHub Issues.
 - **Ridge routing and governance:** `ridge/README.md` and
   `ridge/decision-intake.md`.
 - **Active Ridge open questions:** `ridge/open-questions.md`.
-- **Active Ridge design:** `ridge/README.md`,
+- **Active Ridge pre-production design:** `ridge/README.md`,
   `ridge/areas/`,
   `ridge/story-level-bible.md`,
-  `ridge/summit.md`, `ridge/milestone-plan.md`,
-  `mini-games/potassium-slip.md`, and `mini-games/stampede-sketch.md`.
+  `ridge/summit.md`, and `ridge/milestone-plan.md`.
+- **Optional/current mini-game design:** `mini-games/potassium-slip.md` and
+  `mini-games/stampede-sketch.md`. These are local mini-game contracts, not
+  required first-ending Living Proof.
 - **Current Ridge runtime/prototype reality:** `ridge/ridge-snapshot.md`.
 - **Current runtime source:**
   `../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts`.

--- a/docs/game-design/mini-games/README.md
+++ b/docs/game-design/mini-games/README.md
@@ -4,6 +4,11 @@ This folder routes to mini-game-specific design docs. Mini-games own their
 local rules, controls, run state, and scene feel. Ridge owns how a mini-game is
 found, what durable reward it grants, and how the world changes on return.
 
+For the current Ridge pre-production plan, mini-games are optional side toys or
+alternate-path candidates. Do not treat a mini-game clear as required Living
+Proof for the first ending unless the Ridge router and active route canon
+explicitly say so.
+
 Live PRDs, implementation issues, triage state, and agent briefs live in GitHub
 Issues, not in this folder.
 
@@ -11,8 +16,8 @@ Issues, not in this folder.
 
 | Mini-game | Status | Doc | Ridge contract |
 | --- | --- | --- | --- |
-| Potassium Slip | Shipped / existing flagship | [`potassium-slip.md`](./potassium-slip.md) | Circuit is one major Relay proof; Potassium owns ricochet. |
-| Stampede Sketch | Current new prototype | [`stampede-sketch.md`](./stampede-sketch.md) | First clear grants `stampede-sketch` stamp plus one glide pip. |
+| Potassium Slip | Shipped / existing flagship; optional for new route | [`potassium-slip.md`](./potassium-slip.md) | Potassium owns ricochet and the current Circuit reward. Do not make it required first-ending Living Proof by default. |
+| Stampede Sketch | Prototype / optional candidate | [`stampede-sketch.md`](./stampede-sketch.md) | Candidate stamp/glide reward only; not required for the current first-ending route. |
 
 ## Future Docs
 

--- a/docs/game-design/mini-games/potassium-slip.md
+++ b/docs/game-design/mini-games/potassium-slip.md
@@ -41,11 +41,13 @@ Potassium Slip is the existing arcade anchor for Sketchbook Ridge. It owns the
 ricochet lane and should remain the benchmark for a deep opt-in mini-game, not
 the template every future mini-game must match.
 
-The Circuit is Potassium's durable world reward and one major proof toward the
-first Relay Spire gate, not a solo bypass. Future Ridge gate code should check
-existing inventory ownership with `isItemOwned('circuit')`, or the equivalent
-bridge inventory read, instead of adding a separate Ridge progress flag such as
-`circuitOwned`.
+The Circuit is Potassium's durable world reward in the current/prototype
+runtime. For the active Ridge pre-production plan, Potassium is optional side
+fun and should not be required Living Proof for the first ending unless the
+active route canon deliberately reopens that decision. Current runtime code
+that reads the Circuit should use existing inventory ownership with
+`isItemOwned('circuit')`, or the equivalent bridge inventory read, instead of
+adding a separate Ridge progress flag such as `circuitOwned`.
 
 Ridge signs, Trail Cards, NPCs, and stickers may acknowledge Potassium and the
 Circuit, but Potassium run behavior should stay scene-owned: fresh-start entry,
@@ -65,10 +67,11 @@ The enemies are not literal monsters; they are anxious office artifacts produced
 by the Potassium Compliance Officer to prove that play should be scoped,
 approved, filed, and made sensible before it can help the Ridge.
 
-The campaign reward should stay the **Circuit**. Fictionally, the Compliance
-Officer has withheld it because the Relay Spire signal is "not properly
-approved." Beating the boss recovers the Circuit and lets Potassium count as one
-major proof toward the first Relay Spire gate.
+The campaign reward should stay the **Circuit** in the current/prototype
+runtime. Fictionally, the Compliance Officer has withheld it because the Relay
+Spire signal is "not properly approved." In the active pre-production route,
+this should read as optional side progress unless the route canon explicitly
+makes Potassium part of a later alternate path.
 
 On return to the Ridge, Potassium should leave a visible memory rather than only
 an inventory flag. Good first candidates are:

--- a/docs/game-design/mini-games/stampede-sketch.md
+++ b/docs/game-design/mini-games/stampede-sketch.md
@@ -2,7 +2,9 @@
 
 > Mini-game design brief and Ridge reward contract.
 
-Stampede Sketch is the first new opt-in mini-game for Sketchbook Ridge.
+Stampede Sketch is the first new opt-in mini-game prototype for Sketchbook
+Ridge. In the active Ridge pre-production route, it is optional side fun or an
+alternate-path candidate, not required Living Proof for the first ending.
 
 ## Core Purpose
 
@@ -61,7 +63,8 @@ them to the blanket, but the blanket itself should remain a separate landmark.
 - **Upgrades:** better ways to organize, soften, or survive pressure.
 - **Damage/contact:** smudges, page noise, crowding.
 - **Win:** the blanket stays calm until the timer ends.
-- **First-clear reward:** stamp plus one glide pip for Ridge traversal.
+- **First-clear reward:** candidate stamp plus one glide pip for Ridge
+  traversal if the active route later accepts that reward.
 
 ## First-Slice Art Direction
 

--- a/docs/game-design/ridge/README.md
+++ b/docs/game-design/ridge/README.md
@@ -30,9 +30,9 @@ Use each file for exactly one concern:
 | Current runtime/prototype truth | [`ridge-snapshot.md`](./ridge-snapshot.md) | What exists now in the Phaser prototype, what can be reused, and what is disposable. |
 | Active open questions | [`open-questions.md`](./open-questions.md) | Unresolved ending, Dance Festival, dependency, and scope gaps. |
 | Product vision | [`summit.md`](./summit.md) | Durable fantasy and pillars, not detailed route implementation. |
-| Implementation sequencing | [`milestone-plan.md`](./milestone-plan.md) | Current route-reset target plus legacy/prototype milestone history, seams, branch strategy. Not live backlog. |
+| Implementation sequencing | [`milestone-plan.md`](./milestone-plan.md) | Current route-reset milestones, source stack, prototype reuse rules, and agent checklist. Not live backlog. |
 | Runtime blockout contract | [`map-language.md`](./map-language.md) | Source format and generated facts for the current/prototype blockout. |
-| Legacy topology/reviews | [`legacy/`](./legacy/README.md) | Superseded folded/Cicka Home plans and reviews. Reference only unless an active doc links there. |
+| Legacy prototype history | [`legacy/`](./legacy/README.md) | Superseded folded/Cicka Home plans, old summit/milestone history, map plans, and reviews. Reference only unless an active doc links there. |
 | Art/audio/asset support | [`reference/`](./reference/README.md) | Reference packs that support active docs but do not override route canon. |
 | Live work | GitHub Issues | PRDs, current backlog, triage state, and agent briefs. |
 

--- a/docs/game-design/ridge/README.md
+++ b/docs/game-design/ridge/README.md
@@ -1,9 +1,11 @@
 # Ridge Design Router
 
 This is the first doc to read before changing Ridge design, Ridge planning, or
-Ridge implementation issues.
+Ridge implementation issues. It is the pre-production router for the desired
+game rework, while the existing Phaser Ridge remains a legacy prototype and
+runtime reference.
 
-The active product direction is the linear emotional Ridge route:
+The active pre-production product direction is the linear emotional Ridge route:
 
 ```text
 Bridge Area / Blueprint Bridge
@@ -25,10 +27,10 @@ Use each file for exactly one concern:
 | Shipped behavior | [`../player-manual.md`](../player-manual.md) | Update only when behavior ships. |
 | Current Ridge route canon | [`story-level-bible.md`](./story-level-bible.md) | Route spine, cross-area Cicka/guitar logic, Living Proof, ending order. |
 | Area-specific design canon | [`areas/`](./areas/README.md) | Local geography, blockers, residents, prompts, staging, Cicka Resting Spots, visual/audio notes. |
-| Current runtime/prototype truth | [`ridge-snapshot.md`](./ridge-snapshot.md) | What exists now in the Phaser prototype and what parts are disposable. |
+| Current runtime/prototype truth | [`ridge-snapshot.md`](./ridge-snapshot.md) | What exists now in the Phaser prototype, what can be reused, and what is disposable. |
 | Active open questions | [`open-questions.md`](./open-questions.md) | Unresolved ending, Dance Festival, dependency, and scope gaps. |
 | Product vision | [`summit.md`](./summit.md) | Durable fantasy and pillars, not detailed route implementation. |
-| Implementation sequencing | [`milestone-plan.md`](./milestone-plan.md) | Milestones, seams, branch strategy. Not live backlog. |
+| Implementation sequencing | [`milestone-plan.md`](./milestone-plan.md) | Current route-reset target plus legacy/prototype milestone history, seams, branch strategy. Not live backlog. |
 | Runtime blockout contract | [`map-language.md`](./map-language.md) | Source format and generated facts for the current/prototype blockout. |
 | Legacy topology/reviews | [`legacy/`](./legacy/README.md) | Superseded folded/Cicka Home plans and reviews. Reference only unless an active doc links there. |
 | Art/audio/asset support | [`reference/`](./reference/README.md) | Reference packs that support active docs but do not override route canon. |

--- a/docs/game-design/ridge/README.md
+++ b/docs/game-design/ridge/README.md
@@ -30,7 +30,8 @@ Use each file for exactly one concern:
 | Product vision | [`summit.md`](./summit.md) | Durable fantasy and pillars, not detailed route implementation. |
 | Implementation sequencing | [`milestone-plan.md`](./milestone-plan.md) | Milestones, seams, branch strategy. Not live backlog. |
 | Runtime blockout contract | [`map-language.md`](./map-language.md) | Source format and generated facts for the current/prototype blockout. |
-| Folded topology reference | [`map-plans/proper-map-plan.md`](./map-plans/proper-map-plan.md) | Legacy/prototype topology reference unless rewritten around the active route. |
+| Legacy topology/reviews | [`legacy/`](./legacy/README.md) | Superseded folded/Cicka Home plans and reviews. Reference only unless an active doc links there. |
+| Art/audio/asset support | [`reference/`](./reference/README.md) | Reference packs that support active docs but do not override route canon. |
 | Live work | GitHub Issues | PRDs, current backlog, triage state, and agent briefs. |
 
 When docs disagree about future Ridge design, prefer `CONTEXT.md`,
@@ -68,6 +69,9 @@ Treat these as prototype/reference unless a task explicitly says to adapt them:
 Useful legacy pieces may still be preserved or adapted: the Ridge Blockout
 Source contract, compiler, generated facts, validation, and preview/debugger
 workflow.
+
+Superseded planning docs live under [`legacy/`](./legacy/README.md). Do not
+search that folder first when updating active route design.
 
 ## Update Rules
 

--- a/docs/game-design/ridge/README.md
+++ b/docs/game-design/ridge/README.md
@@ -1,0 +1,103 @@
+# Ridge Design Router
+
+This is the first doc to read before changing Ridge design, Ridge planning, or
+Ridge implementation issues.
+
+The active product direction is the linear emotional Ridge route:
+
+```text
+Bridge Area / Blueprint Bridge
+  -> Concert Area / Concert Crossing Beat
+  -> Dance Festival Area / Opening Dance Shuttle Beat
+  -> Relay Spire / Guitar Farewell / Cicka Threshold Farewell
+```
+
+The current folded/Cicka Home/platformer-like Phaser Ridge is a prototype and
+runtime reference, not the desired product target.
+
+## Source Matrix
+
+Use each file for exactly one concern:
+
+| Concern | Source | Notes |
+| --- | --- | --- |
+| Domain language | [`../../../CONTEXT.md`](../../../CONTEXT.md) | Use these terms exactly. Add only stable domain terms and ambiguities. |
+| Shipped behavior | [`../player-manual.md`](../player-manual.md) | Update only when behavior ships. |
+| Current Ridge route canon | [`story-level-bible.md`](./story-level-bible.md) | Route spine, cross-area Cicka/guitar logic, Living Proof, ending order. |
+| Area-specific design canon | [`areas/`](./areas/README.md) | Local geography, blockers, residents, prompts, staging, Cicka Resting Spots, visual/audio notes. |
+| Current runtime/prototype truth | [`ridge-snapshot.md`](./ridge-snapshot.md) | What exists now in the Phaser prototype and what parts are disposable. |
+| Active open questions | [`open-questions.md`](./open-questions.md) | Unresolved ending, Dance Festival, dependency, and scope gaps. |
+| Product vision | [`summit.md`](./summit.md) | Durable fantasy and pillars, not detailed route implementation. |
+| Implementation sequencing | [`milestone-plan.md`](./milestone-plan.md) | Milestones, seams, branch strategy. Not live backlog. |
+| Runtime blockout contract | [`map-language.md`](./map-language.md) | Source format and generated facts for the current/prototype blockout. |
+| Folded topology reference | [`map-plans/proper-map-plan.md`](./map-plans/proper-map-plan.md) | Legacy/prototype topology reference unless rewritten around the active route. |
+| Live work | GitHub Issues | PRDs, current backlog, triage state, and agent briefs. |
+
+When docs disagree about future Ridge design, prefer `CONTEXT.md`,
+`story-level-bible.md`, and the matching `areas/` doc. When docs disagree about
+current runtime behavior, prefer runtime source plus `ridge-snapshot.md`.
+
+## Status Labels
+
+Use these labels at the top of Ridge planning docs or sections:
+
+- `research-input`: material from a transcript or research pass, not canon.
+- `candidate`: plausible direction that needs Danilo or role review.
+- `accepted`: may guide future design and issue writing.
+- `implemented`: exists in runtime/prototype.
+- `shipped`: player-facing behavior; also update `player-manual.md`.
+- `deferred`: valid idea, not current scope.
+- `rejected`: do not revive without new Danilo direction.
+- `superseded`: kept only for history or comparison.
+- `needs-HITL`: blocked on taste, tribute, naming, scope, or irreversible product choice.
+
+Only `accepted`, `implemented`, and `shipped` material may drive implementation.
+If unsure, mark the point as `candidate` or move it to open questions.
+
+## Legacy Prototype Rules
+
+Treat these as prototype/reference unless a task explicitly says to adapt them:
+
+- Cicka Home as the central hub.
+- Cicka Home mutation ledgers as the main memory model.
+- Folded-desk route order.
+- Required jump/platformer traversal.
+- Main-path slopes, ramps, wall jumps, double jumps, or precision platforming.
+- Mini-game clears as required Living Proof for the first ending.
+
+Useful legacy pieces may still be preserved or adapted: the Ridge Blockout
+Source contract, compiler, generated facts, validation, and preview/debugger
+workflow.
+
+## Update Rules
+
+For Ridge planning changes:
+
+1. Read this file first.
+2. Use `CONTEXT.md` vocabulary exactly.
+3. Update one canonical target file per claim.
+4. Do not paste transcripts into source-of-truth docs.
+5. Put area-local accepted detail in [`areas/`](./areas/README.md); update the
+   bible only when route spine, cross-area dependency, or ending logic changes.
+6. Put unresolved design gaps in [`open-questions.md`](./open-questions.md) or a decision intake.
+7. Put implementation work in GitHub Issues, not local backlog sections.
+8. If a chat creates many claims, use [`decision-intake.md`](./decision-intake.md) before updating canon.
+
+## Size Guardrails
+
+These are soft caps. When a section crosses them, summarize, split, or delete
+stale material before appending more.
+
+| File type | Soft cap |
+| --- | ---: |
+| Router docs | 120 lines |
+| `CONTEXT.md` | 700 lines |
+| `story-level-bible.md` | 600 lines |
+| Area docs | 300 lines |
+| `ridge-snapshot.md` | 450 lines |
+| Research intake | 150 lines |
+| ADR | 80 lines |
+
+If an area doc crosses the soft cap, split only stable subtopics such as
+`layout.md`, `characters.md`, or `staging.md`, and leave a short summary plus
+link in the area `README.md`.

--- a/docs/game-design/ridge/areas/01-bridge/README.md
+++ b/docs/game-design/ridge/areas/01-bridge/README.md
@@ -1,0 +1,54 @@
+# Bridge Area
+
+> Status: accepted first-area direction / needs focused area pass.
+> Read [`../../README.md`](../../README.md) and
+> [`../README.md`](../README.md) before editing this file.
+
+This file owns local design detail for **Bridge Area / Blueprint Bridge**. The
+route-level role lives in [`../../story-level-bible.md`](../../story-level-bible.md).
+
+## Route Role
+
+Bridge Area is the first required Ridge Area. It teaches the core route grammar:
+
+```text
+Cicka noticed something -> a resident needs local help -> the route visibly changes
+```
+
+The emotional idea is: **I can change the world by making something through
+art.**
+
+## Accepted Local Contract
+
+- The main blocker is a missing, unsafe, or unfinished crossing.
+- The solution is a tiny art/drawing soft gate: help a resident finish a bridge
+  drawing or blueprint, then the finished sketch becomes the crossing.
+- Cicka gives an obvious but nonverbal attention cue near the unsafe edge,
+  blank plan, or missing part of the bridge.
+- The route change must be visible in the world, not only in dialogue.
+- The beat should be tiny, obvious, local, and kind.
+
+## Cicka Resting Spot
+
+Use **Bridge Resting Spot** as the practical label.
+
+- Before resolution: Cicka perches near the unsafe crossing or blank plan.
+- After resolution: Cicka settles near the completed bridge sketch or leaves a
+  tiny mark by the crossing.
+
+The resting spot is readable flavor, not a gate.
+
+## Boundaries
+
+- Do not make Bridge Area a platforming test.
+- Do not make the required v0 solution depend on physics drawing.
+- Do not turn the beat into a fetch quest.
+- Future optional upgrade: let the player draw directly on the bridge as a
+  small customization or bridge-building toy.
+
+## Open Local Slots
+
+- resident role, silhouette, and eventual name
+- exact bridge topology and camera framing
+- prop kit for the unfinished sketch/blueprint
+- one or two prompts that make the crossing change feel authored

--- a/docs/game-design/ridge/areas/02-concert/README.md
+++ b/docs/game-design/ridge/areas/02-concert/README.md
@@ -1,0 +1,55 @@
+# Concert Area
+
+> Status: accepted middle-area direction / needs focused area pass.
+> Read [`../../README.md`](../../README.md) and
+> [`../README.md`](../README.md) before editing this file.
+
+This file owns local design detail for **Concert Area / Concert Crossing Beat**.
+The route-level role lives in
+[`../../story-level-bible.md`](../../story-level-bible.md).
+
+## Route Role
+
+Concert Area is the middle required Ridge Area. It turns the route from "making
+something" toward "carrying comfort forward."
+
+The emotional idea is: **I can turn memory into comfort.**
+
+## Accepted Local Contract
+
+- A blocked concert/traffic crossing halts the route.
+- The crossing is blocked because the local guitarist cannot play, the
+  paper-stage setup is tangled, or the guitar needs a small repair.
+- The player helps the resident through conversation, collection, practice
+  together, forgiving auto-play, or another non-arcade fallback.
+- The guitar is entrusted to the player afterward as a meaningful comfort item.
+- The beat must make the later **Guitar Farewell** feel earned.
+
+## Cicka Resting Spot
+
+Use **Concert Resting Spot** as the practical label.
+
+- Before resolution: Cicka watches the guitar case, string, stage edge, or
+  blocked crossing.
+- After resolution: Cicka rests in a quiet listening corner near the opened
+  crossing.
+
+This can later become the post-ending echo spot. The echo should be an empty
+usual spot plus one small paw/page mark, not the player's guitar left behind.
+
+## Boundaries
+
+- A Guitar-Hero-like performance mini-game is allowed as an ideal or optional
+  expression.
+- The required route must have a non-arcade fallback.
+- Avoid making the guitarist a joke-only drunk if it undercuts the tribute.
+- Gentle comedy is welcome if the guitar's emotional role still has room to
+  breathe.
+
+## Open Local Slots
+
+- exact crossing geometry and why it blocks progress
+- guitarist/resident role, silhouette, and eventual name
+- how the guitar is repaired, taught, or entrusted
+- first playable guitar interaction, if any, before Relay
+- visual/audio distinction from Dance Festival and Relay sunset

--- a/docs/game-design/ridge/areas/03-dance-festival/README.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/README.md
@@ -1,10 +1,10 @@
 # Dance Festival Area
 
-> Status: accepted final-area direction / needs spatial and prompt pass.
+> Status: accepted final-area direction / split local source.
 > Read [`../../README.md`](../../README.md) and
-> [`../README.md`](../README.md) before editing this file.
+> [`../README.md`](../README.md) before editing this folder.
 
-This file owns local design detail for **Dance Festival Area / Opening Dance
+This folder owns local design detail for **Dance Festival Area / Opening Dance
 Shuttle Beat**. The route-level role lives in
 [`../../story-level-bible.md`](../../story-level-bible.md).
 
@@ -14,237 +14,50 @@ Dance Festival Area is the final required Ridge Area before Relay Spire.
 
 The emotional idea is: **Life can keep moving with someone new.**
 
-The beat should be romantic, warm, and different from the Guitar Farewell. Two
-fictional residents like each other but are too nervous to step onto the dance
-floor or talk directly. The night dance festival is real, but the player
-participates in afternoon setup and leaves before the festival fully begins.
-The player helps make the event ready, prepares one nervous partner for a
-future dance, and helps the pair find enough rhythm to meet without turning the
-beat into public matchmaking.
+The player participates in afternoon setup for a real night dance festival and
+leaves before the festival fully begins. The beat is romantic, warm, and
+different from the Guitar Farewell: two fictional residents like each other but
+are too nervous to step onto the dance floor or talk directly. The player helps
+the place become ready and gives both residents enough dignity to meet later
+without turning the scene into public matchmaking.
 
-## Geography And Blocker
+## Local Source Map
 
-The dance happens in a small town square, community hall, or festival street at
-the foot of the Relay hill, where a local dance night naturally belongs. The
-route to the Relay Spire is blocked by a practical final-approach problem:
-festival setup temporarily occupies the service road with barriers, lantern
-lines, chair stacks, stage/speaker cables, and a locked gate.
+| File | Owns |
+| --- | --- |
+| [`layout.md`](./layout.md) | Last-Stop Plaza, service-road blocker, shuttle lane, staging, art/audio open slots |
+| [`characters.md`](./characters.md) | Hill-shuttle driver, Last-Stop Operations Helper, Dance Teacher, supporting residents, Cicka, Unnamed Counterpart Cat |
+| [`interaction-flow.md`](./interaction-flow.md) | Practical Wayfinding Loop, Readiness Favors, Folded Song Request, Setup Clearance, Relay transition, conversation rules |
 
-Once setup is safe enough, the steward can open one short daylight window for
-the final hill shuttle before the road closes again for the night festival. The
-player helps the hill-shuttle driver, the Last-Stop Operations Helper, and
-nearby festival helpers finish that setup window, giving the driver a believable
-reason and means to take the player toward the Relay overlook at sunset.
+## Accepted Local Contract
 
-Accepted arrival premise: **Opening Dance Setup + Last Daylight Shuttle**. This
-replaces the previous after-festival **Last Song Table + Final Shuttle Hold**
-candidate.
+- Accepted arrival premise: **Opening Dance Setup + Last Daylight Shuttle**.
+- Last-Stop Plaza sits at the foot of the Relay hill.
+- Festival setup blocks the service road with barriers, lantern lines, chair
+  stacks, stage/speaker cables, and a locked gate.
+- The last daylight hill shuttle can leave only after the setup lane is safe.
+- The route question stays practical first: "How do I get to Relay?"
+- The player helps the **hill-shuttle driver** and **Last-Stop Operations
+  Helper** through dignity-preserving Readiness Favors.
+- The romantic connector is a small **Folded Song Request**, not a public
+  confession.
+- Setup clears through a short **Prompt-Driven Playable Montage**, not a chore
+  list or pure cutscene.
+- The player catches a **Short Threshold Transition** to Relay under sunset.
+- The night dance can appear later as a Living Proof Montage echo during the
+  Guitar Farewell.
 
-```text
-Last-Stop Plaza at the foot of the Relay hill.
-Festival setup blocks the service road.
-Sign: "Service road closes for night dance. Last daylight shuttle after setup check."
-```
+## Boundaries
 
-## Main Residents
+- Do not make the player ask "How do I fix the romance?" as the first-read goal.
+- Do not solve the beat by forcing two shy people into an instant confession.
+- Do not use a purely magical or abstract dance crossing.
+- Do not require arcade dance/rhythm performance for the first ending path.
+- Do not make the couple literal stand-ins for Danilo and Milena.
+- Do not name the Unnamed Counterpart Cat, label him as Micka's father, or
+  confirm parentage before the post-ending return.
 
-On arrival, the hill-shuttle driver stands beside the shuttle near the locked
-service-road gate, checking the same route clipboard too many times. He cannot
-drive yet because setup is still blocking the service lane and the steward will
-not open the barrier until the lane is safe. He is genuinely working the
-afternoon/evening event shuttle shift, but the clipboard is also a safe place to
-hide from asking one small question before the dance begins.
-
-The romantic partner is the shy **Last-Stop Operations Helper**. She works the
-visible plaza table that sits between the shuttle, dance setup, and service-road
-barrier: shuttle questions, setup checklist, lantern tags/signs, volunteer
-handoff, and radioing the steward when the lane is clear. She is not a flashy
-performer; she is the trusted local who keeps the last-stop plaza from becoming
-confused. Emotionally, the operations table lets her keep being useful instead
-of becoming visible enough to be asked to dance.
-
-Supporting static residents:
-
-- traveler near the plaza entry: points the player toward the shuttle and
-  explains that Relay requires the last daylight hill shuttle
-- festival steward near the barrier: explains that the service road opens only
-  after setup is safe and closes again when the night festival begins
-- **Dance Teacher** near the floor: offers gentle facilitation, teaches one
-  small step, covers the operations watch once setup is proven safe, and notices
-  that two shy people are orbiting each other, but is not the romance target
-
-## Discovery Flow
-
-Use a **Practical Wayfinding Loop**, not a quest giver. The player arrives
-asking how to reach Relay, notices the closed service-road barrier and shuttle
-sign, then learns from practical local roles that the final daylight shuttle
-leaves after setup passes inspection and before the road closes for the night
-dance.
-
-First-read sequence:
-
-```text
-Player arrives at Last-Stop Plaza.
-Festival barriers, lantern lines, and shuttle sign show the route is blocked.
-Traveler says Relay requires the last daylight hill shuttle.
-Driver is visible by the shuttle, stuck on the route clipboard.
-Operations helper is visible near the dance floor, stuck perfecting setup details.
-Steward explains that the road opens after setup check, then closes for night.
-```
-
-The player's natural question should be "How do I get to Relay?", not "How do I
-fix the romance?" The romantic problem should emerge only after the player asks
-why the last daylight shuttle is delayed and notices that the driver and
-operations helper are both hiding inside practical work.
-
-Accepted conversation discovery pattern: **Triangulated Discovery Flow**. The
-player should be able to talk to the driver and Last-Stop Operations Helper
-first and receive practical but incomplete answers:
-
-```text
-Driver: cannot leave until setup clears and the steward opens the service gate.
-Operations helper: cannot stop fixing setup details until someone trusted checks the handoff.
-```
-
-Both answers are true, but they do not explain why the two are hiding inside
-work instead of making a small social move. The player can then return to the
-plaza and ask nearby locals what is going on.
-
-Possible local reads:
-
-- traveler: "The driver's been rereading that clipboard for ten minutes."
-- festival steward: "The shuttle waits on the lane. She waits on one perfect
-  lantern. He waits on anything except asking."
-- **Dance Teacher**: "They both know where the floor is. They are practicing
-  the art of being unavailable."
-
-This lets the player piece together the relationship from public behavior and
-local observations rather than receiving an instant confession or omniscient
-quest explanation.
-
-## Readiness Favors
-
-The player should not be able to solve the beat immediately by confronting the
-driver and Last-Stop Operations Helper with "you like each other." That would
-likely make shy people defensive and would flatten the scene into forced
-matchmaking.
-
-Instead, Opening Dance should use two **Readiness Favors**, one for each
-romantic character, before the setup handoff, last daylight shuttle, and later
-night-dance promise can happen.
-
-Current readiness direction:
-
-- driver insecurity: he does not know how to dance and does not want to
-  embarrass himself in front of the Last-Stop Operations Helper
-- Last-Stop Operations Helper insecurity: if she stays useful behind an
-  organizer role, she knows who she is; if she steps onto the floor, she is just
-  someone hoping to be asked
-
-The Readiness Favors should let the player help each person feel prepared while
-preserving their dignity.
-
-- Last-Stop Operations Helper: **Operations Handoff Check**. The player helps
-  her prove the plaza setup is safe enough by checking a few visible festival
-  details, then getting the **Dance Teacher** to keep watch once the night dance
-  starts. The emotional point is not that someone else can plan better; it is
-  that she has done enough and the event can keep going while she enjoys it.
-- Hill-shuttle driver: **One-Step Practice**. The player helps him learn exactly
-  one tiny dance step from the **Dance Teacher**, privately enough to protect his
-  dignity. He does not become good at dancing; he gains one small shared rhythm
-  he can offer later.
-
-After both romantic characters are ready, the connector is **Folded Song
-Request**. The driver writes a tiny folded paper request at the operations
-table, requesting a simple, cute song and asking her for one dance later without
-making a public confession. The request should not lock the beat to bachata or
-any other specific dance genre; it should feel playable on guitar, simple enough
-for a non-dancer, and emotionally compatible with the later Guitar Farewell
-montage.
-
-The exact requested song does not need to be shown or heard by the player; the
-only presented music can be the guitar during the farewell. It can use her own
-event paper, handwriting marks, or song-request language so the ask feels rooted
-in her work rather than imposed by the player.
-
-## Setup Clearance
-
-Required relocation should stay minimal. After the player helps, the driver and
-Last-Stop Operations Helper can share or acknowledge the Folded Song Request,
-then return to their practical roles for the **Setup Clearance Walkthrough**:
-the remaining visible setup details clear the service lane enough for the
-steward to open the barrier and the driver to offer the last daylight ride
-toward Relay.
-
-Present this as a **Prompt-Driven Playable Montage**, not a full manual chore
-sequence or pure cutscene. The player chooses a prompt such as "Help with
-remaining preparations," then triggers a few authored interaction snaps.
-
-Default symbolic set:
-
-- secure the lantern line
-- clear or tape the service-lane obstruction
-- flip the shuttle sign to "Last daylight ride"
-
-Treat these as one-action story beats rather than small chore gameplay; they
-can collapse further if the beat needs to move faster. After the snaps, the sky
-warms, the plaza reads more ready, the **Dance Teacher** keeps watch, and the
-steward opens the gate. The actual dance can remain a promised night-festival
-moment and/or appear in the Guitar Farewell montage.
-
-## Locked Character Roles
-
-The nervous dance resident is the **hill-shuttle driver**. He runs the last
-practical route up toward the Relay overlook, but he is stuck at the festival
-because the service road is not yet clear and because he cannot bring himself to
-ask about the night dance. His daily job, his emotional problem, and the
-player's route blocker should all point at the same practical situation. Do not
-assign him a proper name yet; the role label is enough until a later character
-pass.
-
-The shy **Last-Stop Operations Helper** is the locked romantic partner. She
-belongs in this place because her daily work sits between the dance, the
-service-road barrier, and the last daylight shuttle without requiring technical
-explanation. She likes the driver because he is quietly reliable: he waits for
-helpers to finish packing, remembers nervous passengers, and takes the hill
-road gently. He likes her because she notices small things and keeps the
-last-stop plaza feeling kind. Do not assign her a proper name yet; the role
-label is the canonical placeholder until her movement and emotional function are
-stable.
-
-The **Dance Teacher** exists as a facilitator rather than the romance target.
-They teach one small step, give the player social cover, cover the operations
-watch after the handoff, and notice that two shy people are orbiting each other.
-Avoid turning the beat into a competition for the teacher's attention unless a
-later tone pass proves it can stay gentle.
-
-## Conversation And Tone
-
-Conversation design should use **Recoverable Conversation Choices**. The player
-should feel agency through what they ask, who they approach first, how they
-encourage the driver, and how they recover from a clumsy read. A failed path can
-create awkwardness, delay, or require extra listening, but it should not
-permanently block the first ending.
-
-Do not use a purely magical or abstract "dance crossing" explanation. This beat
-must answer:
-
-- where a dance naturally belongs in the final approach environment
-- what physical barricade prevents the player from reaching the Relay Spire
-- why the resident being helped has a believable reason and practical way to
-  help with that barricade
-- what small backstory or daily purpose makes each involved resident feel like a
-  local person rather than a route-solving robot
-
-The couple should be emotionally inspired by Danilo and Milena's story without
-being literal stand-ins. Protect the intimacy: carry the emotional truth through
-fictional residents, not a private memory exhibit.
-
-The main solution should be conversation, collection, and gentle setup. An
-optional dance/rhythm mini-game can deepen the beat later, but the first ending
-path should not depend on arcade performance.
-
-## Cicka And Counterpart Cat
+## Cicka Resting Spot
 
 Use **Dance Festival Resting Spot** as the practical label.
 
@@ -253,44 +66,15 @@ Use **Dance Festival Resting Spot** as the practical label.
 - After resolution: Cicka settles near the cleared service gate or finished
   shuttle sign, optionally beside the Unnamed Counterpart Cat.
 
-Cicka does not explain love or grief. She watches from the edge of the dance
-setup, perhaps walking through the cleared lane afterward as if the whole thing
-was obvious.
-
-She can also hang out with the **Unnamed Counterpart Cat** near the operations
-table or service gate: loafing together, staring at the same lantern, or briefly
-playing while the humans work. The counterpart cat can visually contrast with
-Cicka, such as a pale or white cat if Cicka reads dark, so that Micka's later
-half-and-half design feels quietly prepared. Do not name him, label him as
-Micka's father, or confirm parentage before the post-ending return.
-
-## Relay Transition
-
-The player catches the sunset shuttle to Relay through a **Short Threshold
-Transition**, not a controllable driving scene. The driver can say a small line
-such as "All aboard the last ride," the vehicle starts over a brief blackout,
-and the player respawns at Relay Spire under sunset.
-
-Control resumes at Cicka's overlook spot for the **Sit and Play Prompt** and
-**Guitar Farewell**. The later night festival can appear as a **Living Proof
-Montage** image during the farewell instead of pulling the playable ending away
-from Cicka; the dancing can read as an emotional echo of the player's guitar
-rather than revealing or playing the actual requested festival song. After the
-montage, Relay returns in **Relay Blue Hour** for the **Send the Sketchbook
-Prompt** rather than full night.
-
-The emotional lesson is that life can continue and new love can arrive after
-loss without replacing what was lost.
+Cicka is an observer, not an explainer. The resting spot is readable flavor, not
+a route gate.
 
 ## Open Local Slots
 
-- exact room topology for Last-Stop Plaza, service-road gate, shuttle,
-  operations table, dance floor, lantern lines, and exits
-- concrete prompts, object interactions, conversation branches, and recovery
-  paths
-- whether the player can help the driver or Last-Stop Operations Helper first
-- final 2-3 authored snaps for Setup Clearance Walkthrough
-- silhouettes, movement, dialogue style, and eventual names for local residents
-- festival palette, signage, music texture, crowd ambience, and prop kit
-- smallest playable version that still lands final emotional readiness before
-  Relay
+- [`layout.md`](./layout.md): exact room topology, prop placement, staging,
+  palette, signage, music texture, and crowd ambience.
+- [`characters.md`](./characters.md): silhouettes, movement, dialogue style, and
+  eventual names for local residents.
+- [`interaction-flow.md`](./interaction-flow.md): concrete prompts, object
+  interactions, recovery paths, readiness order flexibility, and the smallest
+  playable version that still lands final readiness before Relay.

--- a/docs/game-design/ridge/areas/03-dance-festival/README.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/README.md
@@ -1,0 +1,296 @@
+# Dance Festival Area
+
+> Status: accepted final-area direction / needs spatial and prompt pass.
+> Read [`../../README.md`](../../README.md) and
+> [`../README.md`](../README.md) before editing this file.
+
+This file owns local design detail for **Dance Festival Area / Opening Dance
+Shuttle Beat**. The route-level role lives in
+[`../../story-level-bible.md`](../../story-level-bible.md).
+
+## Route Role
+
+Dance Festival Area is the final required Ridge Area before Relay Spire.
+
+The emotional idea is: **Life can keep moving with someone new.**
+
+The beat should be romantic, warm, and different from the Guitar Farewell. Two
+fictional residents like each other but are too nervous to step onto the dance
+floor or talk directly. The night dance festival is real, but the player
+participates in afternoon setup and leaves before the festival fully begins.
+The player helps make the event ready, prepares one nervous partner for a
+future dance, and helps the pair find enough rhythm to meet without turning the
+beat into public matchmaking.
+
+## Geography And Blocker
+
+The dance happens in a small town square, community hall, or festival street at
+the foot of the Relay hill, where a local dance night naturally belongs. The
+route to the Relay Spire is blocked by a practical final-approach problem:
+festival setup temporarily occupies the service road with barriers, lantern
+lines, chair stacks, stage/speaker cables, and a locked gate.
+
+Once setup is safe enough, the steward can open one short daylight window for
+the final hill shuttle before the road closes again for the night festival. The
+player helps the hill-shuttle driver, the Last-Stop Operations Helper, and
+nearby festival helpers finish that setup window, giving the driver a believable
+reason and means to take the player toward the Relay overlook at sunset.
+
+Accepted arrival premise: **Opening Dance Setup + Last Daylight Shuttle**. This
+replaces the previous after-festival **Last Song Table + Final Shuttle Hold**
+candidate.
+
+```text
+Last-Stop Plaza at the foot of the Relay hill.
+Festival setup blocks the service road.
+Sign: "Service road closes for night dance. Last daylight shuttle after setup check."
+```
+
+## Main Residents
+
+On arrival, the hill-shuttle driver stands beside the shuttle near the locked
+service-road gate, checking the same route clipboard too many times. He cannot
+drive yet because setup is still blocking the service lane and the steward will
+not open the barrier until the lane is safe. He is genuinely working the
+afternoon/evening event shuttle shift, but the clipboard is also a safe place to
+hide from asking one small question before the dance begins.
+
+The romantic partner is the shy **Last-Stop Operations Helper**. She works the
+visible plaza table that sits between the shuttle, dance setup, and service-road
+barrier: shuttle questions, setup checklist, lantern tags/signs, volunteer
+handoff, and radioing the steward when the lane is clear. She is not a flashy
+performer; she is the trusted local who keeps the last-stop plaza from becoming
+confused. Emotionally, the operations table lets her keep being useful instead
+of becoming visible enough to be asked to dance.
+
+Supporting static residents:
+
+- traveler near the plaza entry: points the player toward the shuttle and
+  explains that Relay requires the last daylight hill shuttle
+- festival steward near the barrier: explains that the service road opens only
+  after setup is safe and closes again when the night festival begins
+- **Dance Teacher** near the floor: offers gentle facilitation, teaches one
+  small step, covers the operations watch once setup is proven safe, and notices
+  that two shy people are orbiting each other, but is not the romance target
+
+## Discovery Flow
+
+Use a **Practical Wayfinding Loop**, not a quest giver. The player arrives
+asking how to reach Relay, notices the closed service-road barrier and shuttle
+sign, then learns from practical local roles that the final daylight shuttle
+leaves after setup passes inspection and before the road closes for the night
+dance.
+
+First-read sequence:
+
+```text
+Player arrives at Last-Stop Plaza.
+Festival barriers, lantern lines, and shuttle sign show the route is blocked.
+Traveler says Relay requires the last daylight hill shuttle.
+Driver is visible by the shuttle, stuck on the route clipboard.
+Operations helper is visible near the dance floor, stuck perfecting setup details.
+Steward explains that the road opens after setup check, then closes for night.
+```
+
+The player's natural question should be "How do I get to Relay?", not "How do I
+fix the romance?" The romantic problem should emerge only after the player asks
+why the last daylight shuttle is delayed and notices that the driver and
+operations helper are both hiding inside practical work.
+
+Accepted conversation discovery pattern: **Triangulated Discovery Flow**. The
+player should be able to talk to the driver and Last-Stop Operations Helper
+first and receive practical but incomplete answers:
+
+```text
+Driver: cannot leave until setup clears and the steward opens the service gate.
+Operations helper: cannot stop fixing setup details until someone trusted checks the handoff.
+```
+
+Both answers are true, but they do not explain why the two are hiding inside
+work instead of making a small social move. The player can then return to the
+plaza and ask nearby locals what is going on.
+
+Possible local reads:
+
+- traveler: "The driver's been rereading that clipboard for ten minutes."
+- festival steward: "The shuttle waits on the lane. She waits on one perfect
+  lantern. He waits on anything except asking."
+- **Dance Teacher**: "They both know where the floor is. They are practicing
+  the art of being unavailable."
+
+This lets the player piece together the relationship from public behavior and
+local observations rather than receiving an instant confession or omniscient
+quest explanation.
+
+## Readiness Favors
+
+The player should not be able to solve the beat immediately by confronting the
+driver and Last-Stop Operations Helper with "you like each other." That would
+likely make shy people defensive and would flatten the scene into forced
+matchmaking.
+
+Instead, Opening Dance should use two **Readiness Favors**, one for each
+romantic character, before the setup handoff, last daylight shuttle, and later
+night-dance promise can happen.
+
+Current readiness direction:
+
+- driver insecurity: he does not know how to dance and does not want to
+  embarrass himself in front of the Last-Stop Operations Helper
+- Last-Stop Operations Helper insecurity: if she stays useful behind an
+  organizer role, she knows who she is; if she steps onto the floor, she is just
+  someone hoping to be asked
+
+The Readiness Favors should let the player help each person feel prepared while
+preserving their dignity.
+
+- Last-Stop Operations Helper: **Operations Handoff Check**. The player helps
+  her prove the plaza setup is safe enough by checking a few visible festival
+  details, then getting the **Dance Teacher** to keep watch once the night dance
+  starts. The emotional point is not that someone else can plan better; it is
+  that she has done enough and the event can keep going while she enjoys it.
+- Hill-shuttle driver: **One-Step Practice**. The player helps him learn exactly
+  one tiny dance step from the **Dance Teacher**, privately enough to protect his
+  dignity. He does not become good at dancing; he gains one small shared rhythm
+  he can offer later.
+
+After both romantic characters are ready, the connector is **Folded Song
+Request**. The driver writes a tiny folded paper request at the operations
+table, requesting a simple, cute song and asking her for one dance later without
+making a public confession. The request should not lock the beat to bachata or
+any other specific dance genre; it should feel playable on guitar, simple enough
+for a non-dancer, and emotionally compatible with the later Guitar Farewell
+montage.
+
+The exact requested song does not need to be shown or heard by the player; the
+only presented music can be the guitar during the farewell. It can use her own
+event paper, handwriting marks, or song-request language so the ask feels rooted
+in her work rather than imposed by the player.
+
+## Setup Clearance
+
+Required relocation should stay minimal. After the player helps, the driver and
+Last-Stop Operations Helper can share or acknowledge the Folded Song Request,
+then return to their practical roles for the **Setup Clearance Walkthrough**:
+the remaining visible setup details clear the service lane enough for the
+steward to open the barrier and the driver to offer the last daylight ride
+toward Relay.
+
+Present this as a **Prompt-Driven Playable Montage**, not a full manual chore
+sequence or pure cutscene. The player chooses a prompt such as "Help with
+remaining preparations," then triggers a few authored interaction snaps.
+
+Default symbolic set:
+
+- secure the lantern line
+- clear or tape the service-lane obstruction
+- flip the shuttle sign to "Last daylight ride"
+
+Treat these as one-action story beats rather than small chore gameplay; they
+can collapse further if the beat needs to move faster. After the snaps, the sky
+warms, the plaza reads more ready, the **Dance Teacher** keeps watch, and the
+steward opens the gate. The actual dance can remain a promised night-festival
+moment and/or appear in the Guitar Farewell montage.
+
+## Locked Character Roles
+
+The nervous dance resident is the **hill-shuttle driver**. He runs the last
+practical route up toward the Relay overlook, but he is stuck at the festival
+because the service road is not yet clear and because he cannot bring himself to
+ask about the night dance. His daily job, his emotional problem, and the
+player's route blocker should all point at the same practical situation. Do not
+assign him a proper name yet; the role label is enough until a later character
+pass.
+
+The shy **Last-Stop Operations Helper** is the locked romantic partner. She
+belongs in this place because her daily work sits between the dance, the
+service-road barrier, and the last daylight shuttle without requiring technical
+explanation. She likes the driver because he is quietly reliable: he waits for
+helpers to finish packing, remembers nervous passengers, and takes the hill
+road gently. He likes her because she notices small things and keeps the
+last-stop plaza feeling kind. Do not assign her a proper name yet; the role
+label is the canonical placeholder until her movement and emotional function are
+stable.
+
+The **Dance Teacher** exists as a facilitator rather than the romance target.
+They teach one small step, give the player social cover, cover the operations
+watch after the handoff, and notice that two shy people are orbiting each other.
+Avoid turning the beat into a competition for the teacher's attention unless a
+later tone pass proves it can stay gentle.
+
+## Conversation And Tone
+
+Conversation design should use **Recoverable Conversation Choices**. The player
+should feel agency through what they ask, who they approach first, how they
+encourage the driver, and how they recover from a clumsy read. A failed path can
+create awkwardness, delay, or require extra listening, but it should not
+permanently block the first ending.
+
+Do not use a purely magical or abstract "dance crossing" explanation. This beat
+must answer:
+
+- where a dance naturally belongs in the final approach environment
+- what physical barricade prevents the player from reaching the Relay Spire
+- why the resident being helped has a believable reason and practical way to
+  help with that barricade
+- what small backstory or daily purpose makes each involved resident feel like a
+  local person rather than a route-solving robot
+
+The couple should be emotionally inspired by Danilo and Milena's story without
+being literal stand-ins. Protect the intimacy: carry the emotional truth through
+fictional residents, not a private memory exhibit.
+
+The main solution should be conversation, collection, and gentle setup. An
+optional dance/rhythm mini-game can deepen the beat later, but the first ending
+path should not depend on arcade performance.
+
+## Cicka And Counterpart Cat
+
+Use **Dance Festival Resting Spot** as the practical label.
+
+- Before resolution: Cicka loafs near the operations table, shuttle step,
+  lantern crates, or service gate.
+- After resolution: Cicka settles near the cleared service gate or finished
+  shuttle sign, optionally beside the Unnamed Counterpart Cat.
+
+Cicka does not explain love or grief. She watches from the edge of the dance
+setup, perhaps walking through the cleared lane afterward as if the whole thing
+was obvious.
+
+She can also hang out with the **Unnamed Counterpart Cat** near the operations
+table or service gate: loafing together, staring at the same lantern, or briefly
+playing while the humans work. The counterpart cat can visually contrast with
+Cicka, such as a pale or white cat if Cicka reads dark, so that Micka's later
+half-and-half design feels quietly prepared. Do not name him, label him as
+Micka's father, or confirm parentage before the post-ending return.
+
+## Relay Transition
+
+The player catches the sunset shuttle to Relay through a **Short Threshold
+Transition**, not a controllable driving scene. The driver can say a small line
+such as "All aboard the last ride," the vehicle starts over a brief blackout,
+and the player respawns at Relay Spire under sunset.
+
+Control resumes at Cicka's overlook spot for the **Sit and Play Prompt** and
+**Guitar Farewell**. The later night festival can appear as a **Living Proof
+Montage** image during the farewell instead of pulling the playable ending away
+from Cicka; the dancing can read as an emotional echo of the player's guitar
+rather than revealing or playing the actual requested festival song. After the
+montage, Relay returns in **Relay Blue Hour** for the **Send the Sketchbook
+Prompt** rather than full night.
+
+The emotional lesson is that life can continue and new love can arrive after
+loss without replacing what was lost.
+
+## Open Local Slots
+
+- exact room topology for Last-Stop Plaza, service-road gate, shuttle,
+  operations table, dance floor, lantern lines, and exits
+- concrete prompts, object interactions, conversation branches, and recovery
+  paths
+- whether the player can help the driver or Last-Stop Operations Helper first
+- final 2-3 authored snaps for Setup Clearance Walkthrough
+- silhouettes, movement, dialogue style, and eventual names for local residents
+- festival palette, signage, music texture, crowd ambience, and prop kit
+- smallest playable version that still lands final emotional readiness before
+  Relay

--- a/docs/game-design/ridge/areas/03-dance-festival/characters.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/characters.md
@@ -1,0 +1,86 @@
+# Dance Festival Characters
+
+> Status: accepted role direction / needs character pass.
+> Parent: [`README.md`](./README.md).
+
+This file owns local character roles, Cicka use, and naming boundaries for Dance
+Festival.
+
+## Main Residents
+
+On arrival, the **hill-shuttle driver** stands beside the shuttle near the
+locked service-road gate, checking the same route clipboard too many times. He
+cannot drive yet because setup is still blocking the service lane and the
+steward will not open the barrier until the lane is safe. He is genuinely
+working the afternoon/evening event shuttle shift, but the clipboard is also a
+safe place to hide from asking one small question before the dance begins.
+
+The romantic partner is the shy **Last-Stop Operations Helper**. She works the
+visible plaza table that sits between the shuttle, dance setup, and service-road
+barrier: shuttle questions, setup checklist, lantern tags/signs, volunteer
+handoff, and radioing the steward when the lane is clear. She is not a flashy
+performer; she is the trusted local who keeps the last-stop plaza from becoming
+confused. Emotionally, the operations table lets her keep being useful instead
+of becoming visible enough to be asked to dance.
+
+## Supporting Static Residents
+
+- traveler near the plaza entry: points the player toward the shuttle and
+  explains that Relay requires the last daylight hill shuttle
+- festival steward near the barrier: explains that the service road opens only
+  after setup is safe and closes again when the night festival begins
+- **Dance Teacher** near the floor: offers gentle facilitation, teaches one
+  small step, covers the operations watch once setup is proven safe, and notices
+  that two shy people are orbiting each other, but is not the romance target
+
+## Locked Character Roles
+
+The nervous dance resident is the **hill-shuttle driver**. He runs the last
+practical route up toward the Relay overlook, but he is stuck at the festival
+because the service road is not yet clear and because he cannot bring himself to
+ask about the night dance. His daily job, his emotional problem, and the
+player's route blocker should all point at the same practical situation. Do not
+assign him a proper name yet; the role label is enough until a later character
+pass.
+
+The shy **Last-Stop Operations Helper** is the locked romantic partner. She
+belongs in this place because her daily work sits between the dance, the
+service-road barrier, and the last daylight shuttle without requiring technical
+explanation. She likes the driver because he is quietly reliable: he waits for
+helpers to finish packing, remembers nervous passengers, and takes the hill road
+gently. He likes her because she notices small things and keeps the last-stop
+plaza feeling kind. Do not assign her a proper name yet; the role label is the
+canonical placeholder until her movement and emotional function are stable.
+
+The **Dance Teacher** exists as a facilitator rather than the romance target.
+They teach one small step, give the player social cover, cover the operations
+watch after the handoff, and notice that two shy people are orbiting each other.
+Avoid turning the beat into a competition for the teacher's attention unless a
+later tone pass proves it can stay gentle.
+
+## Cicka And Counterpart Cat
+
+Use **Dance Festival Resting Spot** as the practical label.
+
+- Before resolution: Cicka loafs near the operations table, shuttle step,
+  lantern crates, or service gate.
+- After resolution: Cicka settles near the cleared service gate or finished
+  shuttle sign, optionally beside the Unnamed Counterpart Cat.
+
+Cicka does not explain love or grief. She watches from the edge of the dance
+setup, perhaps walking through the cleared lane afterward as if the whole thing
+was obvious.
+
+She can also hang out with the **Unnamed Counterpart Cat** near the operations
+table or service gate: loafing together, staring at the same lantern, or
+briefly playing while the humans work. The counterpart cat can visually contrast
+with Cicka, such as a pale or white cat if Cicka reads dark, so that Micka's
+later half-and-half design feels quietly prepared. Do not name him, label him
+as Micka's father, or confirm parentage before the post-ending return.
+
+## Open Character Slots
+
+- silhouettes and movement style for each resident
+- dialogue style for the hill-shuttle driver and Last-Stop Operations Helper
+- eventual proper names, after role-first labels survive design review
+- how the Unnamed Counterpart Cat visually contrasts with Cicka

--- a/docs/game-design/ridge/areas/03-dance-festival/interaction-flow.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/interaction-flow.md
@@ -100,6 +100,23 @@ only presented music can be the guitar during the farewell. It can use her own
 event paper, handwriting marks, or song-request language so the ask feels rooted
 in her work rather than imposed by the player.
 
+## Object Handoffs
+
+The Dance Festival's "collection" should mean a few grounded prop handoffs, not
+a fetch quest or inventory hunt. Keep the required objects tied to visible setup
+work and character readiness:
+
+- setup checklist / lantern tag: confirms the Operations Handoff Check
+- route clipboard or radio acknowledgement: confirms the driver can make the
+  last daylight shuttle once the steward opens the lane
+- blank song-request slip: becomes the **Folded Song Request** after the driver
+  writes it
+- service-lane tape/sign interaction: clears the lane during Setup Clearance
+
+These can be represented as prompts, brief pickups, or immediate handoffs. The
+important read is that the player helped people finish concrete local tasks,
+not that they vacuumed collectibles out of the plaza.
+
 ## Setup Clearance
 
 Required relocation should stay minimal. After the player helps, the driver and
@@ -147,9 +164,9 @@ The couple should be emotionally inspired by Danilo and Milena's story without
 being literal stand-ins. Protect the intimacy: carry the emotional truth through
 fictional residents, not a private memory exhibit.
 
-The main solution should be conversation, collection, and gentle setup. An
-optional dance/rhythm mini-game can deepen the beat later, but the first ending
-path should not depend on arcade performance.
+The main solution should be conversation, the small object handoffs above, and
+gentle setup. An optional dance/rhythm mini-game can deepen the beat later, but
+the first ending path should not depend on arcade performance.
 
 ## Relay Transition
 

--- a/docs/game-design/ridge/areas/03-dance-festival/interaction-flow.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/interaction-flow.md
@@ -1,0 +1,179 @@
+# Dance Festival Interaction Flow
+
+> Status: accepted interaction direction / needs prompt pass.
+> Parent: [`README.md`](./README.md).
+
+This file owns the playable sequence, prompts, recovery paths, and transition to
+Relay for Dance Festival.
+
+## Discovery Flow
+
+Use a **Practical Wayfinding Loop**, not a quest giver. The player arrives
+asking how to reach Relay, notices the closed service-road barrier and shuttle
+sign, then learns from practical local roles that the final daylight shuttle
+leaves after setup passes inspection and before the road closes for the night
+dance.
+
+First-read sequence:
+
+```text
+Player arrives at Last-Stop Plaza.
+Festival barriers, lantern lines, and shuttle sign show the route is blocked.
+Traveler says Relay requires the last daylight hill shuttle.
+Driver is visible by the shuttle, stuck on the route clipboard.
+Operations helper is visible near the dance floor, stuck perfecting setup details.
+Steward explains that the road opens after setup check, then closes for night.
+```
+
+The player's natural question should be "How do I get to Relay?", not "How do I
+fix the romance?" The romantic problem should emerge only after the player asks
+why the last daylight shuttle is delayed and notices that the driver and
+operations helper are both hiding inside practical work.
+
+Accepted conversation discovery pattern: **Triangulated Discovery Flow**. The
+player should be able to talk to the driver and Last-Stop Operations Helper
+first and receive practical but incomplete answers:
+
+```text
+Driver: cannot leave until setup clears and the steward opens the service gate.
+Operations helper: cannot stop fixing setup details until someone trusted checks the handoff.
+```
+
+Both answers are true, but they do not explain why the two are hiding inside
+work instead of making a small social move. The player can then return to the
+plaza and ask nearby locals what is going on.
+
+Possible local reads:
+
+- traveler: "The driver's been rereading that clipboard for ten minutes."
+- festival steward: "The shuttle waits on the lane. She waits on one perfect
+  lantern. He waits on anything except asking."
+- **Dance Teacher**: "They both know where the floor is. They are practicing
+  the art of being unavailable."
+
+This lets the player piece together the relationship from public behavior and
+local observations rather than receiving an instant confession or omniscient
+quest explanation.
+
+## Readiness Favors
+
+The player should not be able to solve the beat immediately by confronting the
+driver and Last-Stop Operations Helper with "you like each other." That would
+likely make shy people defensive and would flatten the scene into forced
+matchmaking.
+
+Instead, Opening Dance should use two **Readiness Favors**, one for each
+romantic character, before the setup handoff, last daylight shuttle, and later
+night-dance promise can happen.
+
+Current readiness direction:
+
+- driver insecurity: he does not know how to dance and does not want to
+  embarrass himself in front of the Last-Stop Operations Helper
+- Last-Stop Operations Helper insecurity: if she stays useful behind an
+  organizer role, she knows who she is; if she steps onto the floor, she is just
+  someone hoping to be asked
+
+The Readiness Favors should let the player help each person feel prepared while
+preserving their dignity.
+
+- Last-Stop Operations Helper: **Operations Handoff Check**. The player helps
+  her prove the plaza setup is safe enough by checking a few visible festival
+  details, then getting the **Dance Teacher** to keep watch once the night dance
+  starts. The emotional point is not that someone else can plan better; it is
+  that she has done enough and the event can keep going while she enjoys it.
+- Hill-shuttle driver: **One-Step Practice**. The player helps him learn exactly
+  one tiny dance step from the **Dance Teacher**, privately enough to protect his
+  dignity. He does not become good at dancing; he gains one small shared rhythm
+  he can offer later.
+
+After both romantic characters are ready, the connector is **Folded Song
+Request**. The driver writes a tiny folded paper request at the operations
+table, requesting a simple, cute song and asking her for one dance later without
+making a public confession. The request should not lock the beat to bachata or
+any other specific dance genre; it should feel playable on guitar, simple enough
+for a non-dancer, and emotionally compatible with the later Guitar Farewell
+montage.
+
+The exact requested song does not need to be shown or heard by the player; the
+only presented music can be the guitar during the farewell. It can use her own
+event paper, handwriting marks, or song-request language so the ask feels rooted
+in her work rather than imposed by the player.
+
+## Setup Clearance
+
+Required relocation should stay minimal. After the player helps, the driver and
+Last-Stop Operations Helper can share or acknowledge the Folded Song Request,
+then return to their practical roles for the **Setup Clearance Walkthrough**:
+the remaining visible setup details clear the service lane enough for the
+steward to open the barrier and the driver to offer the last daylight ride
+toward Relay.
+
+Present this as a **Prompt-Driven Playable Montage**, not a full manual chore
+sequence or pure cutscene. The player chooses a prompt such as "Help with
+remaining preparations," then triggers a few authored interaction snaps.
+
+Default symbolic set:
+
+- secure the lantern line
+- clear or tape the service-lane obstruction
+- flip the shuttle sign to "Last daylight ride"
+
+Treat these as one-action story beats rather than small chore gameplay; they
+can collapse further if the beat needs to move faster. After the snaps, the sky
+warms, the plaza reads more ready, the **Dance Teacher** keeps watch, and the
+steward opens the gate. The actual dance can remain a promised night-festival
+moment and/or appear in the Guitar Farewell montage.
+
+## Conversation And Tone
+
+Conversation design should use **Recoverable Conversation Choices**. The player
+should feel agency through what they ask, who they approach first, how they
+encourage the driver, and how they recover from a clumsy read. A failed path can
+create awkwardness, delay, or require extra listening, but it should not
+permanently block the first ending.
+
+Do not use a purely magical or abstract "dance crossing" explanation. This beat
+must answer:
+
+- where a dance naturally belongs in the final approach environment
+- what physical barricade prevents the player from reaching the Relay Spire
+- why the resident being helped has a believable reason and practical way to
+  help with that barricade
+- what small backstory or daily purpose makes each involved resident feel like a
+  local person rather than a route-solving robot
+
+The couple should be emotionally inspired by Danilo and Milena's story without
+being literal stand-ins. Protect the intimacy: carry the emotional truth through
+fictional residents, not a private memory exhibit.
+
+The main solution should be conversation, collection, and gentle setup. An
+optional dance/rhythm mini-game can deepen the beat later, but the first ending
+path should not depend on arcade performance.
+
+## Relay Transition
+
+The player catches the sunset shuttle to Relay through a **Short Threshold
+Transition**, not a controllable driving scene. The driver can say a small line
+such as "All aboard the last ride," the vehicle starts over a brief blackout,
+and the player respawns at Relay Spire under sunset.
+
+Control resumes at Cicka's overlook spot for the **Sit and Play Prompt** and
+**Guitar Farewell**. The later night festival can appear as a **Living Proof
+Montage** image during the farewell instead of pulling the playable ending away
+from Cicka; the dancing can read as an emotional echo of the player's guitar
+rather than revealing or playing the actual requested festival song. After the
+montage, Relay returns in **Relay Blue Hour** for the **Send the Sketchbook
+Prompt** rather than full night.
+
+The emotional lesson is that life can continue and new love can arrive after
+loss without replacing what was lost.
+
+## Open Prompt Slots
+
+- concrete prompts, object interactions, conversation branches, and recovery
+  paths
+- whether the player can help the driver or Last-Stop Operations Helper first
+- final 2-3 authored snaps for Setup Clearance Walkthrough
+- smallest playable version that still lands final emotional readiness before
+  Relay

--- a/docs/game-design/ridge/areas/03-dance-festival/layout.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/layout.md
@@ -48,12 +48,13 @@ Sign: "Service road closes for night dance. Last daylight shuttle after setup ch
 - service-road gate or barrier
 - last daylight shuttle sign
 - shuttle or shuttle stop
-- operations table with checklist, lantern tags, radio, or route papers
+- operations table with the setup checklist, lantern tags, radio, route clipboard,
+  and blank song-request slips
 - lantern lines
 - chair stacks
 - stage/speaker cables
 - dance-floor edge
-- folded song-request paper
+- folded song-request paper after the driver writes it
 
 ## Visual And Audio Direction
 

--- a/docs/game-design/ridge/areas/03-dance-festival/layout.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/layout.md
@@ -1,0 +1,80 @@
+# Dance Festival Layout
+
+> Status: accepted layout direction / needs spatial pass.
+> Parent: [`README.md`](./README.md).
+
+This file owns Dance Festival geography, blocker staging, and visual/audio
+placement questions.
+
+## Geography And Blocker
+
+The dance happens in a small town square, community hall, or festival street at
+the foot of the Relay hill, where a local dance night naturally belongs. The
+route to the Relay Spire is blocked by a practical final-approach problem:
+festival setup temporarily occupies the service road with barriers, lantern
+lines, chair stacks, stage/speaker cables, and a locked gate.
+
+Once setup is safe enough, the steward can open one short daylight window for
+the final hill shuttle before the road closes again for the night festival. The
+player helps the hill-shuttle driver, the Last-Stop Operations Helper, and
+nearby festival helpers finish that setup window, giving the driver a believable
+reason and means to take the player toward the Relay overlook at sunset.
+
+Accepted arrival premise: **Opening Dance Setup + Last Daylight Shuttle**. This
+replaces the previous after-festival **Last Song Table + Final Shuttle Hold**
+candidate.
+
+```text
+Last-Stop Plaza at the foot of the Relay hill.
+Festival setup blocks the service road.
+Sign: "Service road closes for night dance. Last daylight shuttle after setup check."
+```
+
+## Required Readability
+
+- The closed service-road barrier must be visible before the player understands
+  the romance.
+- The shuttle and shuttle sign should make Relay feel reachable but delayed.
+- The operations table should sit between the shuttle, dance setup, and
+  service-road barrier so the Last-Stop Operations Helper has a practical reason
+  to be central.
+- The dance floor should be readable enough to promise the night dance without
+  pulling focus away from the final ride to Relay.
+- The steward position should make the road rule feel local and practical, not
+  arbitrary.
+
+## Default Prop Set
+
+- service-road gate or barrier
+- last daylight shuttle sign
+- shuttle or shuttle stop
+- operations table with checklist, lantern tags, radio, or route papers
+- lantern lines
+- chair stacks
+- stage/speaker cables
+- dance-floor edge
+- folded song-request paper
+
+## Visual And Audio Direction
+
+The area should feel warm and romantic without colliding with Concert or the
+later Guitar Farewell. The promised night festival can be visually present
+through setup, lanterns, crowd preparation, and ambient anticipation, while the
+actual full dance stays mostly offscreen or appears later in the ending montage.
+
+Open art/audio choices:
+
+- afternoon-to-sunset palette
+- signage language
+- crowd ambience level
+- music texture before the dance begins
+- lantern and paper prop kit
+- how this area's sound differs from Concert's guitar focus
+
+## Open Spatial Slots
+
+- exact room topology for Last-Stop Plaza
+- camera framing for plaza entry, shuttle, operations table, service gate, and
+  dance floor
+- whether the road gate is one screen or a visible edge across several screens
+- final 2-3 setup snaps that visibly clear the service lane

--- a/docs/game-design/ridge/areas/04-relay-ending/README.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/README.md
@@ -1,0 +1,68 @@
+# Relay Ending Area
+
+> Status: active ending direction / needs staging pass.
+> Read [`../../README.md`](../../README.md) and
+> [`../README.md`](../README.md) before editing this file.
+
+This file owns local design detail for **Relay Spire / Guitar Farewell / Cicka
+Threshold Farewell**. The route-level ending order and Living Proof rules live
+in [`../../story-level-bible.md`](../../story-level-bible.md).
+
+## Route Role
+
+Relay Ending Area is the final threshold after Bridge, Concert, and Dance
+Festival have created enough Living Proof.
+
+The emotional idea is: **I am ready for Cicka's threshold farewell.**
+
+## Accepted Local Contract
+
+- Relay Spire can be physically reachable before it is ready to send.
+- Once Living Proof is enough, the Relay sign becomes readable.
+- Cicka appears in her final field-presence spot, calm and familiar.
+- The player uses **Sit and Play** near Cicka to share the **Guitar Farewell**.
+- A brief **Living Proof Montage** may appear during the guitar.
+- Control returns in **Relay Blue Hour** for **Send the Sketchbook Prompt**.
+- Cicka walks with the player to the threshold, pauses, looks back once, leaves
+  one final paw/page mark, then slips into a page fold or light beyond the
+  player's path.
+- The player returns to the **Open Ridge Return State** with the canonical final
+  mark preserved at Relay and one quiet Concert Resting Spot echo.
+
+## Tone Boundaries
+
+- no literal death scene
+- no grief monologue
+- no credits-only ending
+- no arcade pass/fail challenge during the Guitar Farewell
+- no explanatory departure speech and no written goodbye in the initial version
+- no immediate replacement reveal; Micka remains delayed
+- no scattering sad marks everywhere in the initial return state
+
+## Living Proof Feedback
+
+Unresolved. The player needs a readable state for:
+
+- Relay reachable but not ready
+- Relay ready after the three required Ridge Areas
+- transition from sunset Guitar Farewell to Relay Blue Hour
+
+The feedback should feel like emotional and semantic readiness, not an exact
+visible checklist.
+
+## Cicka Threshold Staging
+
+Unresolved. This area still needs exact decisions for camera behavior, input
+handoff, animation beats, silence, audio, mark placement, threshold geometry,
+and post-ending interactability.
+
+## Open Local Slots
+
+- physical Relay topology and threshold geometry
+- final Cicka field-presence spot
+- camera and input handoff for Sit and Play
+- guitar audio texture and silence timing
+- Living Proof Montage length and image order
+- Send the Sketchbook Prompt presentation
+- Open Ridge Return State interactions
+- delayed Micka trigger

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -21,7 +21,7 @@ questions.
 | --- | --- | --- |
 | 1 | [`01-bridge/README.md`](./01-bridge/README.md) | Blueprint Bridge, first resident-help soft gate, first Cicka attention cue |
 | 2 | [`02-concert/README.md`](./02-concert/README.md) | Concert Crossing, guitar acquisition, comfort-through-memory beat |
-| 3 | [`03-dance-festival/README.md`](./03-dance-festival/README.md) | Opening Dance Shuttle, last daylight shuttle, final pre-Relay readiness |
+| 3 | [`03-dance-festival/README.md`](./03-dance-festival/README.md) | Opening Dance Shuttle index; local detail split into [`layout.md`](./03-dance-festival/layout.md), [`characters.md`](./03-dance-festival/characters.md), and [`interaction-flow.md`](./03-dance-festival/interaction-flow.md) |
 | 4 | [`04-relay-ending/README.md`](./04-relay-ending/README.md) | Relay Spire, Guitar Farewell staging, Cicka Threshold Farewell, return state |
 
 ## Update Rules
@@ -36,3 +36,5 @@ questions.
   [`../story-level-bible.md`](../story-level-bible.md) too.
 - If a design becomes implementation work, publish or update a GitHub Issue
   instead of adding a local backlog.
+- If an area folder has subdocs, update the narrowest subdoc first and keep the
+  area `README.md` as the quick local index.

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -1,0 +1,38 @@
+# Ridge Areas
+
+> Status: active design index.
+> Read [`../README.md`](../README.md) first for Ridge source-of-truth routing.
+
+This folder holds the local source-of-truth docs for the active Ridge route:
+
+```text
+01 Bridge Area -> 02 Concert Area -> 03 Dance Festival Area -> 04 Relay Ending
+```
+
+Use [`../story-level-bible.md`](../story-level-bible.md) for the route spine,
+ending order, Living Proof rules, and cross-area Cicka/guitar logic. Use these
+area files for local geography, blockers, residents, prompts, traversal,
+staging, Cicka Resting Spot details, visual/audio notes, and area-specific open
+questions.
+
+## Area Docs
+
+| Route order | Area doc | Owns |
+| --- | --- | --- |
+| 1 | [`01-bridge/README.md`](./01-bridge/README.md) | Blueprint Bridge, first resident-help soft gate, first Cicka attention cue |
+| 2 | [`02-concert/README.md`](./02-concert/README.md) | Concert Crossing, guitar acquisition, comfort-through-memory beat |
+| 3 | [`03-dance-festival/README.md`](./03-dance-festival/README.md) | Opening Dance Shuttle, last daylight shuttle, final pre-Relay readiness |
+| 4 | [`04-relay-ending/README.md`](./04-relay-ending/README.md) | Relay Spire, Guitar Farewell staging, Cicka Threshold Farewell, return state |
+
+## Update Rules
+
+- Keep each area doc focused on one playable area or ending location.
+- Do not paste full research transcripts here; route them through
+  [`../decision-intake.md`](../decision-intake.md).
+- Put unresolved decisions in [`../open-questions.md`](../open-questions.md)
+  unless they are purely local notes inside one area doc.
+- If an area decision changes the route order, Living Proof logic, Cicka's
+  cross-area role, or guitar/ending dependency, update
+  [`../story-level-bible.md`](../story-level-bible.md) too.
+- If a design becomes implementation work, publish or update a GitHub Issue
+  instead of adding a local backlog.

--- a/docs/game-design/ridge/current-level.md
+++ b/docs/game-design/ridge/current-level.md
@@ -222,32 +222,55 @@ The target asks for:
 - 2-3 required main-path Resident Room Beats before the first ending, each
   centered on a Resident Help Beat, with optional extra residents only if they
   add texture instead of errand fatigue
-- final required Resident Room Beat candidate as Last Dance / Bachata Crossing:
-  a nervous dance/romance setup at the foot of the Relay hill. The route
-  blocker should be practical: festival barriers, a locked service-road gate,
-  and/or the last hill shuttle not running until the event closes properly. The
-  locked route-agent is the nervous hill-shuttle driver, whose daily job and
-  emotional problem both connect to the final approach. His romantic partner is
-  the shy last-stop song-table volunteer, whose daily work connects the dance,
-  final shuttle, service-road barrier, and last-song timing. Locked arrival
-  state: **Last Song Table + Final Shuttle Hold**. The driver waits by the
-  shuttle with the route clipboard; the volunteer stays at the song table
-  because the final song stalls unless a trusted person covers it.
-  Introduce the beat through a practical wayfinding loop: the player asks how
-  to reach Relay, notices the blocked service road and shuttle sign, then
-  discovers the emotional layer through the delayed final song. Reveal the
-  relationship through a triangulated discovery flow: the driver and song-table
-  volunteer give truthful but incomplete practical answers, then nearby locals
-  help the player understand that they are avoiding each other. Do not let the
-  player solve the beat by directly confronting them with their feelings. Each
-  romantic character should need a small readiness favor before the final song,
-  shy dance, and lane-clearing handoff can happen. Conversation choices can
+- final required Resident Room Beat candidate as **Opening Dance Shuttle Beat**:
+  a nervous dance/romance setup at the foot of the Relay hill. The night dance
+  festival is real, but the required route beat happens during afternoon setup.
+  The route blocker should be practical: festival barriers, lantern lines,
+  chair stacks, stage/speaker cables, and a locked service-road gate block the
+  hill route until setup passes inspection. The locked route-agent is the
+  nervous hill-shuttle driver, whose daily job and emotional problem both
+  connect to the final approach. His romantic partner is the shy **Last-Stop
+  Operations Helper**, whose visible plaza-table work connects shuttle
+  questions, setup checks, volunteer handoffs, service-road clearance, and the
+  night dance. Accepted arrival premise: **Opening Dance Setup + Last Daylight
+  Shuttle**. Introduce the beat through a practical wayfinding loop:
+  the player asks how to reach Relay, notices the blocked service road and
+  shuttle sign, then discovers the emotional layer through delayed setup and the
+  last daylight shuttle window before the road closes for the night festival.
+  Reveal the relationship through a triangulated discovery flow: the driver and
+  Last-Stop Operations Helper give truthful but incomplete practical answers,
+  then nearby locals help the player understand that they are avoiding each
+  other. Do not let the player solve the beat by directly confronting them with
+  their feelings. The Last-Stop Operations Helper's readiness favor is
+  **Operations Handoff Check**: the player helps prove the plaza setup is safe
+  enough for a trusted resident to keep watch once the night dance starts, with
+  the dance teacher as the simplest current cover candidate. The point is not
+  replacing her planning; it is showing that she did enough and can enjoy the
+  event. The driver's readiness favor is **One-Step Practice**: the player helps
+  him privately learn one tiny dance step before the setup handoff, last
+  daylight ride, and later night-dance promise can happen. After both favors,
+  the connector is **Folded Song Request**: a tiny paper invitation that lets the
+  driver ask her for one dance later without a public confession. The physical
+  route solve is **Setup Clearance Walkthrough**: final visible setup details
+  clear the service lane enough for the steward to open the gate and the driver
+  to offer the last daylight ride. Present it as a **Prompt-Driven Playable
+  Montage**: a few authored interaction snaps plus a visible sky/plaza time
+  shift, not full manual chores or a pure cutscene. Conversation choices can
   create different tones, orderings, and recoverable awkward paths, but should
-  not permanently block the first ending.
+  not permanently block the first ending. Cicka's role is quiet threshold
+  observer near the operations table, shuttle step, or service gate; she can
+  loaf with the **Unnamed Counterpart Cat** as implied continuity foreshadowing,
+  using only silhouette/color specificity such as a pale or light-ink contrast
+  to Cicka. The scene should not name him, give him dialogue, confirm parentage,
+  or spend Micka before the post-ending return.
 - required route spine: Blueprint Bridge means changing the world through art,
-  Concert Crossing means turning memory into comfort, Last Dance / Bachata
-  Crossing means life can keep moving with someone new, then Relay Spire /
+  Concert Crossing means turning memory into comfort, Opening Dance Shuttle
+  Beat means life can keep moving with someone new, then Relay Spire /
   Guitar Farewell resolves Cicka's threshold farewell
+- Guitar Farewell can include a brief **Living Proof Montage**: Blueprint Bridge
+  being used, Concert Crossing continuing, Opening Dance beginning at night, and
+  Cicka Home carrying accumulated marks. Keep it wordless or nearly wordless so
+  the focus stays on Cicka.
 - Cicka field presence in every required Resident Help Beat, with her role
   varying from subtle obstacle hint to changed-object observer to quiet trust marker
 - optional residents, NPCs, interactive props, and chill spaces that can offer

--- a/docs/game-design/ridge/current-level.md
+++ b/docs/game-design/ridge/current-level.md
@@ -10,6 +10,7 @@
 - **Runtime spatial data:** [`folded-desk-ridge.source.ts`](../../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts).
 - **Blockout language contract:** [`map-language.md`](./map-language.md).
 - **Current map target:** [`proper-map-plan.md`](./map-plans/proper-map-plan.md).
+- **Story/level plan:** [`story-level-bible.md`](./story-level-bible.md).
 - **Product vision:** [`summit.md`](./summit.md).
 - **Live implementation work:** GitHub Issues.
 
@@ -37,6 +38,29 @@ Current runtime characteristics:
 - Telegraph, Domino, high ledge, underpath, and other future beats are present
   as route promises or disabled/teased anchors until their implementation
   slices exist.
+- Ridge remains a proof-of-concept surface. The current playable traversal code
+  can be replaced if the next design pass preserves the useful source contract,
+  compiler, generated facts, and viewer/debugger workflow.
+
+## Protected PoC Assets
+
+The valuable Ridge proof-of-concept investment is the authoring and QA spine,
+not the current moment-to-moment traversal model.
+
+Preserve or adapt:
+
+- Ridge Blockout Source / source contract.
+- compiler and generated spatial facts.
+- route, anchor, shortcut, collider, validation, and mutation facts.
+- read-only previewer/debugger workflow.
+- map-loading path that lets agents and Danilo inspect topology quickly.
+
+Disposable if a better Ridge emerges:
+
+- current required-jump traversal feel.
+- slope/ramp-first geometry assumptions.
+- current folded-desk room arrangement.
+- any runtime module whose main job was proving the old platformer-like route.
 
 ## Current Route Read
 
@@ -62,15 +86,16 @@ Future or optional promises in the blockout include:
 - Telegraph cord drop back to Cicka Home.
 - Domino lift back to Cicka Home.
 
-The level-design goal is that the player learns a compact vertical route, sees
-Relay early, returns to Cicka Home through earned folds or drops, and learns
-Danilo through artifacts rather than static portfolio buildings.
+The level-design goal is that the player walks a compact lived-in sketchbook
+neighborhood, sees Relay early, follows subtle Cicka field-presence hints at
+route blockers, helps tiny residents change the route, and learns Danilo
+through artifacts rather than static portfolio buildings.
 
 ## Current Landmarks
 
 - **Outskirts:** old city edge / future Overworld absorption point, Basement
   hatch promise, Potassium hint space, early Relay sightline.
-- **Cicka Home:** emotional return anchor, Cicka perch, memento/home mutation
+- **Cicka Home:** progress memory space, Cicka home base, memento/home mutation
   space, future underpath clue.
 - **Work Artifact Ledge:** first obvious work/project artifact area with a
   side-shelf skill scrap promise.
@@ -106,17 +131,108 @@ Current accepted behavior:
 
 ## Current Target
 
-The current map target is the **Vertical Folded Ridge With Cicka Switchback**
+The current map target is the **Sketchbook Neighborhood Spine With Folded Shortcuts**
 from [`proper-map-plan.md`](./map-plans/proper-map-plan.md).
+
+Before implementing the next Ridge runtime or blockout rewrite, write and accept
+a prose story/level/character plan for the core Exploration Map scenes and
+their route blockers. Start from the middle/end emotional and progression beats,
+then work backward to the opening so the first scene teaches the right promise.
+Mini-games, shortcuts, and optional platforming pockets may stay rougher in
+this prose pass, but the core overworld/Ridge route blockers should be legible
+in words first.
+
+The accepted ending anchor is the **Cicka Threshold Farewell**: Cicka recurs
+through the Ridge as field presence, accompanies the player to the Relay Spire
+threshold, and then departs somewhere the player cannot follow. The ending
+should stay replayable, tender, and non-literal rather than becoming a death
+scene or grief speech.
+Design the canonical first ending before designing optional endings. Multiple
+endings are not required for the Ridge; add alternate endings only if a later
+story/level pass proves they create meaningful replay value without weakening
+the Cicka farewell.
+The first prose artifact should be a short ending sequence outline before any
+required Resident Room Beats are designed: arrival state, Relay readiness,
+Cicka's final field presence, farewell action, final mark, and return-to-Ridge
+state.
+
+Accepted first ending outline:
+
+1. The player reaches Relay Spire and can stand there before it is ready.
+2. Once Living Proof is enough, the Relay sign becomes readable.
+3. Cicka appears in her final field-presence spot, calm and familiar.
+4. The player shares a quiet Guitar Farewell with Cicka, ideally under a warm
+   sunset or other cozy threshold light.
+5. The player activates or sends the sketchbook.
+6. Cicka walks with the player to the threshold, pauses, leaves one final
+   paw/page mark, then departs somewhere unreachable.
+7. The player returns to Ridge after the ending, with the final mark preserved
+   and the world still open.
+
+The guitar should be established earlier as a meaningful comfort item: something
+the player can pick up, carry, and play in the world, especially at Cicka Home.
+Petting can be a smaller recurring affection interaction. A hug is optional and
+should wait until character art can support it without making the farewell feel
+awkward or over-staged.
+The guitar should enter mid-route through a Resident Room Beat as an entrusted
+reward or responsibility, not as a random pickup. A resident can give or lend it
+after the player helps with a local music/concert problem, then Cicka Home and
+quiet Ridge spots can teach the player that playing for Cicka is a comfort
+ritual before the Relay Spire ending.
+Middle required Resident Room Beat: **Concert Crossing Beat**. A blocked concert/traffic crossing
+halts the route because the local guitarist cannot play, the paper-stage setup
+is tangled, or the guitar needs a small repair. Cicka subtly points attention to
+the guitar case, loose string, or blocked crossing. The player learns a small
+Guitar-Hero-like performance mini-game, helps the concert continue, the crossing
+opens, and the guitar is entrusted to the player afterward. Keep the comedy
+gentle; avoid making the guitarist a joke-only drunk if that undercuts the later
+tribute.
+Because dialogue UI, character assets, route blockers, trees/props, and audio
+are already enough production load, the Concert Crossing Beat needs a non-arcade
+fallback: conversation, collection, practice together, or a forgiving auto-play
+path can resolve the main route while the Guitar-Hero-like mini-game remains the
+ideal or optional version.
+
+The final blocker should be a **Living Proof Gate**. The Relay Spire can be
+physically reachable early, but it should not send the sketchbook until the path
+has created enough resident/world changes, mini-game proofs, and Cicka
+familiarity to make the destination emotionally and semantically ready. Avoid an
+exact visible checklist unless testing shows the player needs clearer feedback.
+Planning assumption: start with 2-3 required main-path Resident Help Beats
+before the first ending, plus optional extra residents for return play. Treat the
+exact count as a Level Designer and Story/Tone tuning variable, not a fixed
+rule.
 
 The target asks for:
 
-- no long hallway row
-- vertical shelves and switchbacks
-- Cicka Home near the lower-middle as an emotional return anchor
-- main route traversal that stays mobile-safe
+- a readable mostly forward neighborhood route toward Relay Spire
+- Relay Spire physically reachable before it can send
+- Living Proof Gate made from enough visible world changes, proofs, and Cicka
+  familiarity rather than an exact checklist
+- first ending path completable through conversations, collection, authored
+  traversal, Resident Room Beats, and world changes without requiring full
+  arcade mini-games
+- Mini-Game Entrances as optional alternate path unlockers, proof sources,
+  rewards, or pure side fun
+- non-arcade fallback for any required beat that contains arcade-like interaction
+- tiny resident problems that create visible route changes
+- first v0 Resident Help Beat as a required soft gate: a closed/taped bridge or
+  missing-plank crossing with an obvious local solution
+- 2-3 required main-path Resident Room Beats before the first ending, each
+  centered on a Resident Help Beat, with optional extra residents only if they
+  add texture instead of errand fatigue
+- Cicka field presence in every required Resident Help Beat, with her role
+  varying from subtle obstacle hint to changed-object observer to quiet trust marker
+- optional residents, NPCs, interactive props, and chill spaces that can offer
+  mini-games, atmosphere, jokes, or company without solving barricades
+- Cicka Home as a progress memory space, not the only emotional anchor
+- no main-path slope reliance in v0; use chunky stairs, cords, shelves, bridges,
+  lifts, and soft drops
+- no required jump button on the v0 main route; use authored climb, descend,
+  drop, lift, bridge, enter, and inspect interactions instead
+- main route traversal that stays mobile-safe and object-driven
 - first-walk route mastery before dexterity
-- Cicka-return shortcuts after mini-game clears
+- folded shortcuts after mini-game clears or resident help beats
 - artifacts as physical learning objects, not resume modal replacements
 
 ## Not Current Scope
@@ -126,6 +242,9 @@ The target asks for:
 - Adding a generic mini-game framework.
 - Adding stored sticker state.
 - Making Cicka Home a checklist hub, shop, or quest board.
+- Making Cicka a continuous follower, puzzle solver, or explicit objective giver.
+- Using slopes/ramps as required main-path traversal in the v0 Ridge blockout.
+- Requiring jump as a core Exploration Map button in the v0 main route.
 - Requiring wall jump, double jump, or precision platforming for the first
   farewell route.
 - Moving the runtime blockout source again without an explicit migration issue

--- a/docs/game-design/ridge/current-level.md
+++ b/docs/game-design/ridge/current-level.md
@@ -41,6 +41,10 @@ Current runtime characteristics:
 - Ridge remains a proof-of-concept surface. The current playable traversal code
   can be replaced if the next design pass preserves the useful source contract,
   compiler, generated facts, and viewer/debugger workflow.
+- Newer story-route planning demotes Cicka Home from canonical hub to local
+  **Cicka Resting Spots** inside each required Ridge Area. The current
+  Cicka Home runtime pieces are proof-of-concept infrastructure until a route
+  rewrite chooses whether to adapt or remove them.
 
 ## Protected PoC Assets
 
@@ -152,9 +156,9 @@ endings are not required for the Ridge; add alternate endings only if a later
 story/level pass proves they create meaningful replay value without weakening
 the Cicka farewell.
 The first prose artifact should be a short ending sequence outline before any
-required Resident Room Beats are designed: arrival state, Relay readiness,
-Cicka's final field presence, farewell action, final mark, and return-to-Ridge
-state.
+required Ridge Areas / Resident Beats are designed: arrival state, Relay
+readiness, Cicka's final field presence, farewell action, final mark, and
+return-to-Ridge state.
 
 Accepted first ending outline:
 
@@ -167,25 +171,29 @@ Accepted first ending outline:
    the Sketchbook Prompt**.
 6. Cicka walks with the player to the threshold, pauses, looks back once, leaves
    one final paw/page mark, then slips into a page fold or light beyond the
-   player's path.
+   player's path. The initial version uses no translated farewell line.
 7. The player returns to the **Open Ridge Return State** after the ending, with
-   the final mark preserved, Cicka's absence felt through favorite spots or
-   marks, and the world still open.
+   the canonical final mark preserved at the Relay threshold, one quieter echo
+   at the Concert Resting Spot, and the world still open. The echo is the
+   empty usual spot plus one small paw/page mark, not the player's guitar left
+   behind.
 
 The guitar should be established earlier as a meaningful comfort item: something
-the player can pick up, carry, and play in the world, especially at Cicka Home.
+the player can pick up, carry, and play in the world, especially at local Cicka
+Resting Spots.
 Petting can be a smaller recurring affection interaction. A hug is optional and
 should wait until character art can support it without making the farewell feel
 awkward or over-staged.
-The guitar should enter mid-route through a Resident Room Beat as an entrusted
+The guitar should enter mid-route through a Resident Beat as an entrusted
 reward or responsibility, not as a random pickup. A resident can give or lend it
-after the player helps with a local music/concert problem, then Cicka Home and
-quiet Ridge spots can teach the player that playing for Cicka is a comfort
-ritual before the Relay Spire ending.
-Middle required Resident Room Beat: **Concert Crossing Beat**. A blocked concert/traffic crossing
-halts the route because the local guitarist cannot play, the paper-stage setup
-is tangled, or the guitar needs a small repair. Cicka subtly points attention to
-the guitar case, loose string, or blocked crossing. The player learns a small
+after the player helps with a local music/concert problem, then local Cicka
+Resting Spots can teach the player that playing for Cicka is a comfort ritual
+before the Relay Spire ending.
+Middle required Ridge Area / Resident Beat: **Concert Crossing Beat**. A
+blocked concert/traffic crossing halts the route because the local guitarist
+cannot play, the paper-stage setup is tangled, or the guitar needs a small
+repair. Cicka subtly points attention to the guitar case, loose string, or
+blocked crossing. The player learns a small
 Guitar-Hero-like performance mini-game, helps the concert continue, the crossing
 opens, and the guitar is entrusted to the player afterward. Keep the comedy
 gentle; avoid making the guitarist a joke-only drunk if that undercuts the later
@@ -213,8 +221,8 @@ The target asks for:
 - Living Proof Gate made from enough visible world changes, proofs, and Cicka
   familiarity rather than an exact checklist
 - first ending path completable through conversations, collection, authored
-  traversal, Resident Room Beats, and world changes without requiring full
-  arcade mini-games
+  traversal, Ridge Areas, Resident Beats, and world changes without requiring
+  full arcade mini-games
 - Mini-Game Entrances as optional alternate path unlockers, proof sources,
   rewards, or pure side fun
 - non-arcade fallback for any required beat that contains arcade-like interaction
@@ -222,10 +230,11 @@ The target asks for:
 - first v0 Resident Help Beat as **Blueprint Bridge**: a required soft gate
   where helping a resident finish a bridge drawing/blueprint makes the crossing
   real
-- 2-3 required main-path Resident Room Beats before the first ending, each
-  centered on a Resident Help Beat, with optional extra residents only if they
+- 2-3 required main-path Ridge Areas before the first ending, each centered on a
+  Resident Beat / Resident Help Beat, with optional extra residents only if they
   add texture instead of errand fatigue
-- final required Resident Room Beat candidate as **Opening Dance Shuttle Beat**:
+- final required Ridge Area / Resident Beat candidate as **Opening Dance
+  Shuttle Beat**:
   a nervous dance/romance setup at the foot of the Relay hill. The night dance
   festival is real, but the required route beat happens during afternoon setup.
   The route blocker should be practical: festival barriers, lantern lines,
@@ -235,8 +244,10 @@ The target asks for:
   connect to the final approach. His romantic partner is the shy **Last-Stop
   Operations Helper**, whose visible plaza-table work connects shuttle
   questions, setup checks, volunteer handoffs, service-road clearance, and the
-  night dance. Accepted arrival premise: **Opening Dance Setup + Last Daylight
-  Shuttle**. Introduce the beat through a practical wayfinding loop:
+  night dance. Keep these as role-first character labels for now; proper names
+  can wait until a later character pass. Accepted arrival premise: **Opening
+  Dance Setup + Last Daylight Shuttle**. Introduce the beat through a practical
+  wayfinding loop:
   the player asks how to reach Relay, notices the blocked service road and
   shuttle sign, then discovers the emotional layer through delayed setup and the
   last daylight shuttle window before the road closes for the night festival.
@@ -278,9 +289,9 @@ The target asks for:
   Guitar Farewell resolves Cicka's threshold farewell
 - Guitar Farewell can include a brief **Living Proof Montage**: Blueprint Bridge
   being used, Concert Crossing continuing, Opening Dance beginning at night as
-  an emotional echo under the player's guitar, and Cicka Home carrying
-  accumulated marks. Keep it wordless or nearly wordless so the focus stays on
-  Cicka.
+  an emotional echo under the player's guitar, and earlier Cicka Resting Spots
+  carrying accumulated marks. Keep it wordless or nearly wordless so the focus
+  stays on Cicka.
 - Relay time should progress from sunset for **Sit and Play Prompt** to **Relay
   Blue Hour** for **Send the Sketchbook Prompt**. The montage can show the night
   festival beginning elsewhere, but Relay should not become full night before
@@ -297,16 +308,21 @@ The target asks for:
   **Send the Sketchbook Prompt**. This starts the Cicka Threshold Farewell while
   keeping the guitar as comfort rather than the send button.
 - Cicka's departure should be physical and mostly silent: walk together, pause,
-  look back, final mark, then page-fold/light departure. Any meow or translated
-  fragment should stay tiny and optional.
+  look back, final mark, then page-fold/light departure. The initial version
+  should use no translated farewell line; a tiny raw meow/chirp sound can remain
+  optional if it supports the staging.
 - Immediate post-ending play should use the **Open Ridge Return State**:
-  replayable, quiet, and absence-marked. Micka remains delayed until the later
-  post-ending trigger rather than appearing immediately.
-- Cicka field presence in every required Resident Help Beat, with her role
-  varying from subtle obstacle hint to changed-object observer to quiet trust marker
+  replayable, quiet, and minimally absence-marked. The canonical final mark
+  persists at the Relay threshold, one quieter echo appears at the Concert
+  Resting Spot, and Micka remains delayed until the later post-ending trigger
+  rather than appearing immediately. The echo should be an empty usual spot with
+  one small paw/page mark, not the guitar left behind.
+- Cicka field presence in every required Resident Help Beat, with one local
+  **Cicka Resting Spot** per required Ridge Area. Her role can vary from
+  subtle obstacle hint to changed-object observer to quiet trust marker.
 - optional residents, NPCs, interactive props, and chill spaces that can offer
   mini-games, atmosphere, jokes, or company without solving barricades
-- Cicka Home as a progress memory space, not the only emotional anchor
+- Cicka Resting Spots as local progress-memory spaces, not hubs
 - no main-path slope reliance in v0; use chunky stairs, cords, shelves, bridges,
   lifts, and soft drops
 - no required jump button on the v0 main route; use authored climb, descend,
@@ -322,7 +338,7 @@ The target asks for:
 - Adding a minimap.
 - Adding a generic mini-game framework.
 - Adding stored sticker state.
-- Making Cicka Home a checklist hub, shop, or quest board.
+- Making Cicka Resting Spots into checklist hubs, shops, or quest boards.
 - Making Cicka a continuous follower, puzzle solver, or explicit objective giver.
 - Using slopes/ramps as required main-path traversal in the v0 Ridge blockout.
 - Requiring jump as a core Exploration Map button in the v0 main route.

--- a/docs/game-design/ridge/current-level.md
+++ b/docs/game-design/ridge/current-level.md
@@ -216,18 +216,19 @@ The target asks for:
   rewards, or pure side fun
 - non-arcade fallback for any required beat that contains arcade-like interaction
 - tiny resident problems that create visible route changes
-- first v0 Resident Help Beat as a required soft gate: a closed/taped bridge or
-  missing-plank crossing with an obvious local art/drawing solution
+- first v0 Resident Help Beat as **Blueprint Bridge**: a required soft gate
+  where helping a resident finish a bridge drawing/blueprint makes the crossing
+  real
 - 2-3 required main-path Resident Room Beats before the first ending, each
   centered on a Resident Help Beat, with optional extra residents only if they
   add texture instead of errand fatigue
 - final required Resident Room Beat candidate as Last Dance / Bachata Crossing:
   a nervous dance/romance setup that prepares the farewell without repeating the
   Guitar Farewell
-- required proof arc: Bridge means changing the world by making something
-  through art/drawing,
-  Concert means turning memory into comfort, Dance means life can keep moving
-  with someone new, then Relay is ready for Cicka's threshold farewell
+- required route spine: Blueprint Bridge means changing the world through art,
+  Concert Crossing means turning memory into comfort, Last Dance / Bachata
+  Crossing means life can keep moving with someone new, then Relay Spire /
+  Guitar Farewell resolves Cicka's threshold farewell
 - Cicka field presence in every required Resident Help Beat, with her role
   varying from subtle obstacle hint to changed-object observer to quiet trust marker
 - optional residents, NPCs, interactive props, and chill spaces that can offer

--- a/docs/game-design/ridge/current-level.md
+++ b/docs/game-design/ridge/current-level.md
@@ -252,8 +252,11 @@ The target asks for:
   event. The driver's readiness favor is **One-Step Practice**: the player helps
   him privately learn one tiny dance step before the setup handoff, last
   daylight ride, and later night-dance promise can happen. After both favors,
-  the connector is **Folded Song Request**: a tiny paper invitation that lets the
-  driver ask her for one dance later without a public confession. The physical
+  the connector is **Folded Song Request**: a tiny paper invitation where the
+  driver requests a simple, cute, guitar-friendly song and asks her for one
+  dance later without a public confession. Do not lock the beat to bachata or
+  any other specific dance genre; the exact requested song can remain unshown
+  and unheard by the player. The physical
   route solve is **Setup Clearance Walkthrough**: final visible setup details
   clear the service lane enough for the steward to open the gate and the driver
   to offer the last daylight ride. Present it as a **Prompt-Driven Playable
@@ -271,9 +274,10 @@ The target asks for:
   Beat means life can keep moving with someone new, then Relay Spire /
   Guitar Farewell resolves Cicka's threshold farewell
 - Guitar Farewell can include a brief **Living Proof Montage**: Blueprint Bridge
-  being used, Concert Crossing continuing, Opening Dance beginning at night, and
-  Cicka Home carrying accumulated marks. Keep it wordless or nearly wordless so
-  the focus stays on Cicka.
+  being used, Concert Crossing continuing, Opening Dance beginning at night as
+  an emotional echo under the player's guitar, and Cicka Home carrying
+  accumulated marks. Keep it wordless or nearly wordless so the focus stays on
+  Cicka.
 - Relay time should progress from sunset for **Sit and Play Prompt** to **Relay
   Blue Hour** for **Send the Sketchbook Prompt**. The montage can show the night
   festival beginning elsewhere, but Relay should not become full night before

--- a/docs/game-design/ridge/current-level.md
+++ b/docs/game-design/ridge/current-level.md
@@ -223,8 +223,24 @@ The target asks for:
   centered on a Resident Help Beat, with optional extra residents only if they
   add texture instead of errand fatigue
 - final required Resident Room Beat candidate as Last Dance / Bachata Crossing:
-  a nervous dance/romance setup that prepares the farewell without repeating the
-  Guitar Farewell
+  a nervous dance/romance setup at the foot of the Relay hill. The route
+  blocker should be practical: festival barriers, a locked service-road gate,
+  and/or the last hill shuttle not running until the event closes properly. The
+  locked route-agent is the nervous hill-shuttle driver, whose daily job and
+  emotional problem both connect to the final approach. His romantic partner is
+  the shy last-stop lantern/ticket clerk, whose daily work connects the dance,
+  final shuttle, service-road barrier, and hill-road lanterns. Locked arrival
+  state: **Last Ticket + Lantern Check**. The driver waits by the shuttle with
+  the route clipboard; the clerk closes the booth ledger and lantern tokens;
+  each needs the other's sign-off before the final shuttle can leave.
+  Introduce the beat through a practical wayfinding loop: the player asks how
+  to reach Relay, notices the blocked service road and shuttle sign, then
+  discovers the emotional layer through the delayed final check. Reveal the
+  relationship through a triangulated discovery flow: the driver and clerk give
+  truthful but incomplete practical answers, then nearby locals help the player
+  understand that they are avoiding each other. Conversation
+  choices can create different tones, orderings, and recoverable awkward paths,
+  but should not permanently block the first ending.
 - required route spine: Blueprint Bridge means changing the world through art,
   Concert Crossing means turning memory into comfort, Last Dance / Bachata
   Crossing means life can keep moving with someone new, then Relay Spire /

--- a/docs/game-design/ridge/current-level.md
+++ b/docs/game-design/ridge/current-level.md
@@ -163,11 +163,14 @@ Accepted first ending outline:
 3. Cicka appears in her final field-presence spot, calm and familiar.
 4. The player shares a quiet Guitar Farewell with Cicka, ideally under a warm
    sunset or other cozy threshold light.
-5. The player activates or sends the sketchbook.
-6. Cicka walks with the player to the threshold, pauses, leaves one final
-   paw/page mark, then departs somewhere unreachable.
-7. The player returns to Ridge after the ending, with the final mark preserved
-   and the world still open.
+5. Control returns in **Relay Blue Hour** at the Relay sign/spire for a **Send
+   the Sketchbook Prompt**.
+6. Cicka walks with the player to the threshold, pauses, looks back once, leaves
+   one final paw/page mark, then slips into a page fold or light beyond the
+   player's path.
+7. The player returns to the **Open Ridge Return State** after the ending, with
+   the final mark preserved, Cicka's absence felt through favorite spots or
+   marks, and the world still open.
 
 The guitar should be established earlier as a meaningful comfort item: something
 the player can pick up, carry, and play in the world, especially at Cicka Home.
@@ -271,6 +274,27 @@ The target asks for:
   being used, Concert Crossing continuing, Opening Dance beginning at night, and
   Cicka Home carrying accumulated marks. Keep it wordless or nearly wordless so
   the focus stays on Cicka.
+- Relay time should progress from sunset for **Sit and Play Prompt** to **Relay
+  Blue Hour** for **Send the Sketchbook Prompt**. The montage can show the night
+  festival beginning elsewhere, but Relay should not become full night before
+  the farewell.
+- The shuttle ride from Last-Stop Plaza to Relay should be a **Short Threshold
+  Transition**, not a controllable driving segment: the driver can say "All
+  aboard the last ride," the vehicle starts over a brief blackout, the player
+  respawns at Relay Spire under sunset, and control resumes at Cicka's overlook
+  spot.
+- The final Relay Spire interaction should be a **Sit and Play Prompt** near
+  Cicka. It starts the Guitar Farewell without rhythm UI, fail state, or final
+  skill check.
+- After the Guitar Farewell, control returns at the Relay sign/spire for a
+  **Send the Sketchbook Prompt**. This starts the Cicka Threshold Farewell while
+  keeping the guitar as comfort rather than the send button.
+- Cicka's departure should be physical and mostly silent: walk together, pause,
+  look back, final mark, then page-fold/light departure. Any meow or translated
+  fragment should stay tiny and optional.
+- Immediate post-ending play should use the **Open Ridge Return State**:
+  replayable, quiet, and absence-marked. Micka remains delayed until the later
+  post-ending trigger rather than appearing immediately.
 - Cicka field presence in every required Resident Help Beat, with her role
   varying from subtle obstacle hint to changed-object observer to quiet trust marker
 - optional residents, NPCs, interactive props, and chill spaces that can offer

--- a/docs/game-design/ridge/current-level.md
+++ b/docs/game-design/ridge/current-level.md
@@ -246,10 +246,10 @@ The target asks for:
   other. Do not let the player solve the beat by directly confronting them with
   their feelings. The Last-Stop Operations Helper's readiness favor is
   **Operations Handoff Check**: the player helps prove the plaza setup is safe
-  enough for a trusted resident to keep watch once the night dance starts, with
-  the dance teacher as the simplest current cover candidate. The point is not
-  replacing her planning; it is showing that she did enough and can enjoy the
-  event. The driver's readiness favor is **One-Step Practice**: the player helps
+  enough for the **Dance Teacher** to keep watch once the night dance starts.
+  The point is not replacing her planning; it is showing that she did enough
+  and can enjoy the event. The driver's readiness favor is **One-Step
+  Practice**: the player helps
   him privately learn one tiny dance step before the setup handoff, last
   daylight ride, and later night-dance promise can happen. After both favors,
   the connector is **Folded Song Request**: a tiny paper invitation where the
@@ -260,8 +260,11 @@ The target asks for:
   route solve is **Setup Clearance Walkthrough**: final visible setup details
   clear the service lane enough for the steward to open the gate and the driver
   to offer the last daylight ride. Present it as a **Prompt-Driven Playable
-  Montage**: a few authored interaction snaps plus a visible sky/plaza time
-  shift, not full manual chores or a pure cutscene. Conversation choices can
+  Montage**: three default symbolic one-action snaps, plus a visible sky/plaza
+  time shift, not full manual chores or a pure cutscene. The default snaps are:
+  secure the lantern line, clear or tape the service-lane obstruction, and flip
+  the shuttle sign to "Last daylight ride." These can collapse further if the
+  beat needs to move faster. Conversation choices can
   create different tones, orderings, and recoverable awkward paths, but should
   not permanently block the first ending. Cicka's role is quiet threshold
   observer near the operations table, shuttle step, or service gate; she can

--- a/docs/game-design/ridge/current-level.md
+++ b/docs/game-design/ridge/current-level.md
@@ -228,19 +228,22 @@ The target asks for:
   and/or the last hill shuttle not running until the event closes properly. The
   locked route-agent is the nervous hill-shuttle driver, whose daily job and
   emotional problem both connect to the final approach. His romantic partner is
-  the shy last-stop lantern/ticket clerk, whose daily work connects the dance,
-  final shuttle, service-road barrier, and hill-road lanterns. Locked arrival
-  state: **Last Ticket + Lantern Check**. The driver waits by the shuttle with
-  the route clipboard; the clerk closes the booth ledger and lantern tokens;
-  each needs the other's sign-off before the final shuttle can leave.
+  the shy last-stop song-table volunteer, whose daily work connects the dance,
+  final shuttle, service-road barrier, and last-song timing. Locked arrival
+  state: **Last Song Table + Final Shuttle Hold**. The driver waits by the
+  shuttle with the route clipboard; the volunteer stays at the song table
+  because the final song stalls unless a trusted person covers it.
   Introduce the beat through a practical wayfinding loop: the player asks how
   to reach Relay, notices the blocked service road and shuttle sign, then
-  discovers the emotional layer through the delayed final check. Reveal the
-  relationship through a triangulated discovery flow: the driver and clerk give
-  truthful but incomplete practical answers, then nearby locals help the player
-  understand that they are avoiding each other. Conversation
-  choices can create different tones, orderings, and recoverable awkward paths,
-  but should not permanently block the first ending.
+  discovers the emotional layer through the delayed final song. Reveal the
+  relationship through a triangulated discovery flow: the driver and song-table
+  volunteer give truthful but incomplete practical answers, then nearby locals
+  help the player understand that they are avoiding each other. Do not let the
+  player solve the beat by directly confronting them with their feelings. Each
+  romantic character should need a small readiness favor before the final song,
+  shy dance, and lane-clearing handoff can happen. Conversation choices can
+  create different tones, orderings, and recoverable awkward paths, but should
+  not permanently block the first ending.
 - required route spine: Blueprint Bridge means changing the world through art,
   Concert Crossing means turning memory into comfort, Last Dance / Bachata
   Crossing means life can keep moving with someone new, then Relay Spire /

--- a/docs/game-design/ridge/current-level.md
+++ b/docs/game-design/ridge/current-level.md
@@ -217,10 +217,17 @@ The target asks for:
 - non-arcade fallback for any required beat that contains arcade-like interaction
 - tiny resident problems that create visible route changes
 - first v0 Resident Help Beat as a required soft gate: a closed/taped bridge or
-  missing-plank crossing with an obvious local solution
+  missing-plank crossing with an obvious local art/drawing solution
 - 2-3 required main-path Resident Room Beats before the first ending, each
   centered on a Resident Help Beat, with optional extra residents only if they
   add texture instead of errand fatigue
+- final required Resident Room Beat candidate as Last Dance / Bachata Crossing:
+  a nervous dance/romance setup that prepares the farewell without repeating the
+  Guitar Farewell
+- required proof arc: Bridge means changing the world by making something
+  through art/drawing,
+  Concert means turning memory into comfort, Dance means life can keep moving
+  with someone new, then Relay is ready for Cicka's threshold farewell
 - Cicka field presence in every required Resident Help Beat, with her role
   varying from subtle obstacle hint to changed-object observer to quiet trust marker
 - optional residents, NPCs, interactive props, and chill spaces that can offer

--- a/docs/game-design/ridge/decision-intake.md
+++ b/docs/game-design/ridge/decision-intake.md
@@ -14,7 +14,7 @@ each claim to one canonical home.
 | Accepted route spine, ending order, Cicka, guitar, or Living Proof decision | [`story-level-bible.md`](./story-level-bible.md) |
 | Accepted area-local Bridge, Concert, Dance Festival, or Relay detail | matching file or subdoc under [`areas/`](./areas/README.md) |
 | Current implemented/runtime truth | [`ridge-snapshot.md`](./ridge-snapshot.md) or runtime source |
-| Hard-to-reverse surprising trade-off | `docs/adr/NNNN-slug.md` |
+| Hard-to-reverse surprising trade-off | numbered ADR under [`../../adr/`](../../adr/) |
 | Work to build | GitHub Issue |
 | Raw inspiration, rejected ideas, or source rationale | `docs/research/provenance/` or no repo change |
 

--- a/docs/game-design/ridge/decision-intake.md
+++ b/docs/game-design/ridge/decision-intake.md
@@ -1,0 +1,111 @@
+# Ridge Decision Intake
+
+Use this when a grilling session, research pass, or Danilo conversation creates
+many possible Ridge decisions. A transcript is input, not canon.
+
+The job of a decision intake is to classify claims, compress them, and route
+each claim to one canonical home.
+
+## Routing Rules
+
+| Claim type | Destination |
+| --- | --- |
+| New stable domain term or ambiguity | [`../../../CONTEXT.md`](../../../CONTEXT.md) |
+| Accepted route spine, ending order, Cicka, guitar, or Living Proof decision | [`story-level-bible.md`](./story-level-bible.md) |
+| Accepted area-local Bridge, Concert, Dance Festival, or Relay detail | matching file under [`areas/`](./areas/README.md) |
+| Current implemented/runtime truth | [`ridge-snapshot.md`](./ridge-snapshot.md) or runtime source |
+| Hard-to-reverse surprising trade-off | `docs/adr/NNNN-slug.md` |
+| Work to build | GitHub Issue |
+| Raw inspiration, rejected ideas, or source rationale | `docs/research/provenance/` or no repo change |
+
+Do not update multiple canon docs with the same decision. Link instead.
+
+## Intake Template
+
+```md
+# Decision Intake: <Topic> - YYYY-MM-DD
+
+Status: research-input
+Source: grilling transcript / research pass / Danilo conversation
+Canon target: none yet
+Reviewer needed: yes/no
+
+## One-Screen Summary
+
+- 3 to 5 bullets max.
+
+## Candidate Decisions
+
+| ID | Claim | Conflicts with current docs? | Proposed home | Status |
+| --- | --- | --- | --- | --- |
+
+## Canon Updates Requested
+
+- `CONTEXT.md`: terms only
+- `story-level-bible.md`: route spine, cross-area dependencies, ending logic only
+- `areas/`: area-local accepted detail only
+- `ridge-snapshot.md`: runtime truth only
+- GitHub issue: implementation only
+
+## Rejected / Deferred
+
+Ideas that must not leak into implementation.
+
+## HITL Questions
+
+Only product, tone, tribute, naming, or irreversible scope questions.
+```
+
+## Area Update Template
+
+Use this shape when a decision intake produces accepted detail for one Ridge
+Area. Keep the area `README.md` as the first local home; split subdocs only after
+it crosses the soft cap in [`README.md`](./README.md).
+
+```md
+# <Area Name>
+
+Status: accepted / candidate / superseded
+Parent: Ridge Areas
+Scope: one area only
+
+## Contract
+
+10 bullets max: what must stay true.
+
+## Player Path
+
+8 steps max.
+
+## Characters
+
+Role-first labels only until naming pass.
+
+## Cicka Use
+
+Presence, marks, limits, no exposition.
+
+## Out Of Bounds
+
+Rejected names, mechanics, tone, reveals.
+
+## Open Slots
+
+Only unresolved decisions, each with owner/status.
+
+## Sources
+
+Links only. No transcript paste.
+```
+
+## Failure Modes
+
+- Pasting transcripts into `story-level-bible.md`.
+- Treating provenance or research summaries as active spec.
+- Using `CONTEXT.md` as a story bible instead of a glossary.
+- Repeating one decision in `summit.md`, `story-level-bible.md`,
+  `ridge-snapshot.md`, and GitHub Issues.
+- Letting `candidate` ideas drive implementation.
+- Creating ADRs for reversible tone choices.
+- Locking proper names before role-first labels survive play/design review.
+- Mirroring GitHub backlog state in local docs.

--- a/docs/game-design/ridge/decision-intake.md
+++ b/docs/game-design/ridge/decision-intake.md
@@ -12,7 +12,7 @@ each claim to one canonical home.
 | --- | --- |
 | New stable domain term or ambiguity | [`../../../CONTEXT.md`](../../../CONTEXT.md) |
 | Accepted route spine, ending order, Cicka, guitar, or Living Proof decision | [`story-level-bible.md`](./story-level-bible.md) |
-| Accepted area-local Bridge, Concert, Dance Festival, or Relay detail | matching file under [`areas/`](./areas/README.md) |
+| Accepted area-local Bridge, Concert, Dance Festival, or Relay detail | matching file or subdoc under [`areas/`](./areas/README.md) |
 | Current implemented/runtime truth | [`ridge-snapshot.md`](./ridge-snapshot.md) or runtime source |
 | Hard-to-reverse surprising trade-off | `docs/adr/NNNN-slug.md` |
 | Work to build | GitHub Issue |
@@ -43,7 +43,7 @@ Reviewer needed: yes/no
 
 - `CONTEXT.md`: terms only
 - `story-level-bible.md`: route spine, cross-area dependencies, ending logic only
-- `areas/`: area-local accepted detail only
+- `areas/`: area-local accepted detail only; use the narrowest subdoc when one exists
 - `ridge-snapshot.md`: runtime truth only
 - GitHub issue: implementation only
 

--- a/docs/game-design/ridge/legacy/README.md
+++ b/docs/game-design/ridge/legacy/README.md
@@ -1,0 +1,30 @@
+# Ridge Legacy Docs
+
+> Status: superseded / reference only.
+> Read [`../README.md`](../README.md) before using anything in this folder.
+
+This folder quarantines older Ridge planning material so agents do not mistake
+it for the active Bridge -> Concert -> Dance Festival -> Relay route.
+
+Use these files only for:
+
+- historical rationale
+- reusable topology ideas
+- comparison against the old folded/Cicka Home direction
+- adapting proven source-contract or QA ideas into a new accepted route plan
+
+Do not use these files as implementation source unless a current issue or
+accepted route doc explicitly links here.
+
+## Folder Map
+
+| Folder | Contains | Status |
+| --- | --- | --- |
+| [`map-plans/`](./map-plans/) | Folded/Cicka Home topology plans and long-term topology ideas | Superseded reference |
+| [`reviews/`](./reviews/) | Reviews of the old blockout skeleton | Superseded reference |
+
+Active Ridge design lives in:
+
+- [`../story-level-bible.md`](../story-level-bible.md)
+- [`../areas/`](../areas/README.md)
+- [`../open-questions.md`](../open-questions.md)

--- a/docs/game-design/ridge/legacy/README.md
+++ b/docs/game-design/ridge/legacy/README.md
@@ -23,6 +23,11 @@ accepted route doc explicitly links here.
 | [`map-plans/`](./map-plans/) | Folded/Cicka Home topology plans and long-term topology ideas | Superseded reference |
 | [`reviews/`](./reviews/) | Reviews of the old blockout skeleton | Superseded reference |
 
+| File | Contains | Status |
+| --- | --- | --- |
+| [`prototype-summit.md`](./prototype-summit.md) | Older long-form product vision, mini-game roadmap, and prototype development notes | Superseded reference |
+| [`prototype-milestone-history.md`](./prototype-milestone-history.md) | Older M0-M7 prototype milestone plan and implementation status | Superseded reference |
+
 Active Ridge design lives in:
 
 - [`../story-level-bible.md`](../story-level-bible.md)

--- a/docs/game-design/ridge/legacy/map-plans/README.md
+++ b/docs/game-design/ridge/legacy/map-plans/README.md
@@ -1,0 +1,16 @@
+# Legacy Ridge Map Plans
+
+> Status: superseded topology reference.
+
+These docs describe the older folded/Cicka Home route direction. They may
+contain reusable spatial ideas, but they do not override the active Ridge route
+canon in [`../../story-level-bible.md`](../../story-level-bible.md) or the
+current area docs in [`../../areas/`](../../areas/README.md).
+
+## Files
+
+- [`proper-map-plan.md`](./proper-map-plan.md): prior folded/Cicka Home topology
+  target.
+- [`topology-spike.md`](./topology-spike.md): earlier M5 map-design spike.
+- [`long-term-topology-ideas.md`](./long-term-topology-ideas.md): exploratory
+  topology ideas, not an active roadmap.

--- a/docs/game-design/ridge/legacy/map-plans/long-term-topology-ideas.md
+++ b/docs/game-design/ridge/legacy/map-plans/long-term-topology-ideas.md
@@ -1,16 +1,16 @@
 # Sketchbook Ridge Long-Term Topology Ideas
 
-> Exploratory companion to [`summit.md`](../summit.md).
+> Exploratory companion to [`summit.md`](../../summit.md).
 > This is not a locked roadmap or active milestone commitment. It captures a
 > likely long-term overworld direction so future planning can borrow from it
 > deliberately instead of reinventing it from memory.
 
-Active sources: [`summit.md`](../summit.md),
-[`milestone-plan.md`](../milestone-plan.md),
-[`docs/design/style-guide.md`](../../../design/style-guide.md),
-[`A Short Hike` research note](../../../research/summaries/game-inspirations/a-short-hike.md),
+Active sources: [`summit.md`](../../summit.md),
+[`milestone-plan.md`](../../milestone-plan.md),
+[`docs/design/style-guide.md`](../../../../design/style-guide.md),
+[`A Short Hike` research note](../../../../research/summaries/game-inspirations/a-short-hike.md),
 and the current Ridge role contracts in
-[`docs/agents/sketchbook-ridge-team.md`](../../../agents/sketchbook-ridge-team.md).
+[`docs/agents/sketchbook-ridge-team.md`](../../../../agents/sketchbook-ridge-team.md).
 
 ## Intent
 

--- a/docs/game-design/ridge/legacy/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/legacy/map-plans/proper-map-plan.md
@@ -5,9 +5,9 @@
 > Issue #54 proved the current Ridge can change visually, but the route is still
 > a short prop line. This document records the prior folded/Cicka Home topology
 > target. It is not the active Ridge route canon unless a new slice explicitly
-> rewrites it around [`../story-level-bible.md`](../story-level-bible.md).
+> rewrites it around [`../../story-level-bible.md`](../../story-level-bible.md).
 
-For current Ridge source-of-truth routing, read [`../README.md`](../README.md)
+For current Ridge source-of-truth routing, read [`../../README.md`](../../README.md)
 first.
 
 ## Decision

--- a/docs/game-design/ridge/legacy/map-plans/topology-spike.md
+++ b/docs/game-design/ridge/legacy/map-plans/topology-spike.md
@@ -3,7 +3,7 @@
 > Status: superseded legacy/reference.
 > This was the M5 folded/Cicka Home map-design spike for the prior Ridge
 > direction. Keep it as planning history and topology reference only. For
-> current Ridge source-of-truth routing, read [`../README.md`](../README.md).
+> current Ridge source-of-truth routing, read [`../../README.md`](../../README.md).
 
 ## Purpose
 
@@ -114,15 +114,15 @@ Constraints:
 
 Use these docs as inspiration, not hard scope:
 
-- [`summit.md`](../summit.md): Ridge vision,
+- [`summit.md`](../../summit.md): Ridge vision,
   Cicka arc, mini-game reward language, and mobile constraints.
 - [`long-term-topology-ideas.md`](./long-term-topology-ideas.md):
   compact three-layer mountain, shortcut vocabulary, and secret families.
-- [`2d-map-design-principles.md`](../../../research/summaries/design-theory/2d-map-design-principles.md):
+- [`2d-map-design-principles.md`](../../../../research/summaries/design-theory/2d-map-design-principles.md):
   loops, landmarks, mental mapping, and earned shortcut relief.
-- [`lucky-luna.md`](../../../research/summaries/game-inspirations/lucky-luna.md):
+- [`lucky-luna.md`](../../../../research/summaries/game-inspirations/lucky-luna.md):
   mobile-native falling/descent ideas for optional later pockets.
-- [`nine-sols.md`](../../../research/summaries/game-inspirations/nine-sols.md):
+- [`nine-sols.md`](../../../../research/summaries/game-inspirations/nine-sols.md):
   evolving home anchor, mementos, and restorative return space.
 
 ## Weighted Options

--- a/docs/game-design/ridge/legacy/prototype-milestone-history.md
+++ b/docs/game-design/ridge/legacy/prototype-milestone-history.md
@@ -1,0 +1,467 @@
+# Prototype Milestone History
+
+> Status: superseded / reference only.
+> Current milestone routing lives in [`../milestone-plan.md`](../milestone-plan.md).
+> Read [`../README.md`](../README.md) before adapting anything from this file.
+
+This file preserves the old M0-M7 prototype milestone plan, implementation
+status, and branch/seam notes. Use it for history, reusable runtime seams, and
+comparison against the old folded/Cicka Home direction. Do not use it as the
+active route-reset plan unless a current issue explicitly links here.
+
+PRDs, implementation issues, triage state, current backlog, and agent-ready
+briefs live in GitHub Issues through the workflow in
+[`docs/agents/issue-tracker.md`](../../../agents/issue-tracker.md).
+
+Preserved note from the old file: it was used for durable milestone shape,
+ownership boundaries, branch/seam strategy, and reference stacks. Current
+milestone routing lives in [`../milestone-plan.md`](../milestone-plan.md), and
+current prototype truth lives in [`ridge-snapshot.md`](../ridge-snapshot.md).
+
+## Preserved Route-Reset Goal
+
+At the time of this note, the phase was **Ridge pre-production for the desired
+game rework**.
+
+The first complete route target should prove:
+
+1. a compact Bridge -> Concert -> Dance Festival -> Relay route exists
+2. the Relay Spire is visible early
+3. required Resident Help Beats visibly change the Ridge
+4. Cicka feels present through local field appearances and resting spots
+5. Guitar Farewell, Send the Sketchbook Prompt, Cicka Threshold Farewell, and
+   Open Ridge Return State land without arcade gating
+6. optional mini-games remain side fun, rewards, shortcuts, or future
+   alternate-path candidates rather than required first-ending proof
+
+Anything beyond that is future scope unless a slice explicitly pulls it in.
+
+The older M1-M5 sections below describe useful prototype history and reusable
+seams. Do not treat them as the active product target unless a current issue or
+the Ridge router explicitly sends you there.
+
+## Preserved Route-Reset Milestones
+
+These labels were proposed for pre-production issues before the active
+milestone router was split back out:
+
+- **P0 Route Decision Intake**: convert grilling/research transcripts into
+  accepted route claims, rejected ideas, and open questions.
+- **P1 Area Paper Pass**: tighten Bridge, Concert, Dance Festival, and Relay
+  docs until each area has layout, resident beats, blockers, Cicka presence,
+  and exit conditions.
+- **P2 First Playable Route Blockout**: prove the route can be walked end to
+  end with placeholder art and no required precision platforming.
+- **P3 Living Proof Feedback**: make resident help, world changes, and Relay
+  readiness readable without a visible chore checklist.
+- **P4 Ending Pass**: land Guitar Farewell, Send the Sketchbook Prompt, Cicka
+  Threshold Farewell, Open Ridge Return State, and later Micka timing.
+
+Optional mini-games, old Cicka Home mutation work, and folded-desk topology
+should enter these milestones only when an active route doc or issue pulls a
+specific piece forward.
+
+## Preserved Runtime / Prototype Status
+
+This section is a milestone snapshot for orientation. Do not mirror every
+GitHub issue update here; update it only when the milestone-level reality or
+current shipped/prototype capability changes.
+
+- **M1 Ridge Shell** is complete for the current placeholder slice: Ridge can
+  boot directly with `?startScene=ridge`, uses shared side-view movement, shows
+  the Relay Spire, Cicka's first perch, a static Ridge Guide, and three Trail
+  Card props.
+- **M2 Trail Card and Manual Overlay Surface** is complete for the current
+  prototype slice: the reusable global Trail Card overlay, reusable Manual Page
+  overlay shape, Ridge trigger contract, and mobile/readability polish are in
+  place.
+- **M3 Art and Audio Research Pack** is in review: visual, overlay/manual, and
+  audio direction packs now guide Cicka, Guide, Trail Card, Manual Page,
+  Stampede, Relay Spire, and Ridge audio without blocking rough engineering
+  prototypes.
+- **M4 Stampede Sketch Prototype** is underway with M4a movement, M4b pressure
+  loop, M4c/M4d prototype shell, and M4d.5 responsive shell/input work accepted
+  for continuation: the Stampede Trail Card can enter a scene-local arena with
+  timer, page-noise cadence, capped swarm surges, pressure-aware swarm motion,
+  soft contact feedback, automatic pencil swipe, run ending UI, return to
+  Ridge, bridge-backed React scene UI, Notebook shell presentation, enlarged
+  arcade control mats shared with Potassium, and a first scene-local
+  pickup/upgrade draft. First M4e playtest tuning widened the true arena to
+  match the visible notebook page, added HP/contact readability, softened the
+  contact limit, and added respawn telegraphs. The tuning pass is accepted for
+  continuation; the respawn warning improved fairness and added useful route
+  planning. M4f durable rewards are accepted for continuation: first clear
+  awards the `stampede-sketch` Ridge stamp and one glide pip, repeat clears do
+  not duplicate rewards, and the result panel reports earned/already-owned
+  reward state.
+- **M5 Ridge Memory** has its first visual slices accepted for continuation:
+  M5a derives Ridge-owned sticker/world-change memories from durable progress
+  without stored sticker state, and M5b adds the first Cicka note/translator
+  tease plus a dev-only `devRidgeStamp=stampede-sketch` seed for fast local
+  testing. M5c/M5d add Cicka's Stampede-gated walk-by bark, first deliberate
+  pre-translator interaction, and a primitive readability polish pass. M5e has
+  promoted the prepared Cicka prototype spritesheet into
+  `public/assets/ridge/cicka/` as the first runtime-wired AI sprite adoption
+  proof, with audit notes and refined pipeline gates.
+- **Ridge Architecture Deepening (#60-#64)** is implemented as the current
+  prototype runtime direction: #60 made the blockout the prototype spatial
+  source for the existing folded/Cicka Home runtime,
+  #61 consolidated traversal comfort, #62 added compiled blockout facts, #63
+  slimmed `RidgeScene` into lifecycle glue, and #64 made Cicka Home mutation
+  resolution data-driven. #65 is the documentation cleanup slice that records
+  this final shape.
+- **Asset staging is now an active coordination concern**: prepared POC assets
+  still exist for Potassium, Stampede, and future Ridge character/prop families.
+  Cicka's adopted runtime copy now lives under `public/assets/ridge/cicka/`;
+  its external prepared archive is provenance/source material, not a pending
+  runtime adoption target. Keep remaining candidates documented and adopt them
+  in small scene-owned slices instead of turning them into a broad
+  art-integration branch. See
+  [`asset-staging-plan.md`](../reference/asset-staging-plan.md).
+
+## Production Crew
+
+Role contracts and activation phrases live in
+[`docs/agents/sketchbook-ridge-team.md`](../../../agents/sketchbook-ridge-team.md).
+
+- **Level Designer**: level design and milestone shape.
+- **Story / Tone Designer**: emotional/story tone.
+- **Systems / Production Designer**: systems and production constraints.
+- **Character Designer**: NPC/character design.
+- **Architect**: architecture and branch conflict control.
+- **Visual Direction Artist**: character and environment art research.
+- **Overlay Readability Designer**: overlay, manual, and mobile visual readability.
+- **Audio Designer**: music and sound design research.
+
+## Reference Stack
+
+Ridge rework issues should link [`README.md`](../README.md),
+[`story-level-bible.md`](../story-level-bible.md), and the relevant
+[`areas/`](../areas/README.md) doc first. Add the relevant subset below only
+when the issue touches runtime, art, audio, overlays, or legacy/prototype reuse:
+
+- [`summit.md`](../summit.md)
+- [`ridge-snapshot.md`](../ridge-snapshot.md)
+- [`runtime-architecture.md`](../../../runtime-architecture.md)
+- [`runtime-modes.md`](../../../runtime-modes.md)
+- [`architecture-direction.md`](../../../architecture-direction.md)
+- [`style-guide.md`](../../../design/style-guide.md)
+- [`10-architecture.md`](../../../../.agents/rules/10-architecture.md)
+- [`20-game-runtime.md`](../../../../.agents/rules/20-game-runtime.md)
+- [`30-react-overlays.md`](../../../../.agents/rules/30-react-overlays.md)
+
+Use [`potassium-slip.md`](../../mini-games/potassium-slip.md) for Potassium-specific behavior,
+[`stampede-sketch.md`](../../mini-games/stampede-sketch.md) for Stampede-specific behavior,
+and [`mini-games/README.md`](../../mini-games/README.md) as the mini-game routing
+index.
+
+## Conflict Strategy
+
+Architect's rule:
+
+> Parallelize scene internals. Serialize shared seams.
+
+Do not let many branches edit these at the same time:
+
+- `src/game/bridge/store.ts`
+- `src/game/scenes/sceneIds.ts`
+- `src/game/scenes/sceneRegistry.ts`
+- `src/game/overlays/overlayIds.ts`
+- `src/game/overlays/overlayRegistry.ts`
+- `src/game/sceneLifecycle/contexts/createSceneContexts.ts`
+- `src/game/sharedSceneRuntime/**`
+- `src/game/sharedSceneRuntime/phaserScenePresentation.ts`
+
+Use one short-lived integration branch to land shared seam edits in dependency
+order. Feature branches should export scene-local definitions from their own
+folders and let the integration owner wire them into shared registries.
+
+Suggested branches:
+
+- `ridge/integration`
+- `ridge/m0-progress-baseline`
+- `ridge/shell-scene`
+- `ridge/trail-card-overlay`
+- `ridge/stampede-sketch`
+- `ridge/memory-layer`
+- `ridge/art-audio-research`
+- `ridge/telegraph-terrace`
+
+## Ownership Boundaries
+
+- Runtime/integration owns bridge progress, scene ids, scene registry, overlay ids, overlay registry, presentation policy, and scene context assembly.
+- Ridge scene owner owns `src/game/scenes/ridge/**`.
+- Stampede owner owns `src/game/scenes/stampedeSketch/**`.
+- Telegraph owner owns `src/game/scenes/telegraphTerrace/**`.
+- Reusable overlay owner owns `src/game/overlays/**`.
+- Scene-local result overlays belong with their scene unless promoted deliberately.
+- Shared scene runtime changes require explicit review because they affect existing scenes.
+- Art/audio research should write docs and asset specs first; implementation should not block on final polish.
+
+## Legacy Prototype Milestones
+
+### M0: Production Baseline
+
+Goal: establish the shared seams before parallel work starts.
+
+Owner: runtime/integration.
+
+Outputs:
+
+- Potassium Circuit source confirmed as existing inventory ownership.
+- Minimal Ridge progress shape defined: stamps, manual pages, glide pips, shortcuts.
+- First reward ids reserved.
+- Current smoke path confirmed: Overworld, Hobbies, Basement, Potassium, overlays, pause, touch.
+
+Blocks:
+
+- Ridge Shell
+- Stampede reward wiring
+- Ridge Memory
+- Relay Spire gate
+
+### M1: Ridge Shell
+
+Goal: make the main game shape playable with placeholders.
+
+Owner: Ridge scene.
+
+Start Ridge as a separate `ridge` scene first. Keep the current overworld as
+the default route until the Ridge shell feels good. During development, boot
+directly into Ridge with `?startScene=ridge` for fast iteration.
+
+Keep the first movement shell flat and readable. Use visual height changes,
+landmark silhouettes, and prop staging before adding real vertical traversal.
+
+Outputs:
+
+- `src/game/scenes/ridge/**`.
+- Side-view Ridge scene using shared player/camera runtime.
+- Relay Spire silhouette.
+- three hobby triggers with Trail Cards.
+- Cicka first perch.
+- one static NPC.
+- return path to prior/current parent scene.
+- placeholder sticker layer.
+
+Can proceed with rough art. Do not wait for final drawings.
+
+### M2: Trail Card And Manual Overlay Surface
+
+Goal: make opt-in scene entry and one-screen knowledge clues readable.
+
+Owner: reusable overlay/UI.
+
+Outputs:
+
+- Trail Card overlay via `OverlayHost`.
+- first Manual Page overlay shape if needed by Relay/Telegraph.
+- mobile-first layout rules.
+- copy lives in `src/shared/i18n/messages/en/`.
+
+Registry wiring should be serialized through the integration branch.
+
+### M3: Art And Audio Research Pack
+
+Goal: unblock implementation without creating final-asset pressure.
+
+Owners: Visual Direction Artist, Overlay Readability Designer, Audio Designer.
+
+Outputs:
+
+- NPC silhouette sheet for Cicka, Ridge Guide, Potassium Compliance Officer, `TODO: AI`, Printer Oracle.
+- Cicka mini kit spec: perch, blink, loaf, stretch, suspicious turn, tiny hop, paw-print mark, pre-translator "meow" bubble.
+- landmark silhouette board: Relay Spire, Basement hatch, Potassium hint, Stampede picnic blanket, Telegraph terrace, Domino desk/elevator.
+- sticker / ink-memory vocabulary.
+- Trail Card and Manual Page visual specs.
+- Ridge audio palette, Cicka SFX language, Potassium acknowledgement micro-pack, Stampede prototype audio notes.
+
+Current review packs:
+
+- [`m3-visual-pack.md`](../reference/m3-visual-pack.md)
+- [`m3-overlay-pack.md`](../reference/m3-overlay-pack.md)
+- [`m3-audio-pack.md`](../reference/m3-audio-pack.md)
+
+These are research/spec deliverables. They should not block engineering beyond
+basic silhouette placeholders.
+
+### M4: Stampede Sketch Prototype
+
+Goal: ship the first new opt-in mini-game.
+
+Owner: Stampede scene.
+
+Purpose: protect one calm picnic-blanket patch from a stampede of runaway ideas.
+Use [`stampede-sketch.md`](../../mini-games/stampede-sketch.md) for player-guardian and enemy
+intent before generating or wiring final Stampede art.
+
+Outputs:
+
+- `src/game/scenes/stampedeSketch/**`.
+- 60-90 second survivor prototype. M4a movement feel covers direct entry from
+  the Stampede Trail Card, top-down 8-way movement, pointer drag steering, and
+  return to Ridge. M4b adds a scene-local page-noise cadence, pressure HUD,
+  capped swarm surges, and soft contact feedback before reward wiring.
+- capped enemies.
+- central or near-central calm patch objective with proximity aggro: nearby
+  enemies chase the player, distant enemies may crowd the blanket.
+- auto-attacks.
+- XP pickups.
+- three-choice upgrade draft.
+- result overlay.
+- first-clear stamp and glide pip reward.
+
+Depends on M0 and the Ridge trigger contract from M1. Most scene internals can
+be built independently.
+
+Current checkpoint:
+
+- **M4a Movement Feel** accepted: direct entry from the Stampede Trail Card,
+  top-down 8-way movement, pointer drag steering, vertical-board presentation,
+  and return to Ridge are in place.
+- **M4b Pressure Loop** accepted for prototype continuation: session timer,
+  page-noise cadence, pressure HUD, capped swarm surges, contact limit, soft
+  contact feedback, and pressure-aware swarm motion are in place.
+- **M4c/M4d prototype shell** accepted: run ending surfaces, Retry/Back
+  routing, the first automatic pencil swipe, mobile-friendly start/result UI,
+  and the bridge-backed scene UI path are in place. Stampede text-heavy status
+  and panels now render through React scene UI instead of Phaser canvas text,
+  and Potassium uses the same scene UI path for draft-choice and terminal
+  panels.
+- **M4d.5 Responsive Shell/Input Spike** accepted for prototype continuation:
+  Notebook shell presentation, scene UI panels, and larger control mats are in
+  place for Stampede and Potassium. Reusable Notebook Shell language now lives
+  in [`notebook-shell-design-language.md`](../../../design/notebook-shell-design-language.md).
+  Keep the notebook treatment restrained if future polish makes it too noisy or
+  brittle.
+- **M4e Pickup / Upgrade Draft** accepted for continuation: cleared marks spawn
+  simple scrap pickups, collecting the first threshold opens a scene UI upgrade
+  draft, and one selected upgrade can make the pencil faster, the swipe wider,
+  or the guardian slightly quicker. First tuning feedback also made the playable
+  arena fill the notebook page more honestly, exposed HP/contact radius in the
+  HUD/scene, raised prototype survivability, and telegraphed mark respawns.
+  The respawn warning is now part of the prototype loop because it creates
+  fairer avoidance and direction-planning decisions.
+- **M4f Durable Rewards Draft** accepted for continuation: first Stampede clear
+  now awards the `stampede-sketch` Ridge stamp and one glide pip through bridge
+  progress, repeat clears do not duplicate the reward, the result panel reports
+  earned/already-owned reward state, and Ridge renders one small Stampede blanket
+  memory mark derived from the stamp.
+- Scene architecture is intentionally scene-local. `StampedeSketchScene` should
+  remain the Phaser adapter/orchestrator while run decisions live behind
+  `runtime/runFlow.ts` and swarm steering lives behind `runtime/swarmMotion.ts`.
+
+Potential next implementation slices:
+
+These are local planning notes. Publish approved work as GitHub Issues before
+assigning an AFK agent.
+
+1. **M5 Ridge Memory continuation**: add the first small Ridge shortcut or the
+   first Cicka proximity/talk interaction as its own scene-owned slice.
+
+Hold until later:
+
+- Enemy-enemy avoidance beyond pressure-aware steering.
+- More Stampede upgrades and endless mode.
+- Player manual updates; Stampede is still dev/prototype behavior.
+
+### M5: Ridge Memory
+
+Goal: make the Ridge visibly remember rewards.
+
+Owner: Ridge scene.
+
+Outputs:
+
+- sticker/world-change rendering from stamps and manual pages.
+- one shortcut.
+- Ridge-only glide behavior.
+- first Cicka Note, memory reaction, or pre-translator interaction.
+
+Current checkpoint:
+
+- **Architecture-deepening child issues #60-#64 are represented in code**:
+  spatial facts now derive from the Ridge Blockout, traversal assists are owned
+  by the Ridge traversal runtime, Ridge scene presentation is split into
+  blockout/landmark modules, and Cicka Home mutations resolve from compiled
+  facts plus durable Ridge progress.
+
+- **M5a Durable Sticker Layer** accepted: `worldMemory.ts` derives visible
+  Ridge memory ids from durable progress, empty progress returns no memories,
+  and the `stampede-sketch` stamp renders Stampede blanket memories without
+  storing sticker ids.
+- **M5b Cicka Memory + Dev Stamp Seed** accepted: `stampede-sketch` also derives
+  the `cicka-stampede-note` memory at Cicka's perch, Ridge renders the tiny
+  Cicka memory tease, and local dev can seed the known stamp with
+  `?mode=interactive&startScene=ridge&devRidgeStamp=stampede-sketch`.
+- **M5c Cicka Walk-By Memory** accepted for continuation: after the Stampede
+  stamp, Cicka gives one tiny walk-by bark per Ridge entry without stored Cicka
+  state.
+- **M5d Cicka First Interaction** accepted for continuation: Cicka can answer a
+  deliberate interaction with pre-translator meow punctuation, while the permanent
+  Cicka memory becomes a paw/scratch decal instead of duplicate speech text;
+  the same PR includes a small primitive readability polish pass for Cicka,
+  her speech bubble, and the memory decal.
+- **M5e Cicka Runtime Asset Adoption** accepted for continuation: the prepared
+  Cicka spritesheet has been promoted into `public/assets/ridge/cicka/`, Ridge
+  loads it as a display-only perch NPC with tiny idle/notice animation, and the
+  first AI sprite audit records frame stability, runtime risks, and future
+  review gates.
+
+Potential next implementation slices:
+
+These are local planning notes. Publish approved work as GitHub Issues before
+assigning an AFK agent.
+
+1. **Ridge Route Reset Planning**: align the next implementation plan with the
+   active Bridge Area -> Concert Area -> Dance Festival Area -> Relay/Cicka
+   ending route in [`story-level-bible.md`](../story-level-bible.md). Treat
+   [`legacy/`](./README.md) as legacy/prototype reference unless a slice
+   explicitly adapts its source-contract or topology ideas.
+2. **Later First Ridge Shortcut / Ridge-Only Glide**: revisit these after the
+   route reset gives shortcuts and movement rewards a real route shape.
+3. **Translator / Cicka Daydream**: keep translated Cicka subtitles and the
+   Cicka daydream mini-slice for later, after Ridge Memory proves return play.
+
+Do not add stored sticker state. Do not add Stampede upgrades, endless mode,
+shared memory architecture, or Ridge shortcuts inside Cicka memory slices.
+
+## Preserved Future Route Milestones
+
+### M6: Relay Spire First Ending
+
+Goal: close the first complete route.
+
+Owner: integration + Ridge.
+
+Outputs:
+
+- final gate: the three required Ridge Areas and their visible resident/world
+  changes provide enough Living Proof for the first ending. Mini-games can
+  remain optional fun, rewards, shortcuts, or future alternate solutions; they
+  are not required Living Proof for the current first-ending route.
+- Guitar Farewell, Send the Sketchbook Prompt, Cicka Threshold Farewell, and
+  Open Ridge Return State follow `story-level-bible.md`.
+- short ending/contact overlay.
+- return to Ridge after ending.
+- post-ending Ridge state where Micka first appears after the player completes
+  or replays one mini-game and returns.
+- player manual updated when behavior ships.
+
+### M7: Telegraph Terrace Prototype
+
+Goal: test the Muay Thai / Clair Obscur reactive timing lane.
+
+Owner: Telegraph scene.
+
+Outputs:
+
+- `src/game/scenes/telegraphTerrace/**`.
+- one-button parry loop.
+- three attack patterns.
+- Tempo build and counter release.
+- assist timing.
+- manual page reward.
+
+This can begin after M0 and the Trail/Manual overlay shape. It should not block
+Stampede or the first ending.

--- a/docs/game-design/ridge/legacy/prototype-summit.md
+++ b/docs/game-design/ridge/legacy/prototype-summit.md
@@ -1,0 +1,824 @@
+# Prototype Summit History
+
+> Status: superseded / reference only.
+> Current product vision lives in [`../summit.md`](../summit.md). Active route
+> canon lives in [`../story-level-bible.md`](../story-level-bible.md) and
+> [`../areas/`](../areas/README.md). Shipped behavior still belongs in
+> [`player-manual.md`](../../player-manual.md).
+
+This file preserves older summit/planning material. It is useful for taste,
+history, and reusable ideas, but it does not override the active
+Bridge/Concert/Dance Festival/Relay route.
+
+## Team Frame
+
+- **Level Designer**: owns the playable world, pacing, and scope.
+- **Story / Tone Designer**: protects warmth, manga sketchbook tone, and the feeling that the world remembers Danilo.
+- **Systems / Production Designer**: protects input simplicity, Phaser/React boundaries, and build order.
+- **Character Designer**: protects NPC silhouettes, interaction charm, and the feeling that the ridge is inhabited.
+
+The competition winner remains **Sketchbook Ridge**. The production direction is:
+
+> Use Ridge as the playable spine, Summit as the architecture discipline, and
+> Archipelago's stickers as the visible reward language.
+
+## Target Player
+
+The primary audience is **Danilo on laptop and mobile phone**.
+
+Other people may play it, but the game should be tuned for Danilo's taste first:
+
+- compact exploration like *A Short Hike*
+- readable secrets and manual-page epiphanies like *Tunic*
+- ricochet/run synergy like *Ball x Pit*, already represented by Potassium Slip
+- active timing and parry joy like *Clair Obscur*
+- deterministic toy-system cleverness like *Divinity: Original Sin 2*
+- optional movement mastery like *Hollow Knight*
+- neutral/spacing mind games from fighting games
+- silly substory seriousness like *Yakuza: Like a Dragon*
+- hand-drawn manga intimacy, with *Oyasumi Punpun* as a taste signal for personal, sketchy, funny-sad honesty
+
+## One-Sentence Game
+
+Danilo crosses a compact hand-drawn ridge inside his own sketchbook, helping
+small resident moments come alive across Bridge, Concert, Dance Festival, and
+Relay, while optional hobby toys and secrets can add stamps, stickers, and
+return-state changes without becoming required first-ending gates.
+
+## Core Fantasy
+
+This is **Danilo's tiny private mountain**, not a portfolio theme park.
+
+The goal is to reach the **Relay Spire** and "send the sketchbook." On paper, that means shipping the portfolio. Emotionally, it means noticing that the unfinished jokes, hobbies, game tastes, tools, and half-serious obsessions already form a coherent world. Cicka is the emotional spine of that realization: she starts as a tiny resident, becomes the guide who teaches the player how to notice the Ridge, and makes the first ending a quiet farewell and tribute rather than only a contact/credits beat.
+
+The current static portfolio-building model is not the long-term fantasy. The
+better version is a **scrambled sketchbook**: Danilo's pages, tools, memories,
+and proofs are out of order. The player learns Danilo by restoring meaning
+through play, not by opening resume modals. Basement, Potassium Slip, and the
+Glasses re-read effect are strong anchors; generic information buildings should
+eventually be absorbed into artifacts, mini-games, Cicka notes, manual pages,
+and local Cicka Resting Spot changes.
+
+The ending should not say "you became perfect." It should say:
+
+> You shipped something alive.
+
+It should also say, softly:
+
+> Thank you for walking with me.
+
+## Fun Pillars
+
+1. **One Ridge, Many Returns**  
+   The overworld is one compact side-view route with shortcuts and changed landmarks, not a huge map.
+
+2. **Opt-In Toys**  
+   Mini-games are entered from clear hobby props. The player always knows what they are opting into, how long it takes, and what it might reward.
+
+3. **Potassium Owns Ricochet**  
+   Potassium Slip is the Ball x Pit lane. Do not build a second ricochet scene near it.
+
+4. **Stickers Change The World**  
+   Rewards are visible on return: patched planks, inked-in signs, doodled arrows, new margin jokes, background characters, and route readability.
+
+5. **Low-Cortisol Overworld, High-Spice Mini-Games**  
+   The ridge is calm, curious, and forgiving. Mini-games can be intense, but they are short and replayable.
+
+6. **Mobile Is Real**  
+   No required input pattern should depend on keyboard-only dexterity. Every scene needs a touch-first control plan.
+
+7. **Never Hike Alone**  
+   The ridge should have a small cast of memorable NPCs and one very important cat presence, so exploration feels companionable instead of empty.
+
+8. **Learn Danilo By Restoring The Sketchbook**  
+   Portfolio facts should be discovered as objects, mementos, skills, jokes,
+   manual insights, and lived scenes. Avoid turning the Ridge into buildings
+   that open static information modals.
+
+## Route Vision
+
+The desired Ridge is a compact route that can be crossed quickly once learned.
+The active first route is Bridge Area -> Concert Area -> Dance Festival Area ->
+Relay Spire. Long-term, it can still borrow **A Short Hike mood, Tunic
+re-reading, and Hollow Knight shortcut relief**, but the main path should stay
+low-cortisol, readable, and mobile-feasible. The player sees the Relay Spire
+early, like a destination silhouette.
+
+Do not pivot the main world toward top-down, isometric, or 3D-like exploration
+without a deliberate future spike. Phaser's 2D strengths fit a layered
+side-view Ridge well, but the existing folded/Cicka Home/platformer-like
+prototype should donate only useful runtime lessons, not dictate the final route
+shape.
+
+The older zone sketches below are motif libraries, not route canon. Use the
+area docs for current Bridge, Concert, Dance Festival, and Relay design.
+
+### Legacy Motif: Outskirts / Trailhead
+
+Purpose: orient the player and connect to existing shipped content.
+
+Landmarks:
+
+- current street / city edge
+- Developer Basement hatch
+- Glasses pickup and "re-read the world" moment
+- Potassium hint object
+- early scrambled-sketchbook artifacts that replace generic portfolio buildings
+- Cicka's first perch
+- first distant view of Relay Spire
+
+Design beat:
+
+The current street should become the **Outskirts** rather than being replaced immediately. Before Glasses, the ridge feels like a rough sketch with a few obvious prompts. After Glasses, certain props jitter, margin notes appear, and the banana/Potassium path becomes legible.
+
+The current building/modal portfolio pattern should be treated as transitional.
+Outskirts should eventually teach Danilo through found objects and playable
+memory beats: tools on the ground, half-labeled project artifacts, Cicka
+reactions, and manual scraps that make old props readable after a return.
+
+### Legacy Motif: Hobby Ridge
+
+Older purpose: the main opt-in mini-game strip. In the current route, optional
+mini-games may exist as side fun, rewards, shortcuts, or future alternate-path
+candidates, but they are not the first-ending proof spine.
+
+Landmarks:
+
+- picnic blanket / ink swarm entrance for **Stampede Sketch**
+- cliffside bag or terrace for **Telegraph Terrace**
+- messy desk / service elevator for **Domino Desk**
+- manual scraps tucked into signs, nests, vending machines, or printer jams
+- low crawlspaces and scent marks that only make sense after Cicka teaches the player how to notice them
+- optional sparring notebook and scratch shaft entrances later
+
+Level shape:
+
+- 3 to 5 screens wide at first
+- one main clockwise trail
+- one late vertical shortcut shaft
+- no separate biomes in v1
+- palette shifts through ink density, paper texture, and stickers rather than new tile sets
+- future expansion can add double-jump / wall-cling style mobility, but the
+  main path should stay low-cortisol and mobile-feasible
+- the first Cicka farewell ending should not require wall cling or double jump;
+  save those as optional or later topology payoffs unless a mobile control
+  spike proves they are effortless
+
+### Active Motif: Relay Spire / Farewell Peak
+
+Purpose: final shipping/contact/credits route, and the first Cicka farewell.
+
+Gate:
+
+- for the current first-ending route, the three required Ridge Areas and their
+  resident/world changes should provide enough Living Proof
+- plus one Cicka / translator / manual insight that decodes the Relay sign
+- Relay Spire can be physically reachable before the gate is ready; the blocker
+  is that the sketchbook does not have enough living proof to send yet.
+- Treat these as proof categories, not an exact visible checklist. The path to
+  Relay should itself create enough resident help, world change, and Cicka
+  familiarity for the first ending.
+- Optional mini-games are fun, rewards, shortcuts, or future alternate ways to
+  finish a level; they are not required proof for the current first ending.
+- Local Cicka Resting Spot changes are memory and emotional continuity, not
+  separate Living Proof Gate tokens.
+
+The gate should feel earned but not tedious. It should not require every
+mini-game or every optional mastery scene, but it should ask the player to spend
+real time with the Ridge before the farewell.
+
+Ending beat:
+
+- Cicka accompanies the player to the Relay Spire as a guide to a threshold.
+- The player understands she is going somewhere the player cannot follow.
+- Before the final send, the player can play guitar for Cicka as the last
+  ordinary shared comfort moment. This should echo the guitar's earlier story
+  role and visual Cicka Resting Spot presence rather than requiring repeatable
+  resting-spot guitar interactions in the initial route.
+- The farewell is tender but not literal-heavy: no on-screen death scene, no long grief speech.
+- Cicka leaves a final paw mark or page mark, and the Ridge remains replayable after the ending.
+- Design this as the canonical first ending. Do not add multiple endings unless
+  a later story/level pass proves an alternate ending creates meaningful replay
+  value without diluting the Cicka farewell.
+- Micka, a small kitten/child presence, appears only after the player returns
+  to the normal Ridge and completes or replays one mini-game post-ending, not
+  during the ending sequence.
+
+## Main Loop
+
+1. Walk the ridge.
+2. Notice a landmark.
+3. Find an artifact, prop, or scrambled memory.
+4. Read a **Trail Card** overlay when the prop leads to an opt-in scene.
+5. Enter the mini-game, inspect the artifact, or keep hiking.
+6. Clear, fail, or quit back to ridge.
+7. Receive a stamp, manual page, sticker, memento, shortcut, or glide pip.
+8. Revisit the landmark or a local Cicka Resting Spot and see that the
+   sketchbook changed.
+
+The repeatable pleasure is not just "new content." It is returning to the same place and feeling that the sketchbook remembers.
+
+## Reward Language
+
+- **Stamps**: durable record that a hobby scene was cleared.
+- **Stickers**: visible world changes. These are the emotional reward.
+- **Manual Pages**: one-screen clues that reinterpret a route, sign, or mechanic.
+- **Artifacts**: found personal objects, tools, scraps, or odd props that teach
+  Danilo through context instead of static profile text. Major work/project
+  artifacts should be easy to notice; smaller skill scraps such as languages,
+  libraries, and tools can be tucked into optional re-read details.
+- **Mementos**: small memory objects from mini-games that physically change a
+  local Cicka Resting Spot or nearby landmark. They are memory and relationship,
+  not currency.
+- **Glide Pips**: movement upgrades inspired by *A Short Hike* feathers.
+- **Shortcuts**: route changes inspired by *Hollow Knight* relief moments.
+- **Circuit**: Potassium Slip's major reward and a possible future alternate-path proof. Derive this from the existing inventory item instead of duplicating `potassium.circuitOwned` in progress.
+- **Cicka Notes**: tiny cat-side observations that reinterpret nearby props without becoming a full language system.
+- **Developer Laptop**: a future portable or resting-spot-adjacent terminal that
+  extends the Basement computer fantasy. It may support debug/dev commands and
+  artifact inspection after the player has the right key and Glasses, but it
+  should not make typing mandatory for mobile progression.
+
+Bridge-owned progress should stay small and serializable. Exact naming should follow the current bridge store shape. A likely implementation is to extend `BridgeProgressState` with a `ridge` object and add explicit award actions:
+
+```ts
+type RidgeProgress = {
+  stamps: string[];
+  manualPages: string[];
+  mobility: {
+    glidePips: number;
+  };
+  shortcuts: string[];
+};
+```
+
+Stickers can be derived from stamps/manual pages until there is a proven need to store them separately.
+
+## Mini-Game Roadmap
+
+### 0. Potassium Slip
+
+Status: existing flagship.
+
+Role:
+
+- anchor secret
+- Ball x Pit fun already captured
+- possible future alternate-path proof through Circuit, not required for the
+  current first ending
+- benchmark for mini-game depth and documentation
+
+Do:
+
+- keep Circuit as a major reward and possible future alternate-path hook
+- let Ridge signs and NPCs acknowledge Potassium
+- preserve vertical-board controls
+
+Do not:
+
+- add another ricochet scene
+- build a generic arcade framework because Potassium is large
+- make every future mini-game as deep as Potassium
+
+### 1. Stampede Sketch
+
+First new mini-game.
+
+Inspiration: *Vampire Survivors*.
+
+Theme: Danilo is chased by inky ideas, deadline icons, and overexcited notebook
+creatures around a picnic blanket. Nearby enemies chase Danilo; enemies that
+lose his attention may drift toward the blanket and crowd the calm patch.
+
+Purpose: protect one calm picnic-blanket patch from a stampede of runaway ideas.
+See [`stampede-sketch.md`](../../mini-games/stampede-sketch.md) for the active narrative and
+asset brief.
+
+Core verb: **Kite**.
+
+Controls:
+
+- laptop: WASD/arrows
+- mobile: drag-to-move or virtual stick
+- attacks are automatic
+
+First-slice scope:
+
+- 60-90 second internal prototype, then expand to a 3-minute fixed run
+- one arena
+- capped enemy count
+- 3 auto-attacks
+- 3 upgrade choices per level
+- one first-clear glide pip
+- simple results overlay
+
+Why first:
+
+- fastest fun read
+- mobile-friendly
+- balances Potassium's skill-heavy ricochet with low-input chaos
+- easy to tune as a lunch-break toy
+
+### 2. Telegraph Terrace
+
+Second priority if Muay Thai / reactive combat becomes the next obsession.
+
+Inspiration: *Clair Obscur* plus Muay Thai pad work.
+
+Theme: a cliffside training terrace where a sketchy coach, heavy bag, or `TODO: AI` dummy treats a tiny sparring session like a world-title bout.
+
+Core verb: **Parry**.
+
+Controls:
+
+- one large parry button
+- optional dodge/jump later
+- clear audio and visual telegraphs
+- assist timing mode for mobile
+
+First version:
+
+- three short enemy "verses"
+- successful parries build Tempo
+- Tempo powers a simple counter-combo
+- misses cost confidence, not a long restart
+
+Keep it small:
+
+- no full party system
+- no AP encyclopedia
+- no frame-data lab in v1
+
+The fun is that enemy turns are not waiting. They are performance.
+
+### 3. Margin Manual Hunt
+
+Inspiration: *Tunic*.
+
+Theme: torn sketchbook pages explain things the player has been walking past.
+
+Core verb: **Re-see**.
+
+Controls:
+
+- pure overworld interaction
+- React Manual overlay with large readable pages
+
+Rules:
+
+- each page fits on one screen
+- each page teaches one idea
+- no ARG, no cryptography homework
+- manual pages should make Danilo say "oh, wait" rather than "I need a spreadsheet"
+
+Use this to support the Relay Spire gate.
+
+### 4. Cicka Daydream
+
+Optional small mini-scene / Ridge modifier.
+
+Inspiration: the wish to understand Cicka for a day, *A Short Hike* low-stakes movement, and *Tunic* re-reading familiar places.
+
+Theme: Cicka says "meow" and the whole Ridge briefly admits that this is probably a complete sentence.
+
+Core verb: **Notice**.
+
+Controls:
+
+- laptop: move, jump, interact/meow
+- mobile: drag or swipe movement, tap to meow/interact
+- no precision platforming
+
+First version:
+
+- 90-second cat daydream
+- play as Cicka on a tiny version of the Ridge
+- crawl under two props Danilo cannot enter
+- follow scent/sound trails instead of quest markers
+- knock one small object into a new place
+- unlock one Cicka Note or sticker when the daydream ends
+
+Kitty translator rule:
+
+- before translator: Cicka dialogue is only "meow", posture, timing, and punctuation
+- after translator: subtitles are affectionate guesses, not perfect literal speech
+- examples: "meow" becomes "this box has historical importance" or "you are standing on the good paper"
+
+Keep it small:
+
+- no full pet system
+- no cat inventory
+- no permanent second campaign
+- no complex animal-language grammar
+- no required resting-spot affection system in the initial route
+- no dedicated Cicka Resting Spot prompts before a later affection pass
+
+Why it belongs:
+
+- it makes the world less lonely
+- it turns a personal real-life presence into a playable secret
+- it supports the core Ridge idea: new knowledge makes old places different
+
+### 5. Domino Desk
+
+Inspiration: *Divinity: Original Sin 2* surfaces and deterministic systems.
+
+Theme: a messy desk battlefield with coffee rings, tape, staples, sticky notes, and overheated laptop tiles.
+
+Core verb: **Push-turn**.
+
+Controls:
+
+- tap/select piece
+- swipe cardinal direction
+- undo for fat-finger mistakes
+
+First version:
+
+- two compact puzzles
+- deterministic chain reactions
+- no stats
+- no dice
+- reward: service elevator shortcut
+
+The fun is feeling clever, not managing a CRPG.
+
+### 6. Neutral Notebook
+
+Inspiration: fighting games.
+
+Theme: Danilo spars with an onion-paper sketch of his past self.
+
+Core verb: **Poke**.
+
+Controls:
+
+- move/backdash macro zones
+- one poke button
+- one dash button
+- no motion inputs
+
+Keep:
+
+- spacing
+- whiff punish
+- corner tension
+- three-hit rounds
+
+Avoid:
+
+- combo trials
+- netcode
+- full character roster
+
+This is a later scene because the design tuning is subtle.
+
+### 7. Shaft of Scratches
+
+Inspiration: *Hollow Knight* pogo mastery.
+
+Theme: a scratchy utility shaft with doodled hazards.
+
+Core verb: **Pogo**.
+
+Controls:
+
+- jump
+- air-tap/down-strike bounce
+- generous coyote time
+
+Role:
+
+- optional skill souvenir
+- unlocks a satisfying shortcut rope
+
+This should be small and slightly spicy. It should never block the main ending.
+
+## NPC And Dialogue Tone
+
+The tone is **warm weirdos with tiny stakes delivered like destiny**.
+
+Character Designer rule: every NPC should be readable by silhouette first, voice second, and function third. If an NPC exists only to explain a menu, it should be a sign instead.
+
+Examples:
+
+- A training dummy named `TODO: AI` demands an honorable duel before it has implemented legs.
+- A clipboard officer treats banana ricochets as workplace law.
+- A ridge guide gives sincere advice, then worries about font licensing.
+- A printer oracle speaks in jammed paper prophecies.
+- A tiny NPC takes a sticker placement dispute more seriously than the finale.
+- Cicka says "meow" with the emotional specificity of a 900-page novel.
+
+Rules:
+
+- short dialogue
+- sincere under the joke
+- no generic portfolio exposition
+- no recruiter-facing sales pitch
+- the bit should reveal a real Danilo taste, habit, hobby, or worry
+- the cast should stay tiny; no NPC schedules until static characters already feel alive
+
+## Character Layer
+
+Characters should make the Ridge feel inhabited without turning the project into an RPG.
+
+### Cast Size
+
+First target:
+
+- **Cicka**: cat, translator mystery, companionable re-seeing of the Ridge.
+- **Ridge Guide**: gentle A Short Hike-style orientation and small encouragement.
+- **Potassium Compliance Officer**: already the absurd authority of the banana arcade world.
+- **TODO: AI**: training dummy / sparring partner for Telegraph Terrace or Neutral Notebook.
+- **Printer Oracle**: manual-page hint giver, dramatic about paper jams.
+
+That is enough for v1. More characters should arrive only when a new mini-game needs a face.
+
+### Interaction Shape
+
+Each NPC gets:
+
+- one first-meeting line
+- one post-stamp line
+- one optional joke or vulnerability line
+- one clear interaction affordance if they launch a scene or overlay
+
+No NPC should require a dialogue tree in v1. The goal is presence, not conversation management.
+
+### Cicka
+
+Cicka should feel like a real tiny resident of the sketchbook, not a mascot pasted on top.
+
+Behavior:
+
+- appears on perches, boxes, warm laptop vents, and suspiciously important paper
+- sometimes blocks a path for no reason until the player returns with a sticker or manual clue
+- reacts to cleared mini-games with new "meow" punctuation
+- leaves paw-print margin marks near hidden details
+- grows from side resident into the emotional guide for the first ending
+- leaves through a symbolic farewell at the Relay Spire, toward somewhere the player cannot follow
+
+Design:
+
+- small black-ink silhouette with very readable tail shapes
+- stepped animation: blink, loaf, stretch, suspicious turn, tiny hop
+- subtitles should use paper-cut dialogue bubbles, but only after the translator moment
+
+Ending and tribute rule:
+
+- Cicka's farewell is a tribute beat, not a literal death scene.
+- Use presence, absence, paw marks, silence, and optionally a tiny raw sound
+  instead of translated farewell text or heavy exposition in the initial ending.
+- After the ending, the Ridge remains open for replay. Cicka's canonical final
+  mark should persist at the Relay threshold, with one quieter echo at the
+  Concert Resting Spot for the initial return state. The echo is the empty usual
+  spot plus one small paw/page mark, not the player's guitar left behind.
+- Micka appears after the player returns to the Ridge from completing or
+  replaying one post-ending mini-game. She is continuity, not replacement.
+
+Translator fantasy:
+
+The kitty translator is not a universal decoder. It is a playful empathy device. It teaches the player that Cicka has been commenting on the Ridge the whole time, but the translations are intentionally a little questionable.
+
+Good translations:
+
+- "This cardboard is load-bearing."
+- "You forgot to smell the shortcut."
+- "The banana place is loud in a legally interesting way."
+- "Nap here and the world becomes 12% more true."
+
+Bad direction:
+
+- long exposition
+- exact lore dumps
+- Cicka solving puzzles for the player
+- making Cicka sound like a normal human
+
+## Manga And Sketchbook Feel
+
+The style guide remains **Digital Sketchbook**: off-white paper, black ink, hand-drawn silhouettes, paper-cut UI, stepped animation.
+
+The manga influence should come through as:
+
+- panel-like compositions for Trail Cards and Manual Pages
+- expressive black shapes and negative space
+- funny-sad little observations in margins
+- a handmade feeling that tolerates roughness
+
+Use the *Oyasumi Punpun* taste signal carefully. The goal is not to make the portfolio bleak. The useful ingredient is the contrast: simple drawings can carry real interior feeling.
+
+## Level Design Rules
+
+1. The Relay Spire must be visible early.
+2. A landmark should be readable by silhouette before text explains it.
+3. Every first clear should change the ridge visually.
+4. Backtracking must get faster after rewards.
+5. Falling should not punish the player in the overworld.
+6. No main-path jump should require precision platforming.
+7. Optional mastery paths can be hard, but must be clearly optional.
+8. A mobile player should be able to reach the first Trail Card within one minute.
+9. Long-term topology should stay 2D side-view and interconnected, not
+   top-down/isometric by default.
+10. Wall cling / double jump are desirable long-term movement flavors, but not
+    required gates for the first farewell ending.
+
+## Architecture Rules For This Plan
+
+Respect the current React + Phaser architecture:
+
+- **Scenes** are Phaser worlds.
+- **Overlays** are React surfaces.
+- **Triggers** are scene-owned.
+- Durable cross-scene progress belongs in the bridge store.
+- Trail Cards, Manual Pages, upgrade choices, and results screens are React overlays through `OverlayHost`.
+- Mini-games should be separate scene folders, not modes inside one mega-scene.
+- Do not introduce a generic mini-game framework until at least three shipped scenes prove repeated pain.
+- Arcade scenes with direct pointer input should intentionally use a non-`portrait-cover` presentation mode so they do not sit under the mobile gesture overlay. Potassium already uses `vertical-board`; future scenes should extend scene presentation policy deliberately.
+- If Ridge glide needs touch-hold behavior, add durable touch state such as `jumpHeld` or `glideHeld`, not another one-shot. Make glide opt-in for Ridge so Hobbies/Basement do not inherit it by accident.
+
+Likely folders when implementation starts:
+
+- Proposed Ridge scene folder.
+- Proposed Stampede Sketch scene folder.
+- Proposed Telegraph Terrace scene folder.
+- Proposed Cicka Daydream scene folder, only if the cat daydream becomes a separate scene.
+- Proposed Domino Desk scene folder.
+- scene-local overlays under each scene's `overlays/`
+- shared/global Manual or Trail Card overlays only if repeated use justifies it
+
+## Legacy Prototype Development Notes
+
+The slices below record the older prototype plan that produced useful runtime
+lessons. They are not the active route-reset plan. Use
+[`milestone-plan.md`](../milestone-plan.md), GitHub Issues, and the Ridge router
+for current work sequencing.
+
+### Slice 0: Production Baseline
+
+Goal: make the current state legible before adding more.
+
+Tasks:
+
+- treat Potassium Slip as the mini-game benchmark
+- document the final expected Circuit reward path from existing inventory ownership
+- decide the minimal bridge progress keys
+- confirm current return-to-overworld behavior and overlay pause behavior still work
+
+Done when:
+
+- Potassium can be referenced by future Ridge gates without ambiguity
+- there is no new architecture invented for hypothetical mini-games
+- the plan is clear that mini-game run state stays inside each scene, while the bridge stores only durable rewards
+
+### Slice 1: Ridge Shell
+
+Goal: make the main game shape playable.
+
+Tasks:
+
+- add a compact side-view Ridge scene
+- show Relay Spire silhouette
+- add three landmark triggers with Trail Cards
+- place Cicka's first perch and one static NPC who makes the Ridge feel inhabited
+- support return to Ridge from child scenes
+- add placeholder sticker changes for cleared content
+
+Done when Danilo can:
+
+- enter the Ridge
+- see the destination
+- interact with at least three hobby props
+- back out without losing place
+- understand that mini-games are optional
+
+### Slice 2: Stampede Sketch
+
+Goal: ship the first new mini-game.
+
+Tasks:
+
+- implement move-only survivor arena
+- add automatic attacks
+- add XP pickups and three-choice upgrades
+- cap entities for phone performance
+- add results overlay
+- reward first clear with one glide pip and a visible sticker
+
+Done when:
+
+- the first 60 seconds are fun without reading instructions
+- a mobile player can survive through movement alone
+- clearing it changes traversal or visuals on the Ridge
+
+### Slice 3: Ridge Memory
+
+Goal: make rewards emotionally visible.
+
+Tasks:
+
+- sticker layer changes signs, planks, background doodles, or route hints
+- one shortcut opens
+- glide pip affects overworld movement
+- manual page overlay explains one existing sign
+- first Cicka Note, memory reaction, or pre-translator interaction makes an old
+  prop feel newly readable
+
+Done when:
+
+- returning to the Ridge after a clear feels different
+- the player can explain what changed without opening an inventory
+
+### Slice 4: Telegraph Terrace
+
+Goal: test the Muay Thai / Clair Obscur direction at indie scope.
+
+Tasks:
+
+- build one-button parry scene
+- use 3 short attack patterns
+- successful defense builds Tempo
+- Tempo triggers a clear counter
+- add assist timing mode
+- reward a manual page for Relay rhythm glyphs
+
+Done when:
+
+- defense feels active
+- missing is recoverable
+- the scene works with one thumb
+
+### Slice 5: Relay Spire First Ending
+
+Goal: close the loop with Cicka as the emotional spine.
+
+Tasks:
+
+- add final gate logic
+- require the three required Ridge Areas / resident-world changes as the current
+  first-ending proof spine
+- require one Cicka / translator / manual insight
+- add short ending overlay / paper-cut farewell beat
+- return player to Ridge after ending
+- keep mini-games replayable after the ending
+- introduce Micka after the player returns from completing or replaying one
+  post-ending mini-game, not inside the ending sequence
+
+Done when:
+
+- Danilo can finish a complete route in roughly 20 to 35 minutes
+- the ending feels like shipping a living sketchbook and saying goodbye with care
+
+## Design Validation
+
+Before adding another mini-game, the current build should pass these checks:
+
+- Danilo smiles before any long text explains the premise.
+- The Ridge is memorable enough to describe from memory.
+- Phone controls do not feel like a compromise.
+- Every mini-game has one sentence, one verb, one reward.
+- The first reward visibly changes the world.
+- The first NPC interaction makes the Ridge feel less lonely without starting a dialogue tree.
+- Potassium still feels special.
+- The main ending does not require beating the hardest optional scene.
+
+## Scope Cuts
+
+Cut or defer these until the core loop is proven:
+
+- full fighting-game engine
+- full Clair Obscur party/AP system
+- full Tunic cipher language
+- second ricochet mini-game
+- large overworld map
+- top-down/isometric overworld pivot before a dedicated spike
+- multi-biome asset set
+- generic mini-game framework
+- meta-progression shop
+- complex NPC schedules
+- required precision platforming
+
+## Current Open Knobs For Danilo
+
+These are the choices to iterate on next:
+
+- **Tone mix**: default to 70% goofy, 30% quiet ache.
+- **Avatar**: Danilo-as-Danilo, a sketchbook stand-in, or a tiny abstract mascot.
+- **First ending length**: default to 20 to 35 minutes.
+- **Next mini-game after Stampede**: default to Muay Thai / Telegraph Terrace.
+- **Manual difficulty**: default to one-screen aha clues, no real cipher.
+- **Cicka timing**: default to first perch in Slice 1, translator/daydream after Ridge Memory proves return play.
+- **World scale**: default to one ridge before any new area.
+
+## Level Designer Verdict
+
+Build the smallest version that already feels like the desired rework:
+
+1. Bridge Area proves the player can help the Ridge without platformer friction
+2. Concert Area earns the guitar and Cicka comfort logic
+3. Dance Festival Area gives the route a warm last-human-place beat
+4. Relay Spire lands Guitar Farewell, Send the Sketchbook Prompt, and Cicka
+   Threshold Farewell
+5. returning Ridge state remembers what happened without turning optional
+   mini-games into required gates
+
+That is enough for the game to have a soul before it has a backlog.

--- a/docs/game-design/ridge/legacy/reviews/README.md
+++ b/docs/game-design/ridge/legacy/reviews/README.md
@@ -1,0 +1,13 @@
+# Legacy Ridge Reviews
+
+> Status: superseded review archive.
+
+These reviews describe earlier blockout experiments. Use them for comparison or
+historical rationale only. Active route review should start from
+[`../../story-level-bible.md`](../../story-level-bible.md) and the matching
+[`../../areas/`](../../areas/README.md) file.
+
+## Files
+
+- [`blockout-fun-review.md`](./blockout-fun-review.md): review of the first
+  folded/Cicka Home blockout skeleton.

--- a/docs/game-design/ridge/legacy/reviews/blockout-fun-review.md
+++ b/docs/game-design/ridge/legacy/reviews/blockout-fun-review.md
@@ -1,7 +1,7 @@
 # Ridge Blockout Fun Review
 
 Status: design review of
-[`folded-desk-ridge.source.ts`](../../../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts).
+[`folded-desk-ridge.source.ts`](../../../../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts).
 
 This review scores the first text skeleton against the current research notes on
 2D map design, Lucky Luna, and Nine Sols.

--- a/docs/game-design/ridge/map-language.md
+++ b/docs/game-design/ridge/map-language.md
@@ -248,10 +248,13 @@ room opts into a newer language version.
 
 Exit anchors may include `movement=` to choose the generated traversal
 connector. v0 supports `ramp`, `jump`, `climb`, and `drop`; unknown movement
-values fail validation. These are blockout semantics, not final ability names:
-ramps/stairs are assisted walking strips, jumps create sparse forgiving
-platforms, climbs create cord/lift assist zones, and drops create safe return
-zones when unlocked.
+values fail validation. These are blockout semantics, not final ability names.
+`ramp` is a legacy/internal connector label for assisted walking strips; the v0
+Ridge design should describe main-path terrain as chunky stairs, shelves,
+bridges, cords, lifts, and soft drops rather than visual slope traversal. Jump
+connectors remain available for legacy or optional blockouts but are not the v0
+main-route target. Climb connectors create cord/lift assist zones, and drops
+create safe return zones when unlocked.
 
 Seamless-world QA rule: runtime-active, non-empty cells from different room
 beats should not overlap unless the map explicitly declares a merge rule. v0

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -209,7 +209,7 @@ camera width of playable space.
 | 2. Cicka Home | Emotional anchor | desk-nest, pinboard, empty memento space, Cicka interaction |
 | 3. Work Artifact Ledge | Learn Danilo through object | short climb; easy major artifact slot: Saturn/Vega or Hummingbird placeholder |
 | 4. Stampede Blanket | First opt-in action | wide bridge/shelf approach; visible future drop/fold back to Cicka |
-| 5. Taped Bridge / Missing Plank | First required soft gate / Resident Help Beat | closed or unsafe crossing; Cicka field presence draws attention; tiny resident problem opens or patches route |
+| 5. Taped Bridge / Missing Plank | First required art/drawing soft gate / Resident Help Beat | closed or unsafe crossing; Cicka field presence draws attention; tiny resident problem opens or patches route through art |
 | 6. Switchback Shelf | First spatial memory test | trail bends upward/back over Cicka; Cicka Home visible below |
 | 7. Telegraph Terrace | Future mini-game teaser | vertical climb/elevator-looking cord; later cord drop to Cicka |
 | 8. Guide Overlook | Reorientation | Relay Spire visible again from above; Guide points without exposition dump |
@@ -241,7 +241,7 @@ the first shortcut opens. This creates the mental model:
 
 | Unlock | Route change | Why it matters |
 | --- | --- | --- |
-| Bridge resident helped | Taped bridge or missing-plank crossing opens on the main route | Teaches "help resident -> route changes" with a tiny local soft gate |
+| Bridge resident helped | Taped bridge or missing-plank crossing opens on the main route through drawing/art | Teaches "help resident -> route changes" with a tiny local soft gate |
 | Stampede clear | Safe drop/fold from Switchback back to Cicka Home | First "aha"; Cicka is reachable after first mini-game |
 | Telegraph clear | Cord/drop shaft from Telegraph Terrace to Cicka Home | Lucky Luna-style descent; makes terrace feel above home |
 | Domino future | Desk lift/elevator returns from Domino to Cicka Home | Vertical route compression and puzzle identity |
@@ -673,6 +673,14 @@ while the ending uses it as comfort.
 Give Concert Crossing a non-arcade fallback so the main route can ship through
 dialogue, collection, practice, or auto-play before the rhythm mini-game is fully
 polished.
+
+Current final required Resident Room Beat candidate: **Last Dance / Bachata
+Crossing**. Two fictional residents like each other but are too nervous to step
+onto the dance floor or talk directly. The player helps organizers set up the
+dance, prepares one nervous partner, and helps the pair find rhythm so the
+crossing clears. Keep the main solution conversational/collection-based; a dance
+rhythm mini-game can be optional later. The couple can be emotionally inspired
+by Danilo and Milena's story, but should not be literal stand-ins.
 
 Next code issue after that prose plan should be:
 

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -794,7 +794,8 @@ Build:
 - place Bridge Resting Spot, Concert Resting Spot, and Dance Festival Resting
   Spot as progress-memory spaces, not hubs or v0 prompt nodes
 - give each resting spot two tiny visual states: pre-resolution attention cue
-  and post-resolution calm/memory read
+  and immediate post-resolution calm/memory read; the Guitar Farewell montage
+  can revisit those changed states instead of introducing them
 - add at least one Cicka field-presence hint at a local route blocker
 - add at least one Resident Help Beat that visibly changes a route
 - make Stampede route at least one vertical beat away

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -699,10 +699,10 @@ then nearby locals help the player understand that they are avoiding each other.
 Do not let the player solve the beat by directly confronting them with their
 feelings. The Last-Stop Operations Helper's readiness favor is **Operations
 Handoff Check**: the player helps prove the plaza setup is safe enough for a
-trusted resident to keep watch once the night dance starts, with the dance
-teacher as the simplest current cover candidate. The point is not replacing her
-planning; it is showing that she did enough and can enjoy the event. The
-driver's readiness favor is **One-Step Practice**: the player helps him
+the **Dance Teacher** to keep watch once the night dance starts. The point is
+not replacing her planning; it is showing that she did enough and can enjoy the
+event. The driver's readiness favor is **One-Step Practice**: the player helps
+him
 privately learn one tiny dance step before the setup handoff, last daylight
 ride, and later night-dance promise can happen. After both favors, the connector
 is **Folded Song Request**: a tiny paper invitation where the driver requests a
@@ -713,8 +713,11 @@ The physical route solve is
 **Setup Clearance Walkthrough**: final visible setup details clear the service
 lane enough for the steward to open the gate and the driver to offer the last
 daylight ride. Present it as a **Prompt-Driven Playable Montage**: a few
-authored interaction snaps plus a visible sky/plaza time shift, not full manual
-chores or a pure cutscene. Cicka's role is quiet threshold observer near the
+symbolic one-action snaps plus a visible sky/plaza time shift, not full manual
+chores or a pure cutscene. The default snaps are: secure the lantern line, clear
+or tape the service-lane obstruction, and flip the shuttle sign to "Last
+daylight ride." These can collapse further if the beat needs to move faster.
+Cicka's role is quiet threshold observer near the
 operations table, shuttle step, or service gate; she can loaf with the
 **Unnamed Counterpart Cat** as implied continuity foreshadowing, but the scene
 should use only silhouette/color specificity such as a pale or light-ink

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -12,8 +12,9 @@ Use **Sketchbook Neighborhood Spine With Folded Shortcuts**.
 The map should feel like a lived-in paper neighborhood made from desks, pins,
 scraps, small resident spaces, bridges, lifts, and soft drop shafts. The player
 moves toward the Relay Spire by helping tiny residents and seeing routes
-change. Cicka Home remains the place that remembers durable progress, while
-Cicka can also appear as subtle field presence at meaningful route beats.
+change. The current proof-of-concept uses Cicka Home as a memory place, but the
+newer linear story route should distribute that function into local **Cicka
+Resting Spots** inside the required Ridge Areas.
 
 Core promise:
 
@@ -38,9 +39,10 @@ Later: "Old scraps now mean something about Danilo."
 - **Lucky Luna influence is local.** Use descent pockets where the player falls
   through readable shafts and steers horizontally. Do not replace the whole game
   with a hazard-descent gauntlet.
-- **Cicka is present, not only returned to.** Cicka Home remains a progress
-  memory space, but authored Cicka field appearances can guide attention at
-  barricades, wells, bridges, and other route beats through posture and staging.
+- **Cicka is present, not only returned to.** Each required Ridge Area
+  should include a small local **Cicka Resting Spot**, while authored Cicka
+  field appearances can guide attention at barricades, wells, bridges, and
+  other route beats through posture and staging.
 - **One primary destination:** Relay Gate is the visual long-term goal. It
   appears early, disappears behind local terrain, then reappears from a higher
   angle.
@@ -51,27 +53,27 @@ Later: "Old scraps now mean something about Danilo."
   familiarity for the first ending; extra residents can deepen optional return
   play.
 - **Resident count is a tuning variable.** Start the prose plan with 2-3
-  required main-path Resident Room Beats and a small optional cast. Add more only
-  if the Level Designer and Story/Tone pass agree the Ridge needs more inhabited
-  texture without turning into errands.
+  required main-path Ridge Areas / Resident Beats and a small optional cast. Add
+  more only if the Level Designer and Story/Tone pass agree the Ridge needs more
+  inhabited texture without turning into errands.
 - **Required resident beats carry Cicka familiarity.** Every required Resident
   Help Beat should include authored Cicka field presence, but her role can vary:
   first as attention cue, later as observer of a changed object, and eventually
   as quiet trust marker.
-- **Resident Room Beat is a design unit, not a Phaser scene.** One required
-  resident space can include multiple residents, a small conflict, optional
-  interactions, and alternate solutions while still remaining part of the
-  Exploration Map.
+- **Ridge Area is a design unit, not a Phaser Scene.** One required
+  Ridge Area can include a Resident Beat, multiple residents, a small conflict,
+  interiors, optional interactions, and alternate solutions while still
+  remaining part of the Exploration Map.
 - **Mini-games attach; they do not hold up the spine.** The first ending path
-  should work through conversations, collection, authored traversal, Resident
-  Room Beats, and visible world changes. Mini-Game Entrances can add optional
-  alternate path unlocks, proofs, shortcuts, rewards, or pure side fun.
+  should work through conversations, collection, authored traversal, Ridge
+  Areas, Resident Beats, and visible world changes. Mini-Game Entrances can add
+  optional alternate path unlocks, proofs, shortcuts, rewards, or pure side fun.
 - **Not every resident is progression.** Optional residents, NPCs, props, and
   tiny hangout spaces may offer mini-games, alternate flavor, jokes, or vibes
   without solving a barricade.
 - **Backtracking must transform.** A Resident Help Beat or cleared mini-game
-  changes Cicka Home, a local route blocker, a shortcut, or how old artifacts
-  read.
+  changes a Cicka Resting Spot, a local route blocker, a shortcut, or how old
+  artifacts read.
 - **Mobile-safe main path.** Main route uses chunky stairs, ladders or cords,
   bridges, wide shelves, elevators, soft drops, and forgiving crossings.
   Optional secrets can use trickier movement later.
@@ -659,22 +661,22 @@ story beats, level beats, tiny residents, Cicka field presences, route blockers,
 and visible before/after world changes. Design from the middle/end backward so
 the opening is not overfit to the current prototype.
 Write the canonical ending sequence outline first, then work backward into the
-final required Resident Room Beat, the middle cause-and-effect beat, and only
-then the first taped-bridge tutorial beat.
+final required Ridge Area / Resident Beat, the middle cause-and-effect beat,
+and only then the first taped-bridge tutorial beat.
 The ending outline should include the Guitar Farewell as an established comfort
 interaction, not a one-off ending prop: the player finds or receives the guitar
-earlier, can play it at Cicka Home or quiet Ridge spots, and plays for Cicka
-near Relay before the threshold farewell.
-Current middle required Resident Room Beat: a **Concert Crossing Beat** where a blocked
-concert/traffic crossing opens after the player helps with a small
-Guitar-Hero-like performance problem and earns the guitar. Keep the final
+earlier, can play it at local Cicka Resting Spots or quiet Ridge spots, and
+plays for Cicka near Relay before the threshold farewell.
+Current middle required Ridge Area / Resident Beat: a **Concert Crossing Beat**
+where a blocked concert/traffic crossing opens after the player helps with a
+small Guitar-Hero-like performance problem and earns the guitar. Keep the final
 Guitar Farewell separate from arcade difficulty; the concert teaches the item,
 while the ending uses it as comfort.
 Give Concert Crossing a non-arcade fallback so the main route can ship through
 dialogue, collection, practice, or auto-play before the rhythm mini-game is fully
 polished.
 
-Current final required Resident Room Beat candidate: **Opening Dance Shuttle
+Current final required Ridge Area / Resident Beat candidate: **Opening Dance Shuttle
 Beat**. Two fictional residents like each other but are too nervous to step onto
 the dance floor or talk directly. The night dance festival is real, but the
 player participates in afternoon setup and leaves before the festival fully
@@ -686,24 +688,25 @@ resident being helped should have a daily purpose tied to that route. Current
 locked direction: the nervous dancer is the hill-shuttle driver, and the
 romantic partner is the shy **Last-Stop Operations Helper**, whose visible
 plaza-table work connects shuttle questions, setup checks, volunteer handoffs,
-service-road clearance, and the night dance. Accepted arrival premise:
-**Opening Dance Setup + Last Daylight Shuttle**. Conversation choices can create
-different tones, orders, or recoverable awkward paths, but should not
-permanently block the first ending. Introduce the beat through a practical
-wayfinding loop: the player asks how to reach Relay, notices the blocked service
-road and shuttle sign, then learns the emotional layer through delayed setup and
-the last daylight shuttle window before the road closes for the night festival.
+service-road clearance, and the night dance. Keep these as role-first character
+labels for now; proper names can wait until a later character pass. Accepted
+arrival premise: **Opening Dance Setup + Last Daylight Shuttle**. Conversation
+choices can create different tones, orders, or recoverable awkward paths, but
+should not permanently block the first ending. Introduce the beat through a
+practical wayfinding loop: the player asks how to reach Relay, notices the
+blocked service road and shuttle sign, then learns the emotional layer through
+delayed setup and the last daylight shuttle window before the road closes for
+the night festival.
 Reveal the relationship through a triangulated discovery flow: the driver and
 Last-Stop Operations Helper give truthful but incomplete practical answers,
 then nearby locals help the player understand that they are avoiding each other.
 Do not let the player solve the beat by directly confronting them with their
 feelings. The Last-Stop Operations Helper's readiness favor is **Operations
-Handoff Check**: the player helps prove the plaza setup is safe enough for a
-the **Dance Teacher** to keep watch once the night dance starts. The point is
+Handoff Check**: the player helps prove the plaza setup is safe enough for the
+**Dance Teacher** to keep watch once the night dance starts. The point is
 not replacing her planning; it is showing that she did enough and can enjoy the
 event. The driver's readiness favor is **One-Step Practice**: the player helps
-him
-privately learn one tiny dance step before the setup handoff, last daylight
+him privately learn one tiny dance step before the setup handoff, last daylight
 ride, and later night-dance promise can happen. After both favors, the connector
 is **Folded Song Request**: a tiny paper invitation where the driver requests a
 simple, cute, guitar-friendly song and asks her for one dance later without a
@@ -718,7 +721,8 @@ chores or a pure cutscene. The default snaps are: secure the lantern line, clear
 or tape the service-lane obstruction, and flip the shuttle sign to "Last
 daylight ride." These can collapse further if the beat needs to move faster.
 Cicka's role is quiet threshold observer near the
-operations table, shuttle step, or service gate; she can loaf with the
+operations table, shuttle step, or service gate. This is the Opening Dance
+**Cicka Resting Spot**; she can loaf with the
 **Unnamed Counterpart Cat** as implied continuity foreshadowing, but the scene
 should use only silhouette/color specificity such as a pale or light-ink
 contrast to Cicka. Do not name him, give him dialogue, confirm parentage, or
@@ -730,8 +734,9 @@ story, but should not be literal stand-ins.
 
 Guitar Farewell can include a brief **Living Proof Montage**: Blueprint Bridge
 being used, Concert Crossing continuing, Opening Dance beginning at night as an
-emotional echo under the player's guitar, and Cicka Home carrying accumulated
-marks. Keep it wordless or nearly wordless so the focus stays on Cicka.
+emotional echo under the player's guitar, and earlier Cicka Resting Spots
+carrying accumulated marks. Keep it wordless or nearly wordless so the focus
+stays on Cicka.
 
 Relay time should progress from sunset for **Sit and Play Prompt** to **Relay
 Blue Hour** for **Send the Sketchbook Prompt**. The montage can show the night
@@ -752,15 +757,20 @@ the Sketchbook Prompt**. This starts the Cicka Threshold Farewell while keeping
 the guitar as comfort rather than the send button.
 
 Cicka's departure should be physical and mostly silent: walk together, pause,
-look back, final mark, then page-fold/light departure. Any meow or translated
-fragment should stay tiny and optional.
+look back, final mark, then page-fold/light departure. The initial version
+should use no translated farewell line; a tiny raw meow/chirp sound can remain
+optional if it supports the staging.
 
 Immediate post-ending play should use the **Open Ridge Return State**:
-replayable, quiet, and absence-marked. Micka remains delayed until the later
-post-ending trigger rather than appearing immediately.
+replayable, quiet, and minimally absence-marked. The canonical final mark
+persists at the Relay threshold, one quieter echo appears at the Concert
+Resting Spot, and Micka remains delayed until the later post-ending trigger
+rather than appearing immediately. The echo should be an empty usual spot with
+one small paw/page mark, not the guitar left behind.
 
-Current first required Resident Room Beat: **Blueprint Bridge**. Help a resident
-finish a tiny bridge drawing/blueprint, then the finished sketch becomes the crossing.
+Current first required Ridge Area / Resident Beat: **Blueprint Bridge**. Help a
+resident finish a tiny bridge drawing/blueprint, then the finished sketch
+becomes the crossing.
 Direct bridge drawing or physics bridge-building can be a future optional toy,
 not the required v0 route.
 
@@ -778,7 +788,7 @@ Build:
 - introduce a mostly forward neighborhood route with readable bends and folds
 - keep main route mobile-safe with wide shelves, chunky stairs, cords, bridges,
   lifts, and soft drops
-- place Cicka Home as a progress memory space, not first prop in a row
+- place local Cicka Resting Spots as progress-memory spaces, not hubs
 - add at least one Cicka field-presence hint at a local route blocker
 - add at least one Resident Help Beat that visibly changes a route
 - make Stampede route at least one vertical beat away

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -1,9 +1,14 @@
 # Sketchbook Ridge Proper Map Plan
 
+> Status: legacy/prototype topology reference.
 > Follow-up to [`topology-spike.md`](./topology-spike.md).
 > Issue #54 proved the current Ridge can change visually, but the route is still
-> a short prop line. This document defines the first real Ridge map before the
-> next implementation pass.
+> a short prop line. This document records the prior folded/Cicka Home topology
+> target. It is not the active Ridge route canon unless a new slice explicitly
+> rewrites it around [`../story-level-bible.md`](../story-level-bible.md).
+
+For current Ridge source-of-truth routing, read [`../README.md`](../README.md)
+first.
 
 ## Decision
 
@@ -132,10 +137,9 @@ resident-caused route changes**, not abstract platforming.
 
 ## Topology Visual
 
-The old standalone inventory canvas was removed after this plan became the
-current map target.
-draws the same plan as an in-game map-screen style canvas with first-walk,
-shortcut, and future-route layers.
+The old standalone inventory canvas was removed during the prior folded-map
+planning pass. This section draws that plan as an in-game map-screen style
+canvas with first-walk, shortcut, and future-route layers.
 
 ```text
 Legend:

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -683,19 +683,22 @@ Relay hill. The physical blocker is practical: festival barriers, a locked
 service-road gate, and/or the last hill shuttle not running until the event can
 close properly. The resident being helped should have a daily purpose tied to
 that route. Current locked direction: the nervous dancer is the hill-shuttle
-driver, and the romantic partner is the shy last-stop lantern/ticket clerk. She
-belongs at the festival because she stamps last-shuttle tickets, helps close the
-street, and checks the lanterns for the hill road. Locked arrival state:
-**Last Ticket + Lantern Check**. The driver waits by the shuttle with the route
-clipboard; the clerk closes the booth ledger and lantern tokens; each needs the
-other's sign-off before the final shuttle can leave. Conversation choices can
-create different tones, orders, or recoverable awkward paths, but should not
-permanently block the first ending. Introduce the beat through a practical
-wayfinding loop: the player asks how to reach Relay, notices the blocked
-service road and shuttle sign, then learns the emotional layer through the
-delayed final check. Reveal the relationship through a triangulated discovery
-flow: the driver and clerk give truthful but incomplete practical answers, then
-nearby locals help the player understand that they are avoiding each other.
+driver, and the romantic partner is the shy last-stop song-table volunteer. She
+belongs at the festival because she handles song slips, basic final-dance
+timing, and last-shuttle questions. Locked arrival state: **Last Song Table +
+Final Shuttle Hold**. The driver waits by the shuttle with the route clipboard;
+the volunteer stays at the song table because the final song stalls unless a
+trusted person covers it. Conversation choices can create different tones,
+orders, or recoverable awkward paths, but should not permanently block the first
+ending. Introduce the beat through a practical wayfinding loop: the player asks
+how to reach Relay, notices the blocked service road and shuttle sign, then
+learns the emotional layer through the delayed final song. Reveal the
+relationship through a triangulated discovery flow: the driver and song-table
+volunteer give truthful but incomplete practical answers, then nearby locals
+help the player understand that they are avoiding each other. Do not let the
+player solve the beat by directly confronting them with their feelings. Each
+romantic character should need a small readiness favor before the final song,
+shy dance, and lane-clearing handoff can happen.
 Avoid magical or abstract "dance makes route open" causality. Keep the main
 solution conversational/collection-based; a dance rhythm mini-game can be
 optional later. The couple can be emotionally inspired by Danilo and Milena's

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -666,8 +666,10 @@ Concert Area / Concert Crossing Beat, and only then the first Bridge Area /
 Blueprint Bridge tutorial beat.
 The ending outline should include the Guitar Farewell as an established comfort
 interaction, not a one-off ending prop: the player finds or receives the guitar
-earlier, can play it at local Cicka Resting Spots or quiet Ridge spots, and
-plays for Cicka near Relay before the threshold farewell.
+earlier, carries it through later route beats, and plays for Cicka near Relay
+before the threshold farewell. Local Cicka Resting Spots can stay mostly visual
+in v0 with no dedicated prompt; repeatable sitting, petting, lap-resting, or
+guitar interactions can wait for a later affection pass.
 Current middle route area: **Concert Area**, containing **Concert Crossing
 Beat**, where a blocked concert/traffic crossing opens after the player helps
 with a small Guitar-Hero-like performance problem and earns the guitar. Keep
@@ -723,7 +725,7 @@ or tape the service-lane obstruction, and flip the shuttle sign to "Last
 daylight ride." These can collapse further if the beat needs to move faster.
 Cicka's role is quiet threshold observer near the
 operations table, shuttle step, or service gate. This is the Opening Dance
-**Cicka Resting Spot**; she can loaf with the
+**Dance Festival Resting Spot**; she can loaf with the
 **Unnamed Counterpart Cat** as implied continuity foreshadowing, but the scene
 should use only silhouette/color specificity such as a pale or light-ink
 contrast to Cicka. Do not name him, give him dialogue, confirm parentage, or
@@ -789,7 +791,10 @@ Build:
 - introduce a mostly forward neighborhood route with readable bends and folds
 - keep main route mobile-safe with wide shelves, chunky stairs, cords, bridges,
   lifts, and soft drops
-- place local Cicka Resting Spots as progress-memory spaces, not hubs
+- place Bridge Resting Spot, Concert Resting Spot, and Dance Festival Resting
+  Spot as progress-memory spaces, not hubs or v0 prompt nodes
+- give each resting spot two tiny visual states: pre-resolution attention cue
+  and post-resolution calm/memory read
 - add at least one Cicka field-presence hint at a local route blocker
 - add at least one Resident Help Beat that visibly changes a route
 - make Stampede route at least one vertical beat away

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -47,8 +47,10 @@ Later: "Old scraps now mean something about Danilo."
   appears early, disappears behind local terrain, then reappears from a higher
   angle.
 - **Living Proof Gate:** Relay Spire can be physically reached before it can
-  send. It should require enough visible world changes, mini-game proofs, and
-  Cicka familiarity rather than a boss, precision climb, or arbitrary checklist.
+  send. For the current first ending, the three required Ridge Areas and their
+  visible world changes should be enough Living Proof. Changed Cicka Resting
+  Spots can echo proof emotionally, but proof should come from the resident
+  beat/world change, not from noticing the resting spot.
   The path to the Spire should naturally provide enough resident help and cat
   familiarity for the first ending; extra residents can deepen optional return
   play.
@@ -67,7 +69,7 @@ Later: "Old scraps now mean something about Danilo."
 - **Mini-games attach; they do not hold up the spine.** The first ending path
   should work through conversations, collection, authored traversal, Ridge
   Areas, Resident Beats, and visible world changes. Mini-Game Entrances can add
-  optional alternate path unlocks, proofs, shortcuts, rewards, or pure side fun.
+  optional fun, rewards, shortcuts, or future alternate ways to finish a level.
 - **Not every resident is progression.** Optional residents, NPCs, props, and
   tiny hangout spaces may offer mini-games, alternate flavor, jokes, or vibes
   without solving a barricade.

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -705,8 +705,11 @@ planning; it is showing that she did enough and can enjoy the event. The
 driver's readiness favor is **One-Step Practice**: the player helps him
 privately learn one tiny dance step before the setup handoff, last daylight
 ride, and later night-dance promise can happen. After both favors, the connector
-is **Folded Song Request**: a tiny paper invitation that lets the driver ask her
-for one dance later without a public confession. The physical route solve is
+is **Folded Song Request**: a tiny paper invitation where the driver requests a
+simple, cute, guitar-friendly song and asks her for one dance later without a
+public confession. Do not lock the beat to bachata or any other specific dance
+genre; the exact requested song can remain unshown and unheard by the player.
+The physical route solve is
 **Setup Clearance Walkthrough**: final visible setup details clear the service
 lane enough for the steward to open the gate and the driver to offer the last
 daylight ride. Present it as a **Prompt-Driven Playable Montage**: a few
@@ -723,9 +726,9 @@ optional later. The couple can be emotionally inspired by Danilo and Milena's
 story, but should not be literal stand-ins.
 
 Guitar Farewell can include a brief **Living Proof Montage**: Blueprint Bridge
-being used, Concert Crossing continuing, Opening Dance beginning at night, and
-Cicka Home carrying accumulated marks. Keep it wordless or nearly wordless so
-the focus stays on Cicka.
+being used, Concert Crossing continuing, Opening Dance beginning at night as an
+emotional echo under the player's guitar, and Cicka Home carrying accumulated
+marks. Keep it wordless or nearly wordless so the focus stays on Cicka.
 
 Relay time should progress from sunset for **Sit and Play Prompt** to **Relay
 Blue Hour** for **Send the Sketchbook Prompt**. The montage can show the night

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -727,6 +727,32 @@ being used, Concert Crossing continuing, Opening Dance beginning at night, and
 Cicka Home carrying accumulated marks. Keep it wordless or nearly wordless so
 the focus stays on Cicka.
 
+Relay time should progress from sunset for **Sit and Play Prompt** to **Relay
+Blue Hour** for **Send the Sketchbook Prompt**. The montage can show the night
+festival beginning elsewhere, but Relay should not become full night before the
+farewell.
+
+The shuttle ride from Last-Stop Plaza to Relay should be a **Short Threshold
+Transition**, not a controllable driving segment: the driver can say "All aboard
+the last ride," the vehicle starts over a brief blackout, the player respawns at
+Relay Spire under sunset, and control resumes at Cicka's overlook spot.
+
+The final Relay Spire interaction should be a **Sit and Play Prompt** near
+Cicka. It starts the Guitar Farewell without rhythm UI, fail state, or final
+skill check.
+
+After the Guitar Farewell, control returns at the Relay sign/spire for a **Send
+the Sketchbook Prompt**. This starts the Cicka Threshold Farewell while keeping
+the guitar as comfort rather than the send button.
+
+Cicka's departure should be physical and mostly silent: walk together, pause,
+look back, final mark, then page-fold/light departure. Any meow or translated
+fragment should stay tiny and optional.
+
+Immediate post-ending play should use the **Open Ridge Return State**:
+replayable, quiet, and absence-marked. Micka remains delayed until the later
+post-ending trigger rather than appearing immediately.
+
 Current first required Resident Room Beat: **Blueprint Bridge**. Help a resident
 finish a tiny bridge drawing/blueprint, then the finished sketch becomes the crossing.
 Direct bridge drawing or physics bridge-building can be a future optional toy,

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -677,10 +677,29 @@ polished.
 Current final required Resident Room Beat candidate: **Last Dance / Bachata
 Crossing**. Two fictional residents like each other but are too nervous to step
 onto the dance floor or talk directly. The player helps organizers set up the
-dance, prepares one nervous partner, and helps the pair find rhythm so the
-crossing clears. Keep the main solution conversational/collection-based; a dance
-rhythm mini-game can be optional later. The couple can be emotionally inspired
-by Danilo and Milena's story, but should not be literal stand-ins.
+dance, prepares one nervous partner, and helps the pair find rhythm. The dance
+belongs in a town square, community hall, or festival street at the foot of the
+Relay hill. The physical blocker is practical: festival barriers, a locked
+service-road gate, and/or the last hill shuttle not running until the event can
+close properly. The resident being helped should have a daily purpose tied to
+that route. Current locked direction: the nervous dancer is the hill-shuttle
+driver, and the romantic partner is the shy last-stop lantern/ticket clerk. She
+belongs at the festival because she stamps last-shuttle tickets, helps close the
+street, and checks the lanterns for the hill road. Locked arrival state:
+**Last Ticket + Lantern Check**. The driver waits by the shuttle with the route
+clipboard; the clerk closes the booth ledger and lantern tokens; each needs the
+other's sign-off before the final shuttle can leave. Conversation choices can
+create different tones, orders, or recoverable awkward paths, but should not
+permanently block the first ending. Introduce the beat through a practical
+wayfinding loop: the player asks how to reach Relay, notices the blocked
+service road and shuttle sign, then learns the emotional layer through the
+delayed final check. Reveal the relationship through a triangulated discovery
+flow: the driver and clerk give truthful but incomplete practical answers, then
+nearby locals help the player understand that they are avoiding each other.
+Avoid magical or abstract "dance makes route open" causality. Keep the main
+solution conversational/collection-based; a dance rhythm mini-game can be
+optional later. The couple can be emotionally inspired by Danilo and Milena's
+story, but should not be literal stand-ins.
 
 Current first required Resident Room Beat: **Blueprint Bridge**. Help a resident
 finish a tiny bridge drawing/blueprint, then the finished sketch becomes the crossing.

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -661,32 +661,33 @@ story beats, level beats, tiny residents, Cicka field presences, route blockers,
 and visible before/after world changes. Design from the middle/end backward so
 the opening is not overfit to the current prototype.
 Write the canonical ending sequence outline first, then work backward into the
-final required Ridge Area / Resident Beat, the middle cause-and-effect beat,
-and only then the first taped-bridge tutorial beat.
+final required Dance Festival Area / Opening Dance Shuttle Beat, the middle
+Concert Area / Concert Crossing Beat, and only then the first Bridge Area /
+Blueprint Bridge tutorial beat.
 The ending outline should include the Guitar Farewell as an established comfort
 interaction, not a one-off ending prop: the player finds or receives the guitar
 earlier, can play it at local Cicka Resting Spots or quiet Ridge spots, and
 plays for Cicka near Relay before the threshold farewell.
-Current middle required Ridge Area / Resident Beat: a **Concert Crossing Beat**
-where a blocked concert/traffic crossing opens after the player helps with a
-small Guitar-Hero-like performance problem and earns the guitar. Keep the final
-Guitar Farewell separate from arcade difficulty; the concert teaches the item,
-while the ending uses it as comfort.
+Current middle route area: **Concert Area**, containing **Concert Crossing
+Beat**, where a blocked concert/traffic crossing opens after the player helps
+with a small Guitar-Hero-like performance problem and earns the guitar. Keep
+the final Guitar Farewell separate from arcade difficulty; the concert teaches
+the item, while the ending uses it as comfort.
 Give Concert Crossing a non-arcade fallback so the main route can ship through
 dialogue, collection, practice, or auto-play before the rhythm mini-game is fully
 polished.
 
-Current final required Ridge Area / Resident Beat candidate: **Opening Dance Shuttle
-Beat**. Two fictional residents like each other but are too nervous to step onto
-the dance floor or talk directly. The night dance festival is real, but the
-player participates in afternoon setup and leaves before the festival fully
-begins. The dance belongs in a town square, community hall, or festival street
-at the foot of the Relay hill. The physical blocker is practical: festival
-barriers, lantern lines, chair stacks, stage/speaker cables, and a locked
-service-road gate block the hill route until setup passes inspection. The
-resident being helped should have a daily purpose tied to that route. Current
-locked direction: the nervous dancer is the hill-shuttle driver, and the
-romantic partner is the shy **Last-Stop Operations Helper**, whose visible
+Current final route area: **Dance Festival Area**, containing **Opening Dance
+Shuttle Beat**. Two fictional residents like each other but are too nervous to
+step onto the dance floor or talk directly. The night dance festival is real,
+but the player participates in afternoon setup and leaves before the festival
+fully begins. The dance belongs in a town square, community hall, or festival
+street at the foot of the Relay hill. The physical blocker is practical:
+festival barriers, lantern lines, chair stacks, stage/speaker cables, and a
+locked service-road gate block the hill route until setup passes inspection.
+The resident being helped should have a daily purpose tied to that route.
+Current locked direction: the nervous dancer is the hill-shuttle driver, and
+the romantic partner is the shy **Last-Stop Operations Helper**, whose visible
 plaza-table work connects shuttle questions, setup checks, volunteer handoffs,
 service-road clearance, and the night dance. Keep these as role-first character
 labels for now; proper names can wait until a later character pass. Accepted
@@ -768,9 +769,9 @@ Resting Spot, and Micka remains delayed until the later post-ending trigger
 rather than appearing immediately. The echo should be an empty usual spot with
 one small paw/page mark, not the guitar left behind.
 
-Current first required Ridge Area / Resident Beat: **Blueprint Bridge**. Help a
-resident finish a tiny bridge drawing/blueprint, then the finished sketch
-becomes the crossing.
+Current first route area: **Bridge Area**, containing **Blueprint Bridge**.
+Help a resident finish a tiny bridge drawing/blueprint, then the finished
+sketch becomes the crossing.
 Direct bridge drawing or physics bridge-building can be a future optional toy,
 not the required v0 route.
 

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -796,6 +796,8 @@ Build:
 - give each resting spot two tiny visual states: pre-resolution attention cue
   and immediate post-resolution calm/memory read; the Guitar Farewell montage
   can revisit those changed states instead of introducing them
+- keep changed resting-spot states optional to notice or revisit; they must not
+  become checklist gates or route requirements
 - add at least one Cicka field-presence hint at a local route blocker
 - add at least one Resident Help Beat that visibly changes a route
 - make Stampede route at least one vertical beat away

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -209,7 +209,7 @@ camera width of playable space.
 | 2. Cicka Home | Emotional anchor | desk-nest, pinboard, empty memento space, Cicka interaction |
 | 3. Work Artifact Ledge | Learn Danilo through object | short climb; easy major artifact slot: Saturn/Vega or Hummingbird placeholder |
 | 4. Stampede Blanket | First opt-in action | wide bridge/shelf approach; visible future drop/fold back to Cicka |
-| 5. Taped Bridge / Missing Plank | First required art/drawing soft gate / Resident Help Beat | closed or unsafe crossing; Cicka field presence draws attention; tiny resident problem opens or patches route through art |
+| 5. Blueprint Bridge | First required art/drawing soft gate / Resident Help Beat | closed or unsafe crossing; Cicka field presence draws attention to a blank plan; finished bridge sketch becomes the route |
 | 6. Switchback Shelf | First spatial memory test | trail bends upward/back over Cicka; Cicka Home visible below |
 | 7. Telegraph Terrace | Future mini-game teaser | vertical climb/elevator-looking cord; later cord drop to Cicka |
 | 8. Guide Overlook | Reorientation | Relay Spire visible again from above; Guide points without exposition dump |
@@ -241,7 +241,7 @@ the first shortcut opens. This creates the mental model:
 
 | Unlock | Route change | Why it matters |
 | --- | --- | --- |
-| Bridge resident helped | Taped bridge or missing-plank crossing opens on the main route through drawing/art | Teaches "help resident -> route changes" with a tiny local soft gate |
+| Blueprint Bridge helped | Bridge sketch becomes the main-route crossing | Teaches "help resident -> route changes" with a tiny local art beat |
 | Stampede clear | Safe drop/fold from Switchback back to Cicka Home | First "aha"; Cicka is reachable after first mini-game |
 | Telegraph clear | Cord/drop shaft from Telegraph Terrace to Cicka Home | Lucky Luna-style descent; makes terrace feel above home |
 | Domino future | Desk lift/elevator returns from Domino to Cicka Home | Vertical route compression and puzzle identity |
@@ -681,6 +681,11 @@ dance, prepares one nervous partner, and helps the pair find rhythm so the
 crossing clears. Keep the main solution conversational/collection-based; a dance
 rhythm mini-game can be optional later. The couple can be emotionally inspired
 by Danilo and Milena's story, but should not be literal stand-ins.
+
+Current first required Resident Room Beat: **Blueprint Bridge**. Help a resident
+finish a tiny bridge drawing/blueprint, then the finished sketch becomes the crossing.
+Direct bridge drawing or physics bridge-building can be a future optional toy,
+not the required v0 route.
 
 Next code issue after that prose plan should be:
 

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -674,35 +674,58 @@ Give Concert Crossing a non-arcade fallback so the main route can ship through
 dialogue, collection, practice, or auto-play before the rhythm mini-game is fully
 polished.
 
-Current final required Resident Room Beat candidate: **Last Dance / Bachata
-Crossing**. Two fictional residents like each other but are too nervous to step
-onto the dance floor or talk directly. The player helps organizers set up the
-dance, prepares one nervous partner, and helps the pair find rhythm. The dance
-belongs in a town square, community hall, or festival street at the foot of the
-Relay hill. The physical blocker is practical: festival barriers, a locked
-service-road gate, and/or the last hill shuttle not running until the event can
-close properly. The resident being helped should have a daily purpose tied to
-that route. Current locked direction: the nervous dancer is the hill-shuttle
-driver, and the romantic partner is the shy last-stop song-table volunteer. She
-belongs at the festival because she handles song slips, basic final-dance
-timing, and last-shuttle questions. Locked arrival state: **Last Song Table +
-Final Shuttle Hold**. The driver waits by the shuttle with the route clipboard;
-the volunteer stays at the song table because the final song stalls unless a
-trusted person covers it. Conversation choices can create different tones,
-orders, or recoverable awkward paths, but should not permanently block the first
-ending. Introduce the beat through a practical wayfinding loop: the player asks
-how to reach Relay, notices the blocked service road and shuttle sign, then
-learns the emotional layer through the delayed final song. Reveal the
-relationship through a triangulated discovery flow: the driver and song-table
-volunteer give truthful but incomplete practical answers, then nearby locals
-help the player understand that they are avoiding each other. Do not let the
-player solve the beat by directly confronting them with their feelings. Each
-romantic character should need a small readiness favor before the final song,
-shy dance, and lane-clearing handoff can happen.
+Current final required Resident Room Beat candidate: **Opening Dance Shuttle
+Beat**. Two fictional residents like each other but are too nervous to step onto
+the dance floor or talk directly. The night dance festival is real, but the
+player participates in afternoon setup and leaves before the festival fully
+begins. The dance belongs in a town square, community hall, or festival street
+at the foot of the Relay hill. The physical blocker is practical: festival
+barriers, lantern lines, chair stacks, stage/speaker cables, and a locked
+service-road gate block the hill route until setup passes inspection. The
+resident being helped should have a daily purpose tied to that route. Current
+locked direction: the nervous dancer is the hill-shuttle driver, and the
+romantic partner is the shy **Last-Stop Operations Helper**, whose visible
+plaza-table work connects shuttle questions, setup checks, volunteer handoffs,
+service-road clearance, and the night dance. Accepted arrival premise:
+**Opening Dance Setup + Last Daylight Shuttle**. Conversation choices can create
+different tones, orders, or recoverable awkward paths, but should not
+permanently block the first ending. Introduce the beat through a practical
+wayfinding loop: the player asks how to reach Relay, notices the blocked service
+road and shuttle sign, then learns the emotional layer through delayed setup and
+the last daylight shuttle window before the road closes for the night festival.
+Reveal the relationship through a triangulated discovery flow: the driver and
+Last-Stop Operations Helper give truthful but incomplete practical answers,
+then nearby locals help the player understand that they are avoiding each other.
+Do not let the player solve the beat by directly confronting them with their
+feelings. The Last-Stop Operations Helper's readiness favor is **Operations
+Handoff Check**: the player helps prove the plaza setup is safe enough for a
+trusted resident to keep watch once the night dance starts, with the dance
+teacher as the simplest current cover candidate. The point is not replacing her
+planning; it is showing that she did enough and can enjoy the event. The
+driver's readiness favor is **One-Step Practice**: the player helps him
+privately learn one tiny dance step before the setup handoff, last daylight
+ride, and later night-dance promise can happen. After both favors, the connector
+is **Folded Song Request**: a tiny paper invitation that lets the driver ask her
+for one dance later without a public confession. The physical route solve is
+**Setup Clearance Walkthrough**: final visible setup details clear the service
+lane enough for the steward to open the gate and the driver to offer the last
+daylight ride. Present it as a **Prompt-Driven Playable Montage**: a few
+authored interaction snaps plus a visible sky/plaza time shift, not full manual
+chores or a pure cutscene. Cicka's role is quiet threshold observer near the
+operations table, shuttle step, or service gate; she can loaf with the
+**Unnamed Counterpart Cat** as implied continuity foreshadowing, but the scene
+should use only silhouette/color specificity such as a pale or light-ink
+contrast to Cicka. Do not name him, give him dialogue, confirm parentage, or
+spend Micka before the post-ending return.
 Avoid magical or abstract "dance makes route open" causality. Keep the main
 solution conversational/collection-based; a dance rhythm mini-game can be
 optional later. The couple can be emotionally inspired by Danilo and Milena's
 story, but should not be literal stand-ins.
+
+Guitar Farewell can include a brief **Living Proof Montage**: Blueprint Bridge
+being used, Concert Crossing continuing, Opening Dance beginning at night, and
+Cicka Home carrying accumulated marks. Keep it wordless or nearly wordless so
+the focus stays on Cicka.
 
 Current first required Resident Room Beat: **Blueprint Bridge**. Help a resident
 finish a tiny bridge drawing/blueprint, then the finished sketch becomes the crossing.

--- a/docs/game-design/ridge/map-plans/proper-map-plan.md
+++ b/docs/game-design/ridge/map-plans/proper-map-plan.md
@@ -7,18 +7,21 @@
 
 ## Decision
 
-Use **Vertical Folded Ridge With Cicka Switchback**.
+Use **Sketchbook Neighborhood Spine With Folded Shortcuts**.
 
-The map should feel like a small vertical paper mountain made from desks, pins,
-scraps, elevators, and soft drop shafts. Cicka Home sits near the lower middle
-as the emotional return anchor. The player climbs away from Cicka to learn the
-Ridge, then earns shortcuts, drops, and lifts that fold routes back toward her.
+The map should feel like a lived-in paper neighborhood made from desks, pins,
+scraps, small resident spaces, bridges, lifts, and soft drop shafts. The player
+moves toward the Relay Spire by helping tiny residents and seeing routes
+change. Cicka Home remains the place that remembers durable progress, while
+Cicka can also appear as subtle field presence at meaningful route beats.
 
 Core promise:
 
 ```text
-First walk: "Relay is above me, but I need to learn this paper mountain."
-After clear: "Oh, this drop/lift folds back to Cicka."
+First walk: "Relay is ahead, and this sketchbook neighborhood is waking up."
+Blocked route: "Cicka noticed something; a tiny resident here needs help."
+After clear: "The route changed, and this place remembers what I did."
+At Relay: "I can reach the Spire, but the sketchbook is not ready to send yet."
 Later: "Old scraps now mean something about Danilo."
 ```
 
@@ -26,21 +29,52 @@ Later: "Old scraps now mean something about Danilo."
 
 - **No hallway row.** The player should rarely move right for more than one
   screen without a climb, drop, lift, fork, shortcut tell, or artifact clue.
-- **Verticality is core.** Main route alternates horizontal shelves with vertical
-  movement: stairs, ramps, elevators, safe drops, and broad jumps.
+- **Readable neighborhood flow is core.** Main route alternates calm horizontal
+  movement with object-like traversal: chunky paper stairs, ladders or cords,
+  bridges, elevators, safe drops, and wide crossings.
+- **No main-path slopes in v0.** Slopes and visual ramps fight the readable grid;
+  prefer stairs, shelves, cords, lifts, bridges, and soft drops unless a future
+  sliding/descent mechanic deliberately earns slope behavior.
 - **Lucky Luna influence is local.** Use descent pockets where the player falls
   through readable shafts and steers horizontally. Do not replace the whole game
-  with no-jump controls.
-- **Cicka return max:** after any mini-game, Cicka Home must be reachable in
-  20-30 seconds with unlocked shortcuts.
+  with a hazard-descent gauntlet.
+- **Cicka is present, not only returned to.** Cicka Home remains a progress
+  memory space, but authored Cicka field appearances can guide attention at
+  barricades, wells, bridges, and other route beats through posture and staging.
 - **One primary destination:** Relay Gate is the visual long-term goal. It
   appears early, disappears behind local terrain, then reappears from a higher
   angle.
-- **Backtracking must transform.** A cleared mini-game changes either Cicka
-  Home, the path home, or how old artifacts read.
-- **Mobile-safe main path.** Main route uses slopes, stairs, wide shelves,
-  elevators, soft drops, and forgiving jumps. Optional secrets can use trickier
-  movement later.
+- **Living Proof Gate:** Relay Spire can be physically reached before it can
+  send. It should require enough visible world changes, mini-game proofs, and
+  Cicka familiarity rather than a boss, precision climb, or arbitrary checklist.
+  The path to the Spire should naturally provide enough resident help and cat
+  familiarity for the first ending; extra residents can deepen optional return
+  play.
+- **Resident count is a tuning variable.** Start the prose plan with 2-3
+  required main-path Resident Room Beats and a small optional cast. Add more only
+  if the Level Designer and Story/Tone pass agree the Ridge needs more inhabited
+  texture without turning into errands.
+- **Required resident beats carry Cicka familiarity.** Every required Resident
+  Help Beat should include authored Cicka field presence, but her role can vary:
+  first as attention cue, later as observer of a changed object, and eventually
+  as quiet trust marker.
+- **Resident Room Beat is a design unit, not a Phaser scene.** One required
+  resident space can include multiple residents, a small conflict, optional
+  interactions, and alternate solutions while still remaining part of the
+  Exploration Map.
+- **Mini-games attach; they do not hold up the spine.** The first ending path
+  should work through conversations, collection, authored traversal, Resident
+  Room Beats, and visible world changes. Mini-Game Entrances can add optional
+  alternate path unlocks, proofs, shortcuts, rewards, or pure side fun.
+- **Not every resident is progression.** Optional residents, NPCs, props, and
+  tiny hangout spaces may offer mini-games, alternate flavor, jokes, or vibes
+  without solving a barricade.
+- **Backtracking must transform.** A Resident Help Beat or cleared mini-game
+  changes Cicka Home, a local route blocker, a shortcut, or how old artifacts
+  read.
+- **Mobile-safe main path.** Main route uses chunky stairs, ladders or cords,
+  bridges, wide shelves, elevators, soft drops, and forgiving crossings.
+  Optional secrets can use trickier movement later.
 - **Artifacts teach Danilo spatially.** Major work/project artifacts are on
   main or near-main routes. Small skill scraps hide in side pockets.
 - **No minimap dependency.** The player should remember route as landmarks:
@@ -51,39 +85,46 @@ Later: "Old scraps now mean something about Danilo."
 
 | Option | Score | Shape | Pros | Risks |
 | --- | ---: | --- | --- | --- |
-| Vertical Folded Ridge With Cicka Switchback | 96 | Stacked shelves, safe drops, lifts, and return folds around Cicka | Best cure for hallway feel; Cicka stays central; route mastery still matters | Needs camera/world-height work |
+| Sketchbook Neighborhood Spine With Folded Shortcuts | 98 | Mostly forward inhabited route with local resident problems, route changes, and folded shortcuts | Best mobile/portfolio fit; keeps Cicka present; makes topology feel lived-in | Must avoid generic fetch quests or explicit objective text |
+| Vertical Folded Ridge With Cicka Switchback | 88 | Stacked shelves, safe drops, lifts, and return folds around Cicka | Good cure for hallway feel; route mastery still matters | Can read as platformer-first and too Cicka-home-centric |
 | Folded Ridge With Cicka Switchback | 84 | Main trail climbs away, shortcuts fold back to Cicka | Strong "aha"; mobile-safe; fits paper theme | Can still feel like rightward trail if too flat |
 | Lucky Luna Descent Ridge | 82 | Progress mostly through vertical drop shafts and horizontal steering | Mobile-native, fresh movement toy | Big control/level-design shift; can fight current side-view runtime |
 | Three-Layer Mini Mountain | 80 | Lower Outskirts, middle trail, upper Relay route | Best long-term map fantasy; many re-read paths | Can overgrow before core loop works |
 | Page Rooms Network | 72 | Linked sketchbook spreads instead of natural ridge | Very thematic; easy to make each area distinct | Risks feeling like menu rooms |
 | Wide Main Trail Plus Branches | 48 | Longer version of current line with side pockets | Easy implementation | Still hallway syndrome |
 
-Chosen plan uses vertical shelves as the main structure, then borrows Lucky
-Luna's falling pleasure for local descent pockets. It keeps current
-walk/sprint/jump controls and adds elevators/drop routes before adding any new
+Chosen plan uses a mostly forward neighborhood spine as the main structure, then
+adds vertical folds, lifts, drops, and optional descent pockets where they make
+the place feel authored. It treats jump as non-core for the v0 main route and
+uses route changes and authored traversal interactions before adding any new
 player ability.
 
 ## Movement Model
 
-Baseline controls stay side-view:
+Baseline Ridge v0 controls should stay side-view and mobile-native:
 
-- walk / sprint
-- jump
+- walk
 - interact
-- optional drop-through input later if platform tech supports it cleanly
+- explicit climb / descend / enter / inspect prompts where authored traversal
+  needs confirmation
+- optional sprint only if it stays comfortable on touch
+- no required jump button on the main Exploration Map route
 
 Traversal ingredients:
 
 | Ingredient | First use | Purpose |
 | --- | --- | --- |
-| Wide jumps | Work Artifact -> Stampede | Adds active traversal without precision stress |
-| Paper stairs/ramps | Outskirts -> Cicka Home | Keeps entry calm and readable |
+| Wide shelves / bridge crossings | Work Artifact -> Stampede | Adds traversal texture without precision stress |
+| Chunky paper stairs | Outskirts -> Cicka Home | Keeps entry calm and readable without slope physics |
+| Ladders / cords | Cicka Home -> Work Artifact, Telegraph | Adds vertical movement as readable object traversal |
 | Soft drop shafts | Stampede return, later Telegraph return | Lucky Luna-inspired vertical fun; no fall damage |
 | Elevators / lifts | Domino Desk, later Outskirts lift | Route compression and spectacle |
 | Switchback shelves | Cicka -> Guide | Lets player see old places from above |
 | Underpath crawl/low route | Future Cicka secret | Personality and secret language |
+| Future mobility items | Later optional pockets | May add jump-like toys only after the no-jump route grammar works |
 
-Main route should be **up, across, down, up**, not just right.
+Main route should be **mostly forward with readable bends, lifts, drops, and
+resident-caused route changes**, not abstract platforming.
 
 ## Topology Visual
 
@@ -167,15 +208,16 @@ camera width of playable space.
 | 1. Outskirts / City Edge | Entry and future Overworld merge | city edge, Basement hatch space, Potassium hint space, distant Relay silhouette above |
 | 2. Cicka Home | Emotional anchor | desk-nest, pinboard, empty memento space, Cicka interaction |
 | 3. Work Artifact Ledge | Learn Danilo through object | short climb; easy major artifact slot: Saturn/Vega or Hummingbird placeholder |
-| 4. Stampede Blanket | First opt-in action | broad jump/shelf approach; visible future drop/fold back to Cicka |
-| 5. Switchback Shelf | First spatial memory test | trail bends upward/back over Cicka; Cicka Home visible below |
-| 6. Telegraph Terrace | Future mini-game teaser | vertical climb/elevator-looking cord; later cord drop to Cicka |
-| 7. Guide Overlook | Reorientation | Relay Spire visible again from above; Guide points without exposition dump |
-| 8. Lucky Luna Drop Pocket | Movement texture | optional safe descent shaft to a scrap, then easy return |
-| 9. Relay Gate | Destination promise | locked gate, proof slots, view back across route |
-| 10. Domino Desk / Lift | Route-compression promise | desk/elevator silhouette; future lift returns to Cicka |
-| 11. High Ledge Tease | Future movement promise | visible unreachable scrap, no required jump verb |
-| 12. Optional Underpath Tease | Cicka secret language | paw marks below Cicka/Stampede, not usable yet |
+| 4. Stampede Blanket | First opt-in action | wide bridge/shelf approach; visible future drop/fold back to Cicka |
+| 5. Taped Bridge / Missing Plank | First required soft gate / Resident Help Beat | closed or unsafe crossing; Cicka field presence draws attention; tiny resident problem opens or patches route |
+| 6. Switchback Shelf | First spatial memory test | trail bends upward/back over Cicka; Cicka Home visible below |
+| 7. Telegraph Terrace | Future mini-game teaser | vertical climb/elevator-looking cord; later cord drop to Cicka |
+| 8. Guide Overlook | Reorientation | Relay Spire visible again from above; Guide points without exposition dump |
+| 9. Lucky Luna Drop Pocket | Movement texture | optional safe descent shaft to a scrap, then easy return |
+| 10. Relay Gate | Destination promise | locked gate, proof slots, view back across route |
+| 11. Domino Desk / Lift | Route-compression promise | desk/elevator silhouette; future lift returns to Cicka |
+| 12. High Ledge Tease | Future movement promise | visible unreachable scrap, no required jump verb |
+| 13. Optional Underpath Tease | Cicka secret language | paw marks below Cicka/Stampede, not usable yet |
 
 ## First-Walk Route
 
@@ -185,20 +227,21 @@ challenge. Sprinting can shorten it, but should not be required.
 Flow:
 
 ```text
-Outskirts -> climb to Cicka Home -> climb/jump to Work Artifact Ledge
-  -> Stampede -> switchback above Cicka -> Telegraph Terrace
+Outskirts -> climb to Cicka Home -> climb/bridge to Work Artifact Ledge
+  -> Stampede -> taped bridge/help beat -> switchback above Cicka -> Telegraph Terrace
   -> Guide Overlook -> Relay Gate -> Domino Lift Tease
 ```
 
-The player should see Cicka Home again from the Switchback Shelf before the
-first shortcut opens. This creates the mental model:
+The player should see old route space again from the Switchback Shelf before
+the first shortcut opens. This creates the mental model:
 
-> I climbed above Cicka, and this paper mountain can probably fold back down.
+> This neighborhood can fold, remember, and change after I help it.
 
 ## Shortcut Plan
 
 | Unlock | Route change | Why it matters |
 | --- | --- | --- |
+| Bridge resident helped | Taped bridge or missing-plank crossing opens on the main route | Teaches "help resident -> route changes" with a tiny local soft gate |
 | Stampede clear | Safe drop/fold from Switchback back to Cicka Home | First "aha"; Cicka is reachable after first mini-game |
 | Telegraph clear | Cord/drop shaft from Telegraph Terrace to Cicka Home | Lucky Luna-style descent; makes terrace feel above home |
 | Domino future | Desk lift/elevator returns from Domino to Cicka Home | Vertical route compression and puzzle identity |
@@ -255,8 +298,9 @@ Filler budget:
 | --- | --- | --- |
 | Outskirts -> Cicka Home | torn city edge, paper stairs, Basement hatch silhouette, Potassium warning tape | transition old Overworld into Ridge without replacing it yet |
 | Cicka Home -> Work Artifact Ledge | desk legs, pinned notes, Saturn/Hummingbird placeholder object, Cicka paw mark | personal object discovery, not resume modal |
-| Work Artifact -> Stampede | wide jump, loose pages, swarm flecks getting denser, picnic crumbs | anticipation before mini-game |
-| Stampede -> Switchback Shelf | folded-paper ramp, safe drop preview, Cicka Home visible below | first mental-map "aha" setup |
+| Work Artifact -> Stampede | wide shelf or bridge, loose pages, swarm flecks getting denser, picnic crumbs | anticipation before mini-game |
+| Stampede -> Taped Bridge | closed/taped bridge or missing plank, tiny resident silhouette, Cicka staring at the unsafe edge | first Resident Help Beat and visible before/after route proof |
+| Stampede -> Switchback Shelf | folded-paper bridge, safe drop preview, Cicka Home visible below | first mental-map "aha" setup |
 | Switchback -> Telegraph Terrace | hanging cord, timing tick marks, small rest shelf | vertical climb with future mechanic signal |
 | Telegraph -> Guide Overlook | windy paper bridge, Relay silhouette reappears | orientation after climb |
 | Guide -> Relay Gate | quieter open shelf, proof-slot shapes, signal lines | destination pressure and awe |
@@ -296,7 +340,7 @@ NPC placement rules:
 - No dialogue trees in first map rebuild.
 - If an NPC gives info, the environment must already imply that info.
 - Cicka remains most important. Other NPCs should not compete with her as the
-  return anchor.
+  emotional guide or turn her into a quest board.
 - Static silhouettes are enough for first blockout if their function is clear.
 
 ## Fun-First Dream Map
@@ -371,7 +415,7 @@ Player fantasy:
           │  picnic, ink swarm  │       │  fall shaft, steer, scrap  │
           └──────────┬──────────┘       └──────────────┬─────────────┘
                      │                                 │
-                     │ broad jump / loose pages        │ returns near
+                     │ wide bridge / loose pages       │ returns near
                      v                                 │ Stampede
           ┌─────────────────────┐                      │
           │  WORK ARTIFACT LEDGE│<─────────────────────┘
@@ -610,15 +654,43 @@ That is the first real "grok."
 
 ## Implementation Slice
 
-Next code issue should be:
+Do not start the next code issue until the core route is written as prose:
+story beats, level beats, tiny residents, Cicka field presences, route blockers,
+and visible before/after world changes. Design from the middle/end backward so
+the opening is not overfit to the current prototype.
+Write the canonical ending sequence outline first, then work backward into the
+final required Resident Room Beat, the middle cause-and-effect beat, and only
+then the first taped-bridge tutorial beat.
+The ending outline should include the Guitar Farewell as an established comfort
+interaction, not a one-off ending prop: the player finds or receives the guitar
+earlier, can play it at Cicka Home or quiet Ridge spots, and plays for Cicka
+near Relay before the threshold farewell.
+Current middle required Resident Room Beat: a **Concert Crossing Beat** where a blocked
+concert/traffic crossing opens after the player helps with a small
+Guitar-Hero-like performance problem and earns the guitar. Keep the final
+Guitar Farewell separate from arcade difficulty; the concert teaches the item,
+while the ending uses it as comfort.
+Give Concert Crossing a non-arcade fallback so the main route can ship through
+dialogue, collection, practice, or auto-play before the rhythm mini-game is fully
+polished.
 
-**Rebuild Ridge as Folded Ridge topology blockout**
+Next code issue after that prose plan should be:
+
+**Rebuild Ridge as Sketchbook Neighborhood blockout**
+
+Preserve the authoring and QA spine: Ridge Blockout Source, source contract,
+compiler/generated facts, map-loading path, and previewer/debugger layers.
+Treat the current jump-centered traversal runtime and folded-desk arrangement as
+replaceable proof-of-concept scaffolding.
 
 Build:
 
-- expand Ridge world height and introduce stacked shelves
-- keep main route mobile-safe with wide platforms/slopes/stairs/elevators
-- place Cicka Home near lower-middle, not first prop in a row
+- introduce a mostly forward neighborhood route with readable bends and folds
+- keep main route mobile-safe with wide shelves, chunky stairs, cords, bridges,
+  lifts, and soft drops
+- place Cicka Home as a progress memory space, not first prop in a row
+- add at least one Cicka field-presence hint at a local route blocker
+- add at least one Resident Help Beat that visibly changes a route
 - make Stampede route at least one vertical beat away
 - add switchback shelf where Cicka Home is visible below
 - add one optional Lucky Luna-style safe drop pocket
@@ -630,7 +702,8 @@ Build:
 Acceptance:
 
 - first walk from Outskirts to Relay Gate takes 2-3 minutes at normal movement
-- Cicka Home is reachable within 20-30 seconds after seeded Stampede clear
+- seeded Stampede or resident-help route change reduces return travel within
+  20-30 seconds
 - player can describe map from landmarks without minimap
 - seeded Stampede shortcut visibly reduces travel, not just decorates
 - desktop and mobile smoke pass
@@ -641,7 +714,7 @@ Do not generate final art yet.
 
 Useful image-gen later:
 
-- one loose concept image for "paper mountain desk ridge"
+- one loose concept image for "lived-in sketchbook neighborhood"
 - one landmark sheet: Cicka Home, Stampede Blanket, Telegraph Terrace, Domino
   Desk, Relay Gate
 - one overhead-ish mood map after topology is accepted

--- a/docs/game-design/ridge/map-plans/topology-spike.md
+++ b/docs/game-design/ridge/map-plans/topology-spike.md
@@ -1,9 +1,9 @@
 # Sketchbook Ridge Topology Spike
 
-> Active M5 design brief for the next Ridge blockout. This document narrows
-> [`milestone-plan.md`](../milestone-plan.md)
-> into one map-design spike. It is not shipped behavior; update
-> [`player-manual.md`](../../player-manual.md) only after a playable route ships.
+> Status: superseded legacy/reference.
+> This was the M5 folded/Cicka Home map-design spike for the prior Ridge
+> direction. Keep it as planning history and topology reference only. For
+> current Ridge source-of-truth routing, read [`../README.md`](../README.md).
 
 ## Purpose
 

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -3,6 +3,8 @@
 > Planning companion for [`summit.md`](./summit.md).
 > The Summit doc is the product vision. This file is the implementation and
 > milestone map for agents working across branches.
+> Status: mixed current route-reset plan plus legacy/prototype milestone
+> history. Use [`README.md`](./README.md) to decide which sections are active.
 > Read [`README.md`](./README.md) first for Ridge source-of-truth routing and
 > [`story-level-bible.md`](./story-level-bible.md) for the active
 > Bridge/Concert/Dance/Relay route canon. Use [`areas/`](./areas/README.md) for
@@ -18,18 +20,24 @@ for the current human-readable Ridge snapshot.
 
 ## Active Goal
 
-The current product milestone is **Sketchbook Ridge Summit**.
+The current phase is **Ridge pre-production for the desired game rework**.
 
-The first complete milestone should prove:
+The first complete route target should prove:
 
-1. a compact Ridge route exists
+1. a compact Bridge -> Concert -> Dance Festival -> Relay route exists
 2. the Relay Spire is visible early
-3. Potassium Slip can act as the existing arcade anchor
-4. Stampede Sketch is the first new opt-in mini-game
-5. rewards visibly change the Ridge
-6. Cicka and one NPC make the world feel inhabited
+3. required Resident Help Beats visibly change the Ridge
+4. Cicka feels present through local field appearances and resting spots
+5. Guitar Farewell, Send the Sketchbook Prompt, Cicka Threshold Farewell, and
+   Open Ridge Return State land without arcade gating
+6. optional mini-games remain side fun, rewards, shortcuts, or future
+   alternate-path candidates rather than required first-ending proof
 
 Anything beyond that is future scope unless a slice explicitly pulls it in.
+
+The older M1-M5 sections below describe useful prototype history and reusable
+seams. Do not treat them as the active product target unless a current issue or
+the Ridge router explicitly sends you there.
 
 ## Current Implementation Status
 

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -3,6 +3,10 @@
 > Planning companion for [`summit.md`](./summit.md).
 > The Summit doc is the product vision. This file is the implementation and
 > milestone map for agents working across branches.
+> Read [`README.md`](./README.md) first for Ridge source-of-truth routing and
+> [`story-level-bible.md`](./story-level-bible.md) for the active
+> Bridge/Concert/Dance/Relay route canon. Use [`areas/`](./areas/README.md) for
+> area-local design detail.
 
 This is not the live issue tracker. PRDs, implementation issues, triage state,
 current backlog, and agent-ready briefs live in GitHub Issues through the
@@ -375,14 +379,15 @@ Potential next implementation slices:
 These are local planning notes. Publish approved work as GitHub Issues before
 assigning an AFK agent.
 
-1. **Ridge / Outskirts Topology Spike**: design and lightly prototype how the
-   current Overworld becomes Outskirts/Trailhead and Ridge becomes a connected
-   Hollow Knight topology side-view world. Use
-   [`topology-spike.md`](./map-plans/topology-spike.md)
-   as the active M5 map brief. Do not fully replace the default Overworld in
-   the same PR.
+1. **Ridge Route Reset Planning**: align the next implementation plan with the
+   active Bridge Area -> Concert Area -> Dance Festival Area -> Relay/Cicka
+   ending route in [`story-level-bible.md`](./story-level-bible.md). Treat
+   [`topology-spike.md`](./map-plans/topology-spike.md) and
+   [`proper-map-plan.md`](./map-plans/proper-map-plan.md) as legacy/prototype
+   references unless a slice explicitly adapts their source-contract or topology
+   ideas.
 2. **Later First Ridge Shortcut / Ridge-Only Glide**: revisit these after the
-   topology spike gives shortcuts and movement rewards a real route shape.
+   route reset gives shortcuts and movement rewards a real route shape.
 3. **Translator / Cicka Daydream**: keep translated Cicka subtitles and the
    Cicka daydream mini-slice for later, after Ridge Memory proves return play.
 
@@ -397,8 +402,12 @@ Owner: integration + Ridge.
 
 Outputs:
 
-- final gate: at least three major clears / proofs, with Potassium Circuit
-  counting as one proof, plus one Cicka / translator / manual insight.
+- final gate: the three required Ridge Areas and their visible resident/world
+  changes provide enough Living Proof for the first ending. Mini-games can
+  remain optional fun, rewards, shortcuts, or future alternate solutions; they
+  are not required Living Proof for the current first-ending route.
+- Guitar Farewell, Send the Sketchbook Prompt, Cicka Threshold Farewell, and
+  Open Ridge Return State follow `story-level-bible.md`.
 - short ending/contact overlay.
 - return to Ridge after ending.
 - post-ending Ridge state where Micka first appears after the player completes

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -1,33 +1,27 @@
 # Sketchbook Ridge Milestone Plan
 
-> Planning companion for [`summit.md`](./summit.md).
-> The Summit doc is the product vision. This file is the implementation and
-> milestone map for agents working across branches.
-> Status: mixed current route-reset plan plus legacy/prototype milestone
-> history. Use [`README.md`](./README.md) to decide which sections are active.
-> Read [`README.md`](./README.md) first for Ridge source-of-truth routing and
-> [`story-level-bible.md`](./story-level-bible.md) for the active
-> Bridge/Concert/Dance/Relay route canon. Use [`areas/`](./areas/README.md) for
-> area-local design detail.
+> Pre-production milestone router for the desired Ridge game rework.
+> This is not the live issue tracker. PRDs, implementation issues, triage state,
+> and agent-ready briefs live in GitHub Issues through
+> [`docs/agents/issue-tracker.md`](../../agents/issue-tracker.md).
 
-This is not the live issue tracker. PRDs, implementation issues, triage state,
-current backlog, and agent-ready briefs live in GitHub Issues through the
-workflow in [`docs/agents/issue-tracker.md`](../../agents/issue-tracker.md).
+Status: accepted route-reset planning. Read [`README.md`](./README.md) first for
+Ridge source-of-truth routing, [`story-level-bible.md`](./story-level-bible.md)
+for active route canon, and [`areas/`](./areas/README.md) for area-local design.
 
-Use this file for durable milestone shape, ownership boundaries, branch/seam
-strategy, and reference stacks. Use [`ridge-snapshot.md`](./ridge-snapshot.md)
-for the current human-readable Ridge snapshot.
+Legacy/prototype milestone history moved to
+[`legacy/prototype-milestone-history.md`](./legacy/prototype-milestone-history.md).
 
 ## Active Goal
 
 The current phase is **Ridge pre-production for the desired game rework**.
 
-The first complete route target should prove:
+The first complete route should prove:
 
-1. a compact Bridge -> Concert -> Dance Festival -> Relay route exists
-2. the Relay Spire is visible early
+1. Bridge -> Concert -> Dance Festival -> Relay exists as a compact route
+2. Relay Spire is visible early
 3. required Resident Help Beats visibly change the Ridge
-4. Cicka feels present through local field appearances and resting spots
+4. Cicka feels present through field appearances and resting spots
 5. Guitar Farewell, Send the Sketchbook Prompt, Cicka Threshold Farewell, and
    Open Ridge Return State land without arcade gating
 6. optional mini-games remain side fun, rewards, shortcuts, or future
@@ -35,405 +29,103 @@ The first complete route target should prove:
 
 Anything beyond that is future scope unless a slice explicitly pulls it in.
 
-The older M1-M5 sections below describe useful prototype history and reusable
-seams. Do not treat them as the active product target unless a current issue or
-the Ridge router explicitly sends you there.
+## Route-Reset Milestones
 
-## Current Implementation Status
+- **P0 Decision Intake**: convert grilling/research transcripts into accepted
+  route claims, rejected ideas, and open questions.
+- **P1 Area Paper Pass**: tighten Bridge, Concert, Dance Festival, and Relay
+  docs until each area has layout, resident beats, blockers, Cicka presence,
+  and exit conditions.
+- **P2 First Playable Route Blockout**: prove the route can be walked end to
+  end with placeholder art and no required precision platforming.
+- **P3 Living Proof Feedback**: make resident help, world changes, and Relay
+  readiness readable without a visible chore checklist.
+- **P4 Ending Pass**: land Guitar Farewell, Send the Sketchbook Prompt, Cicka
+  Threshold Farewell, Open Ridge Return State, and later Micka timing.
 
-This section is a milestone snapshot for orientation. Do not mirror every
-GitHub issue update here; update it only when the milestone-level reality or
-current shipped/prototype capability changes.
+Optional mini-games, old Cicka Home mutation work, and folded-desk topology
+enter these milestones only when an active route doc or issue pulls a specific
+piece forward.
 
-- **M1 Ridge Shell** is complete for the current placeholder slice: Ridge can
-  boot directly with `?startScene=ridge`, uses shared side-view movement, shows
-  the Relay Spire, Cicka's first perch, a static Ridge Guide, and three Trail
-  Card props.
-- **M2 Trail Card and Manual Overlay Surface** is complete for the current
-  prototype slice: the reusable global Trail Card overlay, reusable Manual Page
-  overlay shape, Ridge trigger contract, and mobile/readability polish are in
-  place.
-- **M3 Art and Audio Research Pack** is in review: visual, overlay/manual, and
-  audio direction packs now guide Cicka, Guide, Trail Card, Manual Page,
-  Stampede, Relay Spire, and Ridge audio without blocking rough engineering
-  prototypes.
-- **M4 Stampede Sketch Prototype** is underway with M4a movement, M4b pressure
-  loop, M4c/M4d prototype shell, and M4d.5 responsive shell/input work accepted
-  for continuation: the Stampede Trail Card can enter a scene-local arena with
-  timer, page-noise cadence, capped swarm surges, pressure-aware swarm motion,
-  soft contact feedback, automatic pencil swipe, run ending UI, return to
-  Ridge, bridge-backed React scene UI, Notebook shell presentation, enlarged
-  arcade control mats shared with Potassium, and a first scene-local
-  pickup/upgrade draft. First M4e playtest tuning widened the true arena to
-  match the visible notebook page, added HP/contact readability, softened the
-  contact limit, and added respawn telegraphs. The tuning pass is accepted for
-  continuation; the respawn warning improved fairness and added useful route
-  planning. M4f durable rewards are accepted for continuation: first clear
-  awards the `stampede-sketch` Ridge stamp and one glide pip, repeat clears do
-  not duplicate rewards, and the result panel reports earned/already-owned
-  reward state.
-- **M5 Ridge Memory** has its first visual slices accepted for continuation:
-  M5a derives Ridge-owned sticker/world-change memories from durable progress
-  without stored sticker state, and M5b adds the first Cicka note/translator
-  tease plus a dev-only `devRidgeStamp=stampede-sketch` seed for fast local
-  testing. M5c/M5d add Cicka's Stampede-gated walk-by bark, first deliberate
-  pre-translator interaction, and a primitive readability polish pass. M5e has
-  promoted the prepared Cicka prototype spritesheet into
-  `public/assets/ridge/cicka/` as the first runtime-wired AI sprite adoption
-  proof, with audit notes and refined pipeline gates.
-- **Ridge Architecture Deepening (#60-#64)** is implemented as the current Ridge
-  architecture direction: #60 made the blockout the spatial source of truth,
-  #61 consolidated traversal comfort, #62 added compiled blockout facts, #63
-  slimmed `RidgeScene` into lifecycle glue, and #64 made Cicka Home mutation
-  resolution data-driven. #65 is the documentation cleanup slice that records
-  this final shape.
-- **Asset staging is now an active coordination concern**: prepared POC assets
-  still exist for Potassium, Stampede, and future Ridge character/prop families.
-  Cicka's adopted runtime copy now lives under `public/assets/ridge/cicka/`;
-  its external prepared archive is provenance/source material, not a pending
-  runtime adoption target. Keep remaining candidates documented and adopt them
-  in small scene-owned slices instead of turning them into a broad
-  art-integration branch. See
-  [`asset-staging-plan.md`](./reference/asset-staging-plan.md).
+## Source Stack
 
-## Production Crew
+For Ridge rework issues, link the smallest relevant set:
 
-Role contracts and activation phrases live in
-[`docs/agents/sketchbook-ridge-team.md`](../../agents/sketchbook-ridge-team.md).
+- [`README.md`](./README.md): source matrix and update protocol
+- [`summit.md`](./summit.md): product fantasy, pillars, and scope instincts
+- [`story-level-bible.md`](./story-level-bible.md): route spine, Living Proof,
+  Cicka/guitar logic, ending order
+- [`areas/`](./areas/README.md): Bridge, Concert, Dance Festival, Relay detail
+- [`open-questions.md`](./open-questions.md): unresolved design gaps
+- [`ridge-snapshot.md`](./ridge-snapshot.md): current Phaser prototype/runtime
+  truth
+- [`reference/`](./reference/README.md): art, audio, overlay, and asset support
+- [`legacy/`](./legacy/README.md): superseded plans and prototype history
 
-- **Level Designer**: level design and milestone shape.
-- **Story / Tone Designer**: emotional/story tone.
-- **Systems / Production Designer**: systems and production constraints.
-- **Character Designer**: NPC/character design.
-- **Architect**: architecture and branch conflict control.
-- **Visual Direction Artist**: character and environment art research.
-- **Overlay Readability Designer**: overlay, manual, and mobile visual readability.
-- **Audio Designer**: music and sound design research.
+When implementing runtime changes, also link the relevant subset of:
 
-## Reference Stack
+- [`../../runtime-architecture.md`](../../runtime-architecture.md)
+- [`../../runtime-modes.md`](../../runtime-modes.md)
+- [`../../architecture-direction.md`](../../architecture-direction.md)
+- [`../../design/style-guide.md`](../../design/style-guide.md)
+- [`../../../.agents/rules/10-architecture.md`](../../../.agents/rules/10-architecture.md)
+- [`../../../.agents/rules/20-game-runtime.md`](../../../.agents/rules/20-game-runtime.md)
+- [`../../../.agents/rules/30-react-overlays.md`](../../../.agents/rules/30-react-overlays.md)
 
-Every GitHub implementation issue should link the relevant subset of these:
+Use [`../mini-games/README.md`](../mini-games/README.md) for optional/current
+mini-game routing.
 
-- [`summit.md`](./summit.md)
-- [`ridge-snapshot.md`](./ridge-snapshot.md)
-- [`runtime-architecture.md`](../../runtime-architecture.md)
-- [`runtime-modes.md`](../../runtime-modes.md)
-- [`architecture-direction.md`](../../architecture-direction.md)
-- [`style-guide.md`](../../design/style-guide.md)
-- [`10-architecture.md`](../../../.agents/rules/10-architecture.md)
-- [`20-game-runtime.md`](../../../.agents/rules/20-game-runtime.md)
-- [`30-react-overlays.md`](../../../.agents/rules/30-react-overlays.md)
+## Prototype Reuse Rules
 
-Use [`potassium-slip.md`](../mini-games/potassium-slip.md) for Potassium-specific behavior,
-[`stampede-sketch.md`](../mini-games/stampede-sketch.md) for Stampede-specific behavior,
-and [`mini-games/README.md`](../mini-games/README.md) as the mini-game routing
-index.
+Useful legacy pieces may be adapted:
 
-## Conflict Strategy
+- typed Ridge Blockout Source contract, compiler, generated facts, and
+  validation patterns
+- preview/debugger workflow
+- scene-owned Cicka display/audio/asset lessons
+- Trail Card, Manual Page, scene UI, and Notebook shell patterns
+- Potassium and Stampede as optional toy references
 
-Architect's rule:
+Do not inherit these as active route requirements:
 
-> Parallelize scene internals. Serialize shared seams.
+- Cicka Home as central hub
+- folded-desk route order
+- platformer-like traversal
+- required mini-game clears as Living Proof
+- Stampede-gated Cicka memory as first-ending dependency
+- old M0-M7 sequence as live backlog
 
-Do not let many branches edit these at the same time:
+## Work Rules
 
-- `src/game/bridge/store.ts`
-- `src/game/scenes/sceneIds.ts`
-- `src/game/scenes/sceneRegistry.ts`
-- `src/game/overlays/overlayIds.ts`
-- `src/game/overlays/overlayRegistry.ts`
-- `src/game/sceneLifecycle/contexts/createSceneContexts.ts`
-- `src/game/sharedSceneRuntime/**`
-- `src/game/sharedSceneRuntime/phaserScenePresentation.ts`
-
-Use one short-lived integration branch to land shared seam edits in dependency
-order. Feature branches should export scene-local definitions from their own
-folders and let the integration owner wire them into shared registries.
-
-Suggested branches:
-
-- `ridge/integration`
-- `ridge/m0-progress-baseline`
-- `ridge/shell-scene`
-- `ridge/trail-card-overlay`
-- `ridge/stampede-sketch`
-- `ridge/memory-layer`
-- `ridge/art-audio-research`
-- `ridge/telegraph-terrace`
+- Publish approved implementation work as GitHub Issues before assigning an
+  AFK/low-thinking agent.
+- Keep source-of-truth claims in one canonical doc; do not paste transcripts
+  into canon.
+- Treat [`decision-intake.md`](./decision-intake.md) as the staging area for
+  large grilling sessions.
+- Keep shared runtime seams serialized; parallelize area docs, scene-local
+  experiments, and reference packs.
+- Update [`player-manual.md`](../player-manual.md) only when behavior ships.
 
 ## Ownership Boundaries
 
-- Runtime/integration owns bridge progress, scene ids, scene registry, overlay ids, overlay registry, presentation policy, and scene context assembly.
-- Ridge scene owner owns `src/game/scenes/ridge/**`.
-- Stampede owner owns `src/game/scenes/stampedeSketch/**`.
-- Telegraph owner owns `src/game/scenes/telegraphTerrace/**`.
-- Reusable overlay owner owns `src/game/overlays/**`.
-- Scene-local result overlays belong with their scene unless promoted deliberately.
-- Shared scene runtime changes require explicit review because they affect existing scenes.
-- Art/audio research should write docs and asset specs first; implementation should not block on final polish.
-
-## Milestones
-
-### M0: Production Baseline
-
-Goal: establish the shared seams before parallel work starts.
-
-Owner: runtime/integration.
-
-Outputs:
-
-- Potassium Circuit source confirmed as existing inventory ownership.
-- Minimal Ridge progress shape defined: stamps, manual pages, glide pips, shortcuts.
-- First reward ids reserved.
-- Current smoke path confirmed: Overworld, Hobbies, Basement, Potassium, overlays, pause, touch.
-
-Blocks:
-
-- Ridge Shell
-- Stampede reward wiring
-- Ridge Memory
-- Relay Spire gate
-
-### M1: Ridge Shell
-
-Goal: make the main game shape playable with placeholders.
-
-Owner: Ridge scene.
-
-Start Ridge as a separate `ridge` scene first. Keep the current overworld as
-the default route until the Ridge shell feels good. During development, boot
-directly into Ridge with `?startScene=ridge` for fast iteration.
-
-Keep the first movement shell flat and readable. Use visual height changes,
-landmark silhouettes, and prop staging before adding real vertical traversal.
-
-Outputs:
-
-- `src/game/scenes/ridge/**`.
-- Side-view Ridge scene using shared player/camera runtime.
-- Relay Spire silhouette.
-- three hobby triggers with Trail Cards.
-- Cicka first perch.
-- one static NPC.
-- return path to prior/current parent scene.
-- placeholder sticker layer.
-
-Can proceed with rough art. Do not wait for final drawings.
-
-### M2: Trail Card And Manual Overlay Surface
-
-Goal: make opt-in scene entry and one-screen knowledge clues readable.
-
-Owner: reusable overlay/UI.
-
-Outputs:
-
-- Trail Card overlay via `OverlayHost`.
-- first Manual Page overlay shape if needed by Relay/Telegraph.
-- mobile-first layout rules.
-- copy lives in `src/shared/i18n/messages/en/`.
-
-Registry wiring should be serialized through the integration branch.
-
-### M3: Art And Audio Research Pack
-
-Goal: unblock implementation without creating final-asset pressure.
-
-Owners: Visual Direction Artist, Overlay Readability Designer, Audio Designer.
-
-Outputs:
-
-- NPC silhouette sheet for Cicka, Ridge Guide, Potassium Compliance Officer, `TODO: AI`, Printer Oracle.
-- Cicka mini kit spec: perch, blink, loaf, stretch, suspicious turn, tiny hop, paw-print mark, pre-translator "meow" bubble.
-- landmark silhouette board: Relay Spire, Basement hatch, Potassium hint, Stampede picnic blanket, Telegraph terrace, Domino desk/elevator.
-- sticker / ink-memory vocabulary.
-- Trail Card and Manual Page visual specs.
-- Ridge audio palette, Cicka SFX language, Potassium acknowledgement micro-pack, Stampede prototype audio notes.
-
-Current review packs:
-
-- [`m3-visual-pack.md`](./reference/m3-visual-pack.md)
-- [`m3-overlay-pack.md`](./reference/m3-overlay-pack.md)
-- [`m3-audio-pack.md`](./reference/m3-audio-pack.md)
-
-These are research/spec deliverables. They should not block engineering beyond
-basic silhouette placeholders.
-
-### M4: Stampede Sketch Prototype
-
-Goal: ship the first new opt-in mini-game.
-
-Owner: Stampede scene.
-
-Purpose: protect one calm picnic-blanket patch from a stampede of runaway ideas.
-Use [`stampede-sketch.md`](../mini-games/stampede-sketch.md) for player-guardian and enemy
-intent before generating or wiring final Stampede art.
-
-Outputs:
-
-- `src/game/scenes/stampedeSketch/**`.
-- 60-90 second survivor prototype. M4a movement feel covers direct entry from
-  the Stampede Trail Card, top-down 8-way movement, pointer drag steering, and
-  return to Ridge. M4b adds a scene-local page-noise cadence, pressure HUD,
-  capped swarm surges, and soft contact feedback before reward wiring.
-- capped enemies.
-- central or near-central calm patch objective with proximity aggro: nearby
-  enemies chase the player, distant enemies may crowd the blanket.
-- auto-attacks.
-- XP pickups.
-- three-choice upgrade draft.
-- result overlay.
-- first-clear stamp and glide pip reward.
-
-Depends on M0 and the Ridge trigger contract from M1. Most scene internals can
-be built independently.
-
-Current checkpoint:
-
-- **M4a Movement Feel** accepted: direct entry from the Stampede Trail Card,
-  top-down 8-way movement, pointer drag steering, vertical-board presentation,
-  and return to Ridge are in place.
-- **M4b Pressure Loop** accepted for prototype continuation: session timer,
-  page-noise cadence, pressure HUD, capped swarm surges, contact limit, soft
-  contact feedback, and pressure-aware swarm motion are in place.
-- **M4c/M4d prototype shell** accepted: run ending surfaces, Retry/Back
-  routing, the first automatic pencil swipe, mobile-friendly start/result UI,
-  and the bridge-backed scene UI path are in place. Stampede text-heavy status
-  and panels now render through React scene UI instead of Phaser canvas text,
-  and Potassium uses the same scene UI path for draft-choice and terminal
-  panels.
-- **M4d.5 Responsive Shell/Input Spike** accepted for prototype continuation:
-  Notebook shell presentation, scene UI panels, and larger control mats are in
-  place for Stampede and Potassium. Reusable Notebook Shell language now lives
-  in [`notebook-shell-design-language.md`](../../design/notebook-shell-design-language.md).
-  Keep the notebook treatment restrained if future polish makes it too noisy or
-  brittle.
-- **M4e Pickup / Upgrade Draft** accepted for continuation: cleared marks spawn
-  simple scrap pickups, collecting the first threshold opens a scene UI upgrade
-  draft, and one selected upgrade can make the pencil faster, the swipe wider,
-  or the guardian slightly quicker. First tuning feedback also made the playable
-  arena fill the notebook page more honestly, exposed HP/contact radius in the
-  HUD/scene, raised prototype survivability, and telegraphed mark respawns.
-  The respawn warning is now part of the prototype loop because it creates
-  fairer avoidance and direction-planning decisions.
-- **M4f Durable Rewards Draft** accepted for continuation: first Stampede clear
-  now awards the `stampede-sketch` Ridge stamp and one glide pip through bridge
-  progress, repeat clears do not duplicate the reward, the result panel reports
-  earned/already-owned reward state, and Ridge renders one small Stampede blanket
-  memory mark derived from the stamp.
-- Scene architecture is intentionally scene-local. `StampedeSketchScene` should
-  remain the Phaser adapter/orchestrator while run decisions live behind
-  `runtime/runFlow.ts` and swarm steering lives behind `runtime/swarmMotion.ts`.
-
-Potential next implementation slices:
-
-These are local planning notes. Publish approved work as GitHub Issues before
-assigning an AFK agent.
-
-1. **M5 Ridge Memory continuation**: add the first small Ridge shortcut or the
-   first Cicka proximity/talk interaction as its own scene-owned slice.
-
-Hold until later:
-
-- Enemy-enemy avoidance beyond pressure-aware steering.
-- More Stampede upgrades and endless mode.
-- Player manual updates; Stampede is still dev/prototype behavior.
-
-### M5: Ridge Memory
-
-Goal: make the Ridge visibly remember rewards.
-
-Owner: Ridge scene.
-
-Outputs:
-
-- sticker/world-change rendering from stamps and manual pages.
-- one shortcut.
-- Ridge-only glide behavior.
-- first Cicka Note, memory reaction, or pre-translator interaction.
-
-Current checkpoint:
-
-- **Architecture-deepening child issues #60-#64 are represented in code**:
-  spatial facts now derive from the Ridge Blockout, traversal assists are owned
-  by the Ridge traversal runtime, Ridge scene presentation is split into
-  blockout/landmark modules, and Cicka Home mutations resolve from compiled
-  facts plus durable Ridge progress.
-
-- **M5a Durable Sticker Layer** accepted: `worldMemory.ts` derives visible
-  Ridge memory ids from durable progress, empty progress returns no memories,
-  and the `stampede-sketch` stamp renders Stampede blanket memories without
-  storing sticker ids.
-- **M5b Cicka Memory + Dev Stamp Seed** accepted: `stampede-sketch` also derives
-  the `cicka-stampede-note` memory at Cicka's perch, Ridge renders the tiny
-  Cicka memory tease, and local dev can seed the known stamp with
-  `?mode=interactive&startScene=ridge&devRidgeStamp=stampede-sketch`.
-- **M5c Cicka Walk-By Memory** accepted for continuation: after the Stampede
-  stamp, Cicka gives one tiny walk-by bark per Ridge entry without stored Cicka
-  state.
-- **M5d Cicka First Interaction** accepted for continuation: Cicka can answer a
-  deliberate interaction with pre-translator meow punctuation, while the permanent
-  Cicka memory becomes a paw/scratch decal instead of duplicate speech text;
-  the same PR includes a small primitive readability polish pass for Cicka,
-  her speech bubble, and the memory decal.
-- **M5e Cicka Runtime Asset Adoption** accepted for continuation: the prepared
-  Cicka spritesheet has been promoted into `public/assets/ridge/cicka/`, Ridge
-  loads it as a display-only perch NPC with tiny idle/notice animation, and the
-  first AI sprite audit records frame stability, runtime risks, and future
-  review gates.
-
-Potential next implementation slices:
-
-These are local planning notes. Publish approved work as GitHub Issues before
-assigning an AFK agent.
-
-1. **Ridge Route Reset Planning**: align the next implementation plan with the
-   active Bridge Area -> Concert Area -> Dance Festival Area -> Relay/Cicka
-   ending route in [`story-level-bible.md`](./story-level-bible.md). Treat
-   [`legacy/`](./legacy/README.md) as legacy/prototype reference unless a slice
-   explicitly adapts its source-contract or topology ideas.
-2. **Later First Ridge Shortcut / Ridge-Only Glide**: revisit these after the
-   route reset gives shortcuts and movement rewards a real route shape.
-3. **Translator / Cicka Daydream**: keep translated Cicka subtitles and the
-   Cicka daydream mini-slice for later, after Ridge Memory proves return play.
-
-Do not add stored sticker state. Do not add Stampede upgrades, endless mode,
-shared memory architecture, or Ridge shortcuts inside Cicka memory slices.
-
-### M6: Relay Spire First Ending
-
-Goal: close the first complete route.
-
-Owner: integration + Ridge.
-
-Outputs:
-
-- final gate: the three required Ridge Areas and their visible resident/world
-  changes provide enough Living Proof for the first ending. Mini-games can
-  remain optional fun, rewards, shortcuts, or future alternate solutions; they
-  are not required Living Proof for the current first-ending route.
-- Guitar Farewell, Send the Sketchbook Prompt, Cicka Threshold Farewell, and
-  Open Ridge Return State follow `story-level-bible.md`.
-- short ending/contact overlay.
-- return to Ridge after ending.
-- post-ending Ridge state where Micka first appears after the player completes
-  or replays one mini-game and returns.
-- player manual updated when behavior ships.
-
-### M7: Telegraph Terrace Prototype
-
-Goal: test the Muay Thai / Clair Obscur reactive timing lane.
-
-Owner: Telegraph scene.
-
-Outputs:
-
-- `src/game/scenes/telegraphTerrace/**`.
-- one-button parry loop.
-- three attack patterns.
-- Tempo build and counter release.
-- assist timing.
-- manual page reward.
-
-This can begin after M0 and the Trail/Manual overlay shape. It should not block
-Stampede or the first ending.
+- Route canon: [`story-level-bible.md`](./story-level-bible.md)
+- Area-local design: [`areas/`](./areas/README.md)
+- Current prototype truth: [`ridge-snapshot.md`](./ridge-snapshot.md)
+- Art/audio/overlay support: [`reference/`](./reference/README.md)
+- Legacy/prototype history: [`legacy/`](./legacy/README.md)
+- Runtime architecture: [`../../runtime-architecture.md`](../../runtime-architecture.md)
+- Live backlog: GitHub Issues
+
+## First-Agent Checklist
+
+Before changing Ridge docs or implementation:
+
+1. Read [`README.md`](./README.md).
+2. Identify whether the task is route canon, area detail, runtime prototype,
+   reference support, legacy adaptation, or live issue work.
+3. Read only the matching source docs.
+4. Update one canonical target per claim.
+5. Leave unresolved or taste-sensitive decisions in
+   [`open-questions.md`](./open-questions.md) or
+   [`decision-intake.md`](./decision-intake.md).

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -382,10 +382,8 @@ assigning an AFK agent.
 1. **Ridge Route Reset Planning**: align the next implementation plan with the
    active Bridge Area -> Concert Area -> Dance Festival Area -> Relay/Cicka
    ending route in [`story-level-bible.md`](./story-level-bible.md). Treat
-   [`topology-spike.md`](./map-plans/topology-spike.md) and
-   [`proper-map-plan.md`](./map-plans/proper-map-plan.md) as legacy/prototype
-   references unless a slice explicitly adapts their source-contract or topology
-   ideas.
+   [`legacy/`](./legacy/README.md) as legacy/prototype reference unless a slice
+   explicitly adapts its source-contract or topology ideas.
 2. **Later First Ridge Shortcut / Ridge-Only Glide**: revisit these after the
    route reset gives shortcuts and movement rewards a real route shape.
 3. **Translator / Cicka Daydream**: keep translated Cicka subtitles and the

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -9,8 +9,8 @@ current backlog, and agent-ready briefs live in GitHub Issues through the
 workflow in [`docs/agents/issue-tracker.md`](../../agents/issue-tracker.md).
 
 Use this file for durable milestone shape, ownership boundaries, branch/seam
-strategy, and reference stacks. Use [`current-level.md`](./current-level.md)
-for the current human-readable Ridge level snapshot.
+strategy, and reference stacks. Use [`ridge-snapshot.md`](./ridge-snapshot.md)
+for the current human-readable Ridge snapshot.
 
 ## Active Goal
 
@@ -103,7 +103,7 @@ Role contracts and activation phrases live in
 Every GitHub implementation issue should link the relevant subset of these:
 
 - [`summit.md`](./summit.md)
-- [`current-level.md`](./current-level.md)
+- [`ridge-snapshot.md`](./ridge-snapshot.md)
 - [`runtime-architecture.md`](../../runtime-architecture.md)
 - [`runtime-modes.md`](../../runtime-modes.md)
 - [`architecture-direction.md`](../../architecture-direction.md)

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -29,6 +29,15 @@ The first complete route should prove:
 
 Anything beyond that is future scope unless a slice explicitly pulls it in.
 
+## Retention Rule
+
+Keep this file as a compact phase compass. It may name the active goal,
+route-reset milestones, source stack, prototype reuse rules, and handoff
+checks. It must not collect issue status, owner assignments, implementation
+task lists, transcript excerpts, dates, or release notes. Put those in GitHub
+Issues, [`decision-intake.md`](./decision-intake.md), or the matching source
+doc instead.
+
 ## Route-Reset Milestones
 
 - **P0 Decision Intake**: convert grilling/research transcripts into accepted

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -6,7 +6,8 @@
 > accepted decision to the correct canon file and remove or rewrite the question.
 
 Read [`README.md`](./README.md) first for source-of-truth routing. Resolved
-area-local detail belongs in the matching [`areas/`](./areas/README.md) file.
+area-local detail belongs in the matching [`areas/`](./areas/README.md) file or
+the narrowest subdoc inside that area folder.
 
 ## Ending
 
@@ -58,7 +59,7 @@ When a grilling/research pass resolves a question:
 
 1. Add accepted route/story decisions to [`story-level-bible.md`](./story-level-bible.md).
 2. Add accepted local area detail to the matching [`areas/`](./areas/README.md)
-   file.
+   file or area subdoc.
 3. Add new stable terms or ambiguities to [`../../../CONTEXT.md`](../../../CONTEXT.md).
 4. Add implementation work to GitHub Issues.
 5. Add runtime/prototype facts to [`ridge-snapshot.md`](./ridge-snapshot.md).

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -1,0 +1,65 @@
+# Ridge Open Questions
+
+> Status: needs-HITL / active brainstorming.
+> This file tracks unresolved design gaps for the active Ridge route. It is not
+> implementation scope and not a backlog. When a question resolves, move the
+> accepted decision to the correct canon file and remove or rewrite the question.
+
+Read [`README.md`](./README.md) first for source-of-truth routing. Resolved
+area-local detail belongs in the matching [`areas/`](./areas/README.md) file.
+
+## Ending
+
+- **Living Proof feedback:** What does the player see, hear, or read when Relay
+  is physically reachable but not ready to send?
+- **Guitar Farewell staging:** What are the camera, input handoff, animation,
+  silence, and audio beats from Sit and Play through Relay Blue Hour?
+- **Cicka Threshold Farewell staging:** What exact physical sequence carries
+  Cicka's final walk, look back, mark, and page-fold/light departure?
+- **Open Ridge Return State:** What interactions remain available immediately
+  after the ending, and what exact state is preserved at Relay and the Concert
+  Resting Spot?
+- **Micka timing:** What post-ending action eventually introduces Micka, and
+  what must stay hidden until then?
+
+## Dance Festival Area
+
+- **Spatial layout:** What is the room topology for Last-Stop Plaza, service
+  road gate, shuttle, operations table, dance floor, lantern lines, and exits?
+- **Moment-to-moment prompts:** What concrete prompts, object interactions,
+  conversation branches, and recovery paths express the beat without turning it
+  into chores or a cutscene?
+- **Readiness Favor order:** Can the player help the driver or Last-Stop
+  Operations Helper first, and what changes if they approach in either order?
+- **Setup Clearance Walkthrough:** Which 2-3 authored snaps are enough to show
+  the service lane becoming safe?
+- **Resident identity pass:** What silhouettes, movement, dialogue style, and
+  eventual names fit the hill-shuttle driver, Last-Stop Operations Helper, Dance
+  Teacher, steward, traveler, and Unnamed Counterpart Cat?
+- **Festival art/audio language:** What palette, signage, music texture, crowd
+  ambience, and prop kit makes this area warm and romantic without colliding
+  with Concert or the later Guitar Farewell?
+- **Scope floor:** What is the smallest playable version that still lands the
+  final emotional readiness before Relay?
+
+## Dependencies
+
+- **Concert dependency:** How exactly does Concert Crossing entrust the guitar
+  so the Guitar Farewell feels earned?
+- **Bridge dependency:** How much does Blueprint Bridge need to teach about
+  resident help and visible world change before later beats depend on it?
+- **Cicka Resting Spots:** What tiny before/after visual state does each
+  required Ridge Area need before those states can echo in the Living Proof
+  Montage?
+
+## Resolution Rule
+
+When a grilling/research pass resolves a question:
+
+1. Add accepted route/story decisions to [`story-level-bible.md`](./story-level-bible.md).
+2. Add accepted local area detail to the matching [`areas/`](./areas/README.md)
+   file.
+3. Add new stable terms or ambiguities to [`../../../CONTEXT.md`](../../../CONTEXT.md).
+4. Add implementation work to GitHub Issues.
+5. Add runtime/prototype facts to [`ridge-snapshot.md`](./ridge-snapshot.md).
+6. Remove or rewrite the resolved question here.

--- a/docs/game-design/ridge/reference/README.md
+++ b/docs/game-design/ridge/reference/README.md
@@ -8,6 +8,9 @@ the active route canon in [`../story-level-bible.md`](../story-level-bible.md),
 the area docs in [`../areas/`](../areas/README.md), shipped behavior, runtime
 source, or GitHub Issues.
 
+Some file names still use old milestone labels such as `m3-*`. Treat those as
+historical package names, not active milestone ownership.
+
 Use reference packs when a task asks for art/audio/overlay/assets or when an
 active design doc links here. Do not search this folder first for route
 decisions.

--- a/docs/game-design/ridge/reference/README.md
+++ b/docs/game-design/ridge/reference/README.md
@@ -21,5 +21,5 @@ decisions.
 - [`m3-visual-pack.md`](./m3-visual-pack.md): visual direction reference.
 - [`m3-overlay-pack.md`](./m3-overlay-pack.md): Trail Card and Manual Page
   overlay reference.
-- [`m3-audio-pack.md`](./m3-audio-pack.md): Ridge, Cicka, Potassium, Stampede,
-  and Telegraph audio reference.
+- [`m3-audio-pack.md`](./m3-audio-pack.md): Ridge, Cicka, optional mini-game,
+  and timing-cue audio reference.

--- a/docs/game-design/ridge/reference/README.md
+++ b/docs/game-design/ridge/reference/README.md
@@ -1,0 +1,25 @@
+# Ridge Reference Packs
+
+> Status: reference / support material.
+
+This folder contains asset, visual, overlay, and audio support packs. These
+files can guide implementation and taste decisions, but they do not override
+the active route canon in [`../story-level-bible.md`](../story-level-bible.md),
+the area docs in [`../areas/`](../areas/README.md), shipped behavior, runtime
+source, or GitHub Issues.
+
+Use reference packs when a task asks for art/audio/overlay/assets or when an
+active design doc links here. Do not search this folder first for route
+decisions.
+
+## Files
+
+- [`asset-staging-plan.md`](./asset-staging-plan.md): asset intake and adoption
+  lanes.
+- [`cicka-runtime-asset-audit.md`](./cicka-runtime-asset-audit.md): first Cicka
+  runtime sprite audit.
+- [`m3-visual-pack.md`](./m3-visual-pack.md): visual direction reference.
+- [`m3-overlay-pack.md`](./m3-overlay-pack.md): Trail Card and Manual Page
+  overlay reference.
+- [`m3-audio-pack.md`](./m3-audio-pack.md): Ridge, Cicka, Potassium, Stampede,
+  and Telegraph audio reference.

--- a/docs/game-design/ridge/reference/asset-staging-plan.md
+++ b/docs/game-design/ridge/reference/asset-staging-plan.md
@@ -1,11 +1,12 @@
 # Sketchbook Ridge Asset Staging Plan
 
-> Planning companion for active Ridge and mini-game asset work.
+> Planning companion for active Ridge pre-production and optional/current
+> mini-game asset work.
 > This is an organization and adoption guide, not a final art bible and not a
 > promise that every prepared asset will ship unchanged.
 
-Active sources: `../summit.md`,
-`../milestone-plan.md`, `m3-visual-pack.md`,
+Active sources: `../README.md`, `../story-level-bible.md`, relevant area docs,
+`../summit.md`, `../milestone-plan.md`, `m3-visual-pack.md`,
 `m3-overlay-pack.md`, `m3-audio-pack.md`,
 `docs/design/style-guide.md`, local generated/prepared asset readmes under
 ignored `asset-sources/**` when present,
@@ -27,8 +28,8 @@ it becomes easy to confuse:
 - prepared spritesheets with runtime-ready integration
 - scene-specific experiments with a repo-wide asset pipeline decision
 
-This document keeps the Summit milestone moving while giving the newer POC
-assets a clear home.
+This document keeps pre-production asset work and current prototype assets in
+separate lanes while giving newer POC assets a clear home.
 
 ## Producer Summary
 
@@ -43,14 +44,16 @@ Producer read:
 
 ## Current Milestone Guardrail
 
-The active milestone still proves:
+The active Ridge route-reset milestone proves:
 
-1. a compact Ridge route exists
+1. a compact Bridge -> Concert -> Dance Festival -> Relay route exists
 2. Relay Spire is visible early
-3. Potassium Slip remains the existing arcade anchor
-4. Stampede Sketch is the first new opt-in mini-game
-5. rewards visibly change the Ridge
-6. Cicka and one NPC make the world feel inhabited
+3. required resident help visibly changes the Ridge
+4. Cicka presence, resting spots, guitar comfort, and farewell staging feel
+   intentional
+5. optional mini-game assets remain side-fun, reward, shortcut, or
+   alternate-path candidates
+6. existing prototype assets are reused only when they support the desired route
 
 Anything that does not directly support those proofs is secondary unless a
 specific slice pulls it in.
@@ -188,7 +191,7 @@ Recommended slice:
 
 Reason:
 
-- Stampede is the current active mini-game milestone
+- Stampede is the current optional/prototype mini-game milestone
 - enemy silhouettes affect readability and tone directly
 - scene-local integration is safer than a cross-game art push
 - the current design now depends on a readable central calm patch plus a

--- a/docs/game-design/ridge/reference/m3-audio-pack.md
+++ b/docs/game-design/ridge/reference/m3-audio-pack.md
@@ -2,12 +2,15 @@
 
 Owner mode: Audio Designer.
 
-Purpose: active audio direction for the Ridge, Cicka, Potassium
-acknowledgements, Stampede Sketch, and Telegraph Terrace. This is a spec pack,
-not final asset direction or runtime architecture.
+Purpose: reference audio direction for the Ridge, Cicka, optional/current
+mini-games, Potassium acknowledgements, Stampede Sketch, and Telegraph Terrace.
+The `M3` name is historical. This is a spec pack, not final asset direction,
+route canon, or runtime architecture.
 
 Active references:
 
+- `../README.md`, `../story-level-bible.md`, and relevant area docs for active
+  Ridge route/ending context.
 - `../summit.md`: low-cortisol Ridge, high-spice mini-games,
   stickers/world memory, Cicka as resident.
 - `style-guide.md`: off-white paper, black ink, stepped handmade feel.

--- a/docs/game-design/ridge/reference/m3-overlay-pack.md
+++ b/docs/game-design/ridge/reference/m3-overlay-pack.md
@@ -1,6 +1,7 @@
 # Sketchbook Ridge M3 Overlay Pack
 
-> Overlay Readability Designer's overlay and manual-page visual readability pack for M3.
+> Overlay Readability Designer's overlay and manual-page visual readability
+> reference pack. The `M3` name is historical.
 > This is a practical spec for Trail Cards, Manual Pages, and monochrome
 > reward/locked language. It should guide implementation without creating final
 > art pressure.
@@ -9,6 +10,8 @@
 
 Use this pack with:
 
+- `docs/game-design/ridge/README.md`
+- the active route/area doc for the task
 - `docs/game-design/ridge/summit.md`
 - `docs/game-design/ridge/milestone-plan.md`
 - `docs/design/style-guide.md`
@@ -16,7 +19,8 @@ Use this pack with:
 - the current `OverlayDialogFrame`, `DialogCard`, `TrailCardOverlay`, and
   `ManualPageOverlay` implementation
 
-Do not use archived competition docs as active source of truth.
+Do not use legacy/prototype docs as active source of truth unless the Ridge
+router or active task sends you there.
 
 ## Overlay Thesis
 

--- a/docs/game-design/ridge/reference/m3-visual-pack.md
+++ b/docs/game-design/ridge/reference/m3-visual-pack.md
@@ -1,14 +1,16 @@
 # Sketchbook Ridge M3 Visual Pack
 
 Visual Direction Artist guidance with Character Designer input. This pack is
-implementation guidance, not a final art bible. M4 should be able to ship rough
-placeholders from these specs without waiting for polished drawings.
+reference guidance, not a final art bible or route-canon source. The `M3` name
+is historical; active Ridge area and ending decisions live in the Ridge router,
+story bible, and area docs.
 
-Active sources: `../summit.md`, `../milestone-plan.md`,
+Active sources: `../README.md`, `../story-level-bible.md`, relevant area docs,
+`../summit.md`, `../milestone-plan.md`,
 `docs/design/style-guide.md`, current runtime docs, scoped agent rules, and
 selected research summaries for A Short Hike, Tunic, Vampire Survivors, Clair
-Obscur, Divinity: Original Sin 2, and fighting game feel. Archived competition
-docs are not used as active source of truth.
+Obscur, Divinity: Original Sin 2, and fighting game feel. Legacy/prototype docs
+are not used as active source of truth unless an active doc links them.
 
 ## Visual Thesis
 
@@ -139,10 +141,10 @@ not unlocked by a menu.
 
 If a sticker makes interaction less clear, remove or fade the sticker.
 
-## M4 Placeholder Rules
+## Legacy M4 Placeholder Rules
 
-M4 Stampede and Ridge implementation can move with placeholders if they obey
-the read of this pack.
+Current/prototype Stampede and Ridge implementation can move with placeholders
+if they obey the read of this pack.
 
 - Use simple black silhouettes on paper: rectangles, ovals, triangles, torn
   scraps, and hand-drawn arcs are enough.
@@ -162,7 +164,8 @@ the read of this pack.
 - Telegraph and Domino can remain inert landmark silhouettes until their scenes
   exist. Their Trail Cards should not imply playable behavior before wiring.
 - Do not introduce a shared asset pipeline or generic mini-game art framework
-  for M4. Scene-owned placeholders are fine until repeated pain is proven.
+  from one prototype. Scene-owned placeholders are fine until repeated pain is
+  proven.
 - Keep placeholder art monochrome and readable at mobile crop. If it only reads
   on desktop, simplify the silhouette.
 

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -1,8 +1,9 @@
-# Current Ridge Level
+# Ridge Snapshot
 
-> Current human-readable Ridge level snapshot. This is not shipped player
-> documentation and not the issue tracker. Update this when the playable Ridge
-> route, runtime blockout, reward contract, or current level target changes.
+> Current human-readable snapshot of Ridge's implemented/prototyped state. This
+> is not shipped player documentation and not the issue tracker. Update this
+> when the playable Ridge route, runtime blockout, reward contract, or near-term
+> Ridge implementation target changes.
 
 ## Ownership
 

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -208,9 +208,12 @@ ideal or optional version.
 
 The final blocker should be a **Living Proof Gate**. The Relay Spire can be
 physically reachable early, but it should not send the sketchbook until the path
-has created enough resident/world changes, mini-game proofs, and Cicka
-familiarity to make the destination emotionally and semantically ready. Avoid an
+has created enough resident/world changes and Cicka familiarity to make the
+destination emotionally and semantically ready. The three required Ridge Areas
+should be enough proof for the current first ending. Avoid an
 exact visible checklist unless testing shows the player needs clearer feedback.
+Changed Cicka Resting Spots should not count as proof by themselves; they are
+emotional echoes of resident/world changes already earned elsewhere.
 Planning assumption: start with 2-3 required main-path Resident Help Beats
 before the first ending, plus optional extra residents for return play. Treat the
 exact count as a Level Designer and Story/Tone tuning variable, not a fixed
@@ -220,13 +223,16 @@ The target asks for:
 
 - a readable mostly forward neighborhood route toward Relay Spire
 - Relay Spire physically reachable before it can send
-- Living Proof Gate made from enough visible world changes, proofs, and Cicka
-  familiarity rather than an exact checklist
+- Living Proof Gate made from enough visible world changes and Cicka familiarity
+  rather than an exact checklist; the three required Ridge Areas should be
+  enough for the current first ending
+- changed Cicka Resting Spots as emotional echoes of proof, not separate proof
+  sources
 - first ending path completable through conversations, collection, authored
   traversal, Ridge Areas, Resident Beats, and world changes without requiring
   full arcade mini-games
-- Mini-Game Entrances as optional alternate path unlockers, proof sources,
-  rewards, or pure side fun
+- Mini-Game Entrances as optional fun, rewards, shortcuts, or future alternate
+  ways to finish a level, not required first-ending proof
 - non-arcade fallback for any required beat that contains arcade-like interaction
 - tiny resident problems that create visible route changes
 - first route area as **Bridge Area**, containing **Blueprint Bridge**: a

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -1,23 +1,28 @@
 # Ridge Snapshot
 
-> Current human-readable snapshot of Ridge's implemented/prototyped state. This
-> is not shipped player documentation and not the issue tracker. Update this
-> when the playable Ridge route, runtime blockout, reward contract, or near-term
-> Ridge implementation target changes.
+> Status: implemented/prototype snapshot.
+> This is the current human-readable snapshot of Ridge's implemented/prototyped
+> state, not the active future design target, shipped player documentation, or
+> issue tracker. Update this when current runtime behavior or prototype
+> capability changes.
 
 ## Ownership
 
 - **Shipped behavior:** [`player-manual.md`](../player-manual.md).
+- **Ridge source router:** [`README.md`](./README.md).
+- **Active story/route canon:** [`story-level-bible.md`](./story-level-bible.md).
+- **Active area design:** [`areas/`](./areas/README.md).
 - **Runtime spatial data:** [`folded-desk-ridge.source.ts`](../../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts).
 - **Blockout language contract:** [`map-language.md`](./map-language.md).
-- **Current map target:** [`proper-map-plan.md`](./map-plans/proper-map-plan.md).
-- **Story/level plan:** [`story-level-bible.md`](./story-level-bible.md).
+- **Legacy folded topology reference:** [`proper-map-plan.md`](./map-plans/proper-map-plan.md).
 - **Product vision:** [`summit.md`](./summit.md).
 - **Live implementation work:** GitHub Issues.
 
 If this file disagrees with the folded desk Ridge blockout about room layout,
 route order, anchors, shortcuts, or progress-gated geometry, the blockout wins.
 If this file disagrees with GitHub about active work state, GitHub wins.
+If this file disagrees with `story-level-bible.md` or the matching `areas/`
+doc about future route intent, the active design docs win.
 
 ## Current Runtime Shape
 
@@ -134,10 +139,21 @@ Current accepted behavior:
 - Cicka can provide early pre-translator presence and Stampede-gated memory
   flavor without becoming a quest board, vendor, or inventory checklist.
 
-## Current Target
+## Future Design Target
 
-The current map target is the **Sketchbook Neighborhood Spine With Folded Shortcuts**
-from [`proper-map-plan.md`](./map-plans/proper-map-plan.md).
+The active future design target is the linear Ridge route from
+[`story-level-bible.md`](./story-level-bible.md):
+
+```text
+Bridge Area / Blueprint Bridge
+  -> Concert Area / Concert Crossing Beat
+  -> Dance Festival Area / Opening Dance Shuttle Beat
+  -> Relay Spire / Guitar Farewell / Cicka Threshold Farewell
+```
+
+The folded/Cicka Home route in
+[`proper-map-plan.md`](./map-plans/proper-map-plan.md) remains legacy prototype
+and topology reference until it is rewritten around this route.
 
 Before implementing the next Ridge runtime or blockout rewrite, write and accept
 a prose story/level/character plan for the core Exploration Map scenes and
@@ -372,7 +388,8 @@ Update this file when:
 - the current blockout route changes meaningfully
 - a room or landmark becomes active/inactive in the runtime
 - a reward changes durable state shape
-- the current map target changes
+- the active future route target changes in a way that affects runtime/prototype
+  interpretation
 - a prior topology/design spike is superseded
 
 Do not update this file just to record every implementation issue. Use GitHub

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -156,8 +156,8 @@ Design the canonical first ending before designing optional endings. Multiple
 endings are not required for the Ridge; add alternate endings only if a later
 story/level pass proves they create meaningful replay value without weakening
 the Cicka farewell.
-The first prose artifact should be a short ending sequence outline before any
-required Ridge Areas / Resident Beats are designed: arrival state, Relay
+The first prose artifact should be a short ending sequence outline before the
+required Ridge Areas and their Resident Beats are designed: arrival state, Relay
 readiness, Cicka's final field presence, farewell action, final mark, and
 return-to-Ridge state.
 
@@ -190,7 +190,7 @@ reward or responsibility, not as a random pickup. A resident can give or lend it
 after the player helps with a local music/concert problem, then local Cicka
 Resting Spots can teach the player that playing for Cicka is a comfort ritual
 before the Relay Spire ending.
-Middle required Ridge Area / Resident Beat: **Concert Crossing Beat**. A
+Middle route area: **Concert Area**, containing **Concert Crossing Beat**. A
 blocked concert/traffic crossing halts the route because the local guitarist
 cannot play, the paper-stage setup is tangled, or the guitar needs a small
 repair. Cicka subtly points attention to the guitar case, loose string, or
@@ -228,14 +228,14 @@ The target asks for:
   rewards, or pure side fun
 - non-arcade fallback for any required beat that contains arcade-like interaction
 - tiny resident problems that create visible route changes
-- first v0 Resident Help Beat as **Blueprint Bridge**: a required soft gate
-  where helping a resident finish a bridge drawing/blueprint makes the crossing
-  real
+- first route area as **Bridge Area**, containing **Blueprint Bridge**: a
+  required soft gate where helping a resident finish a bridge drawing/blueprint
+  makes the crossing real
 - 2-3 required main-path Ridge Areas before the first ending, each centered on a
   Resident Beat / Resident Help Beat, with optional extra residents only if they
   add texture instead of errand fatigue
-- final required Ridge Area / Resident Beat candidate as **Opening Dance
-  Shuttle Beat**:
+- final required route area as **Dance Festival Area**, containing **Opening
+  Dance Shuttle Beat**:
   a nervous dance/romance setup at the foot of the Relay hill. The night dance
   festival is real, but the required route beat happens during afternoon setup.
   The route blocker should be practical: festival barriers, lantern lines,
@@ -284,10 +284,11 @@ The target asks for:
   using only silhouette/color specificity such as a pale or light-ink contrast
   to Cicka. The scene should not name him, give him dialogue, confirm parentage,
   or spend Micka before the post-ending return.
-- required route spine: Blueprint Bridge means changing the world through art,
-  Concert Crossing means turning memory into comfort, Opening Dance Shuttle
-  Beat means life can keep moving with someone new, then Relay Spire /
-  Guitar Farewell resolves Cicka's threshold farewell
+- required route spine: Bridge Area / Blueprint Bridge means changing the world
+  through art, Concert Area / Concert Crossing Beat means turning memory into
+  comfort, Dance Festival Area / Opening Dance Shuttle Beat means life can keep
+  moving with someone new, then Relay Spire / Guitar Farewell resolves Cicka's
+  threshold farewell
 - Guitar Farewell can include a brief **Living Proof Montage**: Blueprint Bridge
   being used, Concert Crossing continuing, Opening Dance beginning at night as
   an emotional echo under the player's guitar, and earlier Cicka Resting Spots

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -329,8 +329,10 @@ The target asks for:
 - Bridge Resting Spot, Concert Resting Spot, and Dance Festival Resting Spot as
   local progress-memory spaces, not hubs or v0 prompt nodes
 - two tiny visual states for each Cicka Resting Spot: before resolution, Cicka
-  draws attention to the local problem; after resolution, the spot becomes
-  calmer through a settled pose, tiny mark, changed prop, or later absence echo
+  draws attention to the local problem; immediately after resolution, the spot
+  becomes calmer through a settled pose, tiny mark, changed prop, or later
+  absence echo; the Guitar Farewell montage can revisit these already-changed
+  states rather than introducing them
 - no main-path slope reliance in v0; use chunky stairs, cords, shelves, bridges,
   lifts, and soft drops
 - no required jump button on the v0 main route; use authored climb, descend,

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -333,6 +333,8 @@ The target asks for:
   becomes calmer through a settled pose, tiny mark, changed prop, or later
   absence echo; the Guitar Farewell montage can revisit these already-changed
   states rather than introducing them
+- changed resting-spot states as optional emotional rewards, not required
+  noticing, revisiting, checklist, or route-gate steps
 - no main-path slope reliance in v0; use chunky stairs, cords, shelves, bridges,
   lifts, and soft drops
 - no required jump button on the v0 main route; use authored climb, descend,

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -179,17 +179,18 @@ Accepted first ending outline:
    empty usual spot plus one small paw/page mark, not the player's guitar left
    behind.
 
-The guitar should be established earlier as a meaningful comfort item: something
-the player can pick up, carry, and play in the world, especially at local Cicka
-Resting Spots.
-Petting can be a smaller recurring affection interaction. A hug is optional and
-should wait until character art can support it without making the farewell feel
-awkward or over-staged.
+The guitar should be established earlier as a meaningful comfort item:
+something the player can pick up and carry before the Relay **Guitar Farewell**.
+Initial local Cicka Resting Spots can stay mostly visual instead of becoming
+repeatable guitar prompts or dedicated interaction nodes.
+Petting, lap resting, and similar affection interactions can wait for a later
+polish pass. A hug is optional and should wait until character art can support
+it without making the farewell feel awkward or over-staged.
 The guitar should enter mid-route through a Resident Beat as an entrusted
 reward or responsibility, not as a random pickup. A resident can give or lend it
-after the player helps with a local music/concert problem, then local Cicka
-Resting Spots can teach the player that playing for Cicka is a comfort ritual
-before the Relay Spire ending.
+after the player helps with a local music/concert problem; the route can then
+stage Cicka around local Resting Spots so the final Relay comfort moment feels
+prepared without requiring resting-spot interactions in v0.
 Middle route area: **Concert Area**, containing **Concert Crossing Beat**. A
 blocked concert/traffic crossing halts the route because the local guitarist
 cannot play, the paper-stage setup is tangled, or the guitar needs a small
@@ -320,11 +321,16 @@ The target asks for:
   rather than appearing immediately. The echo should be an empty usual spot with
   one small paw/page mark, not the guitar left behind.
 - Cicka field presence in every required Resident Help Beat, with one local
-  **Cicka Resting Spot** per required Ridge Area. Her role can vary from
-  subtle obstacle hint to changed-object observer to quiet trust marker.
+  **Cicka Resting Spot** per required Ridge Area: Bridge Resting Spot, Concert
+  Resting Spot, and Dance Festival Resting Spot. Her role can vary from subtle
+  obstacle hint to changed-object observer to quiet trust marker.
 - optional residents, NPCs, interactive props, and chill spaces that can offer
   mini-games, atmosphere, jokes, or company without solving barricades
-- Cicka Resting Spots as local progress-memory spaces, not hubs
+- Bridge Resting Spot, Concert Resting Spot, and Dance Festival Resting Spot as
+  local progress-memory spaces, not hubs or v0 prompt nodes
+- two tiny visual states for each Cicka Resting Spot: before resolution, Cicka
+  draws attention to the local problem; after resolution, the spot becomes
+  calmer through a settled pose, tiny mark, changed prop, or later absence echo
 - no main-path slope reliance in v0; use chunky stairs, cords, shelves, bridges,
   lifts, and soft drops
 - no required jump button on the v0 main route; use authored climb, descend,

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -14,7 +14,7 @@
 - **Active area design:** [`areas/`](./areas/README.md).
 - **Runtime spatial data:** [`folded-desk-ridge.source.ts`](../../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts).
 - **Blockout language contract:** [`map-language.md`](./map-language.md).
-- **Legacy folded topology reference:** [`proper-map-plan.md`](./map-plans/proper-map-plan.md).
+- **Legacy folded topology reference:** [`legacy/`](./legacy/README.md).
 - **Product vision:** [`summit.md`](./summit.md).
 - **Live implementation work:** GitHub Issues.
 
@@ -151,9 +151,8 @@ Bridge Area / Blueprint Bridge
   -> Relay Spire / Guitar Farewell / Cicka Threshold Farewell
 ```
 
-The folded/Cicka Home route in
-[`proper-map-plan.md`](./map-plans/proper-map-plan.md) remains legacy prototype
-and topology reference until it is rewritten around this route.
+The folded/Cicka Home route in [`legacy/`](./legacy/README.md) remains legacy
+prototype and topology reference until it is rewritten around this route.
 
 Before implementing the next Ridge runtime or blockout rewrite, write and accept
 a prose story/level/character plan for the core Exploration Map scenes and

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -127,6 +127,10 @@ The Guitar Farewell montage may revisit these changed resting-spot states, but
 it should not be the first time the player sees them. The world should feel
 responsive during play, not only during the ending.
 
+The player is never required to notice, inspect, or revisit changed resting
+spots to progress. They are readable rewards and emotional continuity for
+players who look, not route gates or checklist items.
+
 Use practical design labels for these spots:
 
 | Area | Practical resting spot label | Before resolution | After resolution |

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -8,6 +8,9 @@
 This bible is in-progress. It records resolved story, level-design, character,
 and progression decisions for the core Exploration Map route.
 
+Current design focus: work backward from the ending by detailing **Last Dance /
+Bachata Crossing** before Concert Crossing and Blueprint Bridge.
+
 Design order:
 
 1. canonical first ending
@@ -22,6 +25,11 @@ Design order:
 The Ridge should read first as a **Sketchbook Neighborhood**: a lived-in paper
 place where the player moves toward the Relay Spire by talking with residents,
 collecting meaningful objects, noticing Cicka, and seeing routes change.
+
+Even when the world uses sketchbook visuals, route blockers should obey
+**Lived-In Causality**. Each required beat should make practical sense as a
+place, a physical blockage, and a resident relationship: where does this happen,
+what is actually blocking progress, and why can this person help?
 
 The first ending path should be completable through conversations, collection,
 authored traversal interactions, Resident Room Beats, and visible world changes.
@@ -105,7 +113,7 @@ Relay Spire / Guitar Farewell -> I am ready for Cicka's threshold farewell.
 
 | Beat | Status | Route role | Cicka role | World change |
 | --- | --- | --- | --- | --- |
-| Last Dance / Bachata Crossing | Accepted final beat candidate | Creates the last emotional readiness before Relay through a nervous dance/romance setup | Quiet observer at the edge of the dance space | Dance crossing clears; path to Relay feels emotionally ready |
+| Last Dance / Bachata Crossing | Accepted final beat candidate | Creates the last emotional readiness before Relay through the Last Ticket + Lantern Check at the foot of the Relay hill | Quiet observer near the unstamped ticket, shuttle step, or service gate | Lantern check completes; final shuttle ticket is stamped; festival barriers/service road clear |
 | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Points attention to guitar case, string, stage, or crossing | Concert continues; crossing opens; guitar entrusted to player |
 | Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
 
@@ -116,6 +124,136 @@ from the Guitar Farewell. Two fictional residents like each other but are too
 nervous to step onto the dance floor or talk directly. The player helps set up
 the dance event with the organizers, prepares one nervous partner for the dance,
 and helps the pair find enough rhythm to meet.
+
+Accepted geography and blocker: the dance happens in a small town square,
+community hall, or festival street at the foot of the Relay hill, where a local
+dance night naturally belongs. The route to the Relay Spire is blocked by a
+practical final-approach problem: festival barriers, a locked service-road gate,
+and/or the last hill shuttle not running until the event can close properly.
+The player helps a resident whose daily purpose connects to that route, such as
+the hill-shuttle driver, hill caretaker, or festival organizer. Helping the
+dance happen lets the organizers clear the street or reopen the service gate,
+and gives the helper a believable reason and means to take the player toward
+the Relay overlook.
+
+Locked arrival state: **Last Ticket + Lantern Check**.
+
+```text
+Last-Stop Plaza at the foot of the Relay hill.
+Festival barriers block the service road.
+Sign: "Hill road closed during dance hour. Final shuttle leaves after lantern check."
+```
+
+On arrival, the hill-shuttle driver stands beside the shuttle near the locked
+service-road gate, checking the same route clipboard too many times. He cannot
+drive yet because the road is still closed, the hill lantern check is not
+signed, and the last-stop clerk has not stamped the final ticket batch. He is
+working, but the work is also a safe place to hide from asking for one small
+dance.
+
+The lantern/ticket clerk stays at the ticket and lantern booth, closing the
+last-shuttle ledger and checking hill-lantern tokens. She needs the driver's
+route confirmation before she can stamp the final tickets. He needs her lantern
+clearance before he can drive. Their jobs literally require them to coordinate,
+which lets the romance grow out of the plaza's real closing procedure.
+
+Supporting static residents:
+
+- traveler near the plaza entry: points the player toward the shuttle and
+  explains that Relay requires the last hill shuttle
+- festival steward near the barrier: explains that the service road opens only
+  after the final dance/lantern check closes cleanly
+- dance teacher near the floor: offers gentle facilitation and possibly one
+  small step, but is not the romance target
+
+Accepted discovery pattern: use a **Practical Wayfinding Loop**, not a quest
+giver. The player arrives asking how to reach Relay, notices the closed
+service-road barrier and shuttle sign, then learns from practical local roles
+that the final shuttle is delayed because the last ticket and lantern check are
+unfinished.
+
+First-read sequence:
+
+```text
+Player arrives at Last-Stop Plaza.
+Closed service-road barrier and shuttle sign show the route is blocked.
+Traveler says Relay requires the last hill shuttle.
+Driver is visible by the shuttle, stuck on the route clipboard.
+Clerk is visible at the booth, stuck on the lantern/ticket ledger.
+Steward explains that the road opens after the final check.
+```
+
+The player's natural question should be "How do I get to Relay?", not "How do I
+fix the romance?" The romantic problem should emerge only after the player asks
+why the last shuttle is delayed and notices that the driver and clerk need each
+other's sign-off.
+
+Accepted conversation discovery pattern: **Triangulated Discovery Flow**. The
+player should be able to talk to the driver and clerk first and receive
+practical but incomplete answers:
+
+```text
+Driver: cannot leave until the lantern check is cleared.
+Clerk: cannot stamp the last tickets until the route is confirmed.
+```
+
+Both answers are true, but they do not explain why the two are avoiding the
+simple act of coordinating. The player can then return to the plaza and ask
+nearby locals what is going on.
+
+Possible local reads:
+
+- traveler: "The driver's been rereading that clipboard for ten minutes."
+- festival steward: "Those two need to sign the same last-run sheet.
+  Separately, apparently."
+- dance teacher: "They both know the steps. They are pretending the paperwork
+  is harder."
+
+This lets the player piece together the relationship from public behavior and
+local observations rather than receiving an instant confession or omniscient
+quest explanation.
+
+Required relocation should stay minimal. After the player helps, the driver and
+clerk can move once to the edge of the dance floor for a shy final dance, then
+return to the shuttle/booth roles so the clerk stamps the final ticket, the
+steward clears the barrier, and the driver offers the ride toward Relay.
+
+Locked route-agent: the nervous dance resident is the **hill-shuttle driver**.
+He runs the last practical route up toward the Relay overlook, but he is stuck
+at the festival because the street is still closed and because he cannot bring
+himself to step onto the floor. His daily job, his emotional problem, and the
+player's route blocker should all point at the same practical situation.
+
+Locked romantic partner: the shy **last-stop lantern/ticket clerk**. She stamps
+last-shuttle tickets, helps close the festival street, and sets or checks the
+lanterns for the hill road. She belongs in this place because her daily work
+sits exactly between the dance, the service-road barrier, and the final shuttle.
+She likes the driver because he is quietly reliable: he waits for her to finish
+packing, remembers nervous passengers, and takes the hill road gently. He likes
+her because she notices small things and keeps the last-stop plaza feeling
+kind.
+
+The dance teacher can still exist, but as a facilitator rather than the romance
+target. They can teach one small step, give the player social cover, or notice
+that two shy people are orbiting each other. Avoid turning the beat into a
+competition for the teacher's attention unless a later tone pass proves it can
+stay gentle.
+
+Conversation design should use **Recoverable Conversation Choices**. The player
+should feel agency through what they ask, who they approach first, how they
+encourage the driver, and how they recover from a clumsy read. A failed path can
+create awkwardness, delay, or require extra listening, but it should not
+permanently block the first ending.
+
+Do not use a purely magical or abstract "dance crossing" explanation. This beat
+must answer:
+
+- where a dance naturally belongs in the final approach environment
+- what physical barricade prevents the player from reaching the Relay Spire
+- why the resident being helped has a believable reason and practical way to
+  help with that barricade
+- what small backstory or daily purpose makes each involved resident feel like a
+  local person rather than a route-solving robot
 
 The couple should be emotionally inspired by Danilo and Milena's story without
 being literal stand-ins. Protect the intimacy: carry the emotional truth through

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -8,8 +8,8 @@
 This bible is in-progress. It records resolved story, level-design, character,
 and progression decisions for the core Exploration Map route.
 
-Current design focus: work backward from the ending by detailing **Last Dance /
-Bachata Crossing** before Concert Crossing and Blueprint Bridge.
+Current design focus: work backward from the ending by detailing **Opening
+Dance Shuttle Beat** before Concert Crossing and Blueprint Bridge.
 
 Design order:
 
@@ -49,10 +49,13 @@ Accepted ending outline:
 3. Cicka appears in her final field-presence spot, calm and familiar.
 4. The player shares a quiet **Guitar Farewell** with Cicka, ideally under a
    warm sunset or other cozy threshold light.
-5. The player activates or sends the sketchbook.
-6. Cicka walks with the player to the threshold, pauses, leaves one final
+5. A brief **Living Proof Montage** can appear during the guitar: Blueprint
+   Bridge being used, Concert Crossing continuing, Opening Dance beginning at
+   night, and Cicka Home carrying accumulated marks.
+6. The player activates or sends the sketchbook.
+7. Cicka walks with the player to the threshold, pauses, leaves one final
    paw/page mark, then departs somewhere unreachable.
-7. The player returns to Ridge after the ending, with the final mark preserved
+8. The player returns to Ridge after the ending, with the final mark preserved
    and the world still open.
 
 Tone boundaries:
@@ -107,96 +110,102 @@ Current required route spine:
 ```text
 Blueprint Bridge -> I can change the world by making something through art.
 Concert Crossing -> I can turn memory into comfort.
-Last Dance / Bachata Crossing -> Life can keep moving with someone new.
+Opening Dance Shuttle Beat -> Life can keep moving with someone new.
 Relay Spire / Guitar Farewell -> I am ready for Cicka's threshold farewell.
 ```
 
 | Beat | Status | Route role | Cicka role | World change |
 | --- | --- | --- | --- | --- |
-| Last Dance / Bachata Crossing | Accepted final beat candidate | Creates the last emotional readiness before Relay through the Last Song Table and Final Shuttle Hold at the foot of the Relay hill | Quiet observer near the song table, shuttle step, or service gate | Final song happens; shuttle lane clears; festival barriers/service road open |
+| Opening Dance Shuttle Beat | Accepted final beat direction; Last-Stop Operations Helper locked as romantic partner role | Creates the last emotional readiness before Relay through afternoon setup for a night dance festival at the foot of the Relay hill | Quiet threshold observer near the lantern crates, operations table, shuttle step, or service gate; may loaf with the Unnamed Counterpart Cat | Festival setup clears enough for one last daylight shuttle to Relay before the night road closure |
 | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Points attention to guitar case, string, stage, or crossing | Concert continues; crossing opens; guitar entrusted to player |
 | Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
 
-## Last Dance / Bachata Crossing
+## Opening Dance Shuttle Beat
 
 The final required Resident Room Beat should be romantic, warm, and different
 from the Guitar Farewell. Two fictional residents like each other but are too
-nervous to step onto the dance floor or talk directly. The player helps set up
-the dance event with the organizers, prepares one nervous partner for the dance,
-and helps the pair find enough rhythm to meet.
+nervous to step onto the dance floor or talk directly. The night dance festival
+is real, but the player participates in afternoon setup and leaves before the
+festival fully begins. The player helps make the event ready, prepares one
+nervous partner for a future dance, and helps the pair find enough rhythm to
+meet without turning the beat into public matchmaking.
 
 Accepted geography and blocker: the dance happens in a small town square,
 community hall, or festival street at the foot of the Relay hill, where a local
 dance night naturally belongs. The route to the Relay Spire is blocked by a
-practical final-approach problem: festival barriers, a locked service-road gate,
-and/or the last hill shuttle not running until the event can close properly.
-The player helps a resident whose daily purpose connects to that route, such as
-the hill-shuttle driver, hill caretaker, or festival organizer. Helping the
-dance happen lets the organizers clear the street or reopen the service gate,
-and gives the helper a believable reason and means to take the player toward
-the Relay overlook.
+practical final-approach problem: festival setup temporarily occupies the
+service road with barriers, lantern lines, chair stacks, stage/speaker cables,
+and a locked gate. Once setup is safe enough, the steward can open one short
+daylight window for the final hill shuttle before the road closes again for the
+night festival. The player helps the hill-shuttle driver, the Last-Stop
+Operations Helper, and nearby festival helpers finish that setup window, giving
+the driver a believable reason and means to take the player toward the Relay
+overlook at sunset.
 
-Locked arrival state: **Last Song Table + Final Shuttle Hold**.
+Accepted arrival premise: **Opening Dance Setup + Last Daylight Shuttle**. This
+replaces the previous after-festival **Last Song Table + Final Shuttle Hold**
+candidate. The stable spine is now:
 
 ```text
 Last-Stop Plaza at the foot of the Relay hill.
-Festival barriers block the service road.
-Sign: "Shuttle lane closed during final dance. Final hill shuttle after last song."
+Festival setup blocks the service road.
+Sign: "Service road closes for night dance. Last daylight shuttle after setup check."
 ```
 
 On arrival, the hill-shuttle driver stands beside the shuttle near the locked
 service-road gate, checking the same route clipboard too many times. He cannot
-drive yet because the festival dance uses the service lane and the steward will
-not open the barrier until the last song finishes and the lane is cleared. He
-is working, but the work is also a safe place to hide from asking for one small
-dance.
+drive yet because setup is still blocking the service lane and the steward will
+not open the barrier until the lane is safe. He is genuinely working the
+afternoon/evening event shuttle shift, but the clipboard is also a safe place to
+hide from asking one small question before the dance begins.
 
-The romantic partner is the shy **last-stop song-table volunteer**. She handles
-the final song table near the dance floor: song slips, basic festival timing,
-and last-shuttle questions. She is not a flashy performer; she is the trusted
-local who keeps the final dance from becoming confused. She cannot easily step
-away because if nobody covers the table, the final song stalls and the shuttle
-lane cannot clear. Emotionally, the table lets her watch the dance while staying
-useful enough not to feel visible.
+The romantic partner is the shy **Last-Stop Operations Helper**. She works the
+visible plaza table that sits between the shuttle, dance setup, and service-road
+barrier: shuttle questions, setup checklist, lantern tags/signs, volunteer
+handoff, and radioing the steward when the lane is clear. She is not a flashy
+performer; she is the trusted local who keeps the last-stop plaza from becoming
+confused. Emotionally, the operations table lets her keep being useful instead
+of becoming visible enough to be asked to dance.
 
 Supporting static residents:
 
 - traveler near the plaza entry: points the player toward the shuttle and
-  explains that Relay requires the last hill shuttle
+  explains that Relay requires the last daylight hill shuttle
 - festival steward near the barrier: explains that the service road opens only
-  after the final dance ends and the lane is clear
-- dance teacher near the floor: can cover the song table for one song, offer
-  gentle facilitation, and possibly teach one small step, but is not the romance
-  target
+  after setup is safe and closes again when the night festival begins
+- dance teacher near the floor: can offer gentle facilitation, teach one small
+  step, or notice that two shy people are orbiting each other, but is not the
+  romance target
 
 Accepted discovery pattern: use a **Practical Wayfinding Loop**, not a quest
 giver. The player arrives asking how to reach Relay, notices the closed
 service-road barrier and shuttle sign, then learns from practical local roles
-that the final shuttle leaves after the last song and the lane-clearing handoff.
+that the final daylight shuttle leaves after setup passes inspection and before
+the road closes for the night dance.
 
 First-read sequence:
 
 ```text
 Player arrives at Last-Stop Plaza.
-Closed service-road barrier and shuttle sign show the route is blocked.
-Traveler says Relay requires the last hill shuttle.
+Festival barriers, lantern lines, and shuttle sign show the route is blocked.
+Traveler says Relay requires the last daylight hill shuttle.
 Driver is visible by the shuttle, stuck on the route clipboard.
-Song-table volunteer is visible near the dance floor, stuck sorting song slips.
-Steward explains that the road opens after the final song and lane clear.
+Operations helper is visible near the dance floor, stuck perfecting setup details.
+Steward explains that the road opens after setup check, then closes for night.
 ```
 
 The player's natural question should be "How do I get to Relay?", not "How do I
 fix the romance?" The romantic problem should emerge only after the player asks
-why the last shuttle is delayed and notices that the driver and song-table
-volunteer are both hiding inside practical work.
+why the last daylight shuttle is delayed and notices that the driver and
+operations helper are both hiding inside practical work.
 
 Accepted conversation discovery pattern: **Triangulated Discovery Flow**. The
-player should be able to talk to the driver and song-table volunteer first and
+player should be able to talk to the driver and Last-Stop Operations Helper first and
 receive practical but incomplete answers:
 
 ```text
-Driver: cannot leave until the final song ends and the lane clears.
-Song-table volunteer: cannot step away unless someone trusted covers the table.
+Driver: cannot leave until setup clears and the steward opens the service gate.
+Operations helper: cannot stop fixing setup details until someone trusted checks the handoff.
 ```
 
 Both answers are true, but they do not explain why the two are hiding inside
@@ -206,55 +215,78 @@ plaza and ask nearby locals what is going on.
 Possible local reads:
 
 - traveler: "The driver's been rereading that clipboard for ten minutes."
-- festival steward: "The shuttle waits on the last song. She waits on someone
-  else to press play. He waits on anything except asking."
-- dance teacher: "They both know where the floor is. They are pretending work
-  is the hard part."
+- festival steward: "The shuttle waits on the lane. She waits on one perfect
+  lantern. He waits on anything except asking."
+- dance teacher: "They both know where the floor is. They are practicing the
+  art of being unavailable."
 
 This lets the player piece together the relationship from public behavior and
 local observations rather than receiving an instant confession or omniscient
 quest explanation.
 
 The player should not be able to solve the beat immediately by confronting the
-driver and song-table volunteer with "you like each other." That would likely
-make shy people defensive and would flatten the scene into forced matchmaking.
-Instead, Last Dance should use two **Readiness Favors**, one for each romantic
-character, before the final song, shy dance, and lane-clearing handoff can
-happen.
+driver and Last-Stop Operations Helper with "you like each other." That would likely make
+shy people defensive and would flatten the scene into forced matchmaking.
+Instead, Opening Dance should use two **Readiness Favors**, one for each
+romantic character, before the setup handoff, last daylight shuttle, and later
+night-dance promise can happen.
 
 Current readiness direction:
 
 - driver insecurity: he does not know how to dance and does not want to
-  embarrass himself in front of the song-table volunteer
-- song-table volunteer insecurity: if she stays behind the table, she is useful;
-  if she steps onto the floor, she is just someone hoping to be asked
+  embarrass himself in front of the Last-Stop Operations Helper
+- Last-Stop Operations Helper insecurity: if she stays useful behind an
+  organizer role, she knows who she is; if she steps onto the floor, she is just
+  someone hoping to be asked
 
 The Readiness Favors should let the player help each person feel prepared while
-preserving their dignity. Her likely favor is **Cover the Last Song Table for
-One Song**: the player gets the dance teacher or steward to cover the table, so
-she can step away without abandoning the event. After both are ready, a small
-romantic connector such as a shy song request, folded note, or indirect
-invitation can make the final step feel romantic without becoming a public
-confession puzzle.
+preserving their dignity.
+
+- Last-Stop Operations Helper: **Operations Handoff Check**. The player helps
+  her prove the plaza setup is safe enough by checking a few visible festival
+  details, then getting a trusted resident to keep watch once the night dance
+  starts. The dance teacher is the simplest current cover candidate, but the
+  covering resident can remain flexible if the supporting cast changes. The
+  emotional point is not that someone else can plan better; it is that she has
+  done enough and the event can keep going while she enjoys it.
+- Hill-shuttle driver: **One-Step Practice**. The player helps him learn exactly
+  one tiny dance step from the dance teacher, privately enough to protect his
+  dignity. He does not become good at dancing; he gains one small shared rhythm
+  he can offer later.
+
+After both romantic characters are ready, the connector is **Folded Song
+Request**. The driver writes a tiny folded paper request at the operations
+table, asking her for one dance later without making a public confession. It can
+use her own event paper, handwriting marks, or song-request language so the ask
+feels rooted in her work rather than imposed by the player.
 
 Required relocation should stay minimal. After the player helps, the driver and
-song-table volunteer can move once to the edge of the dance floor for a shy
-final dance, then return to their practical roles so the final song ends, the
-steward clears the barrier, and the driver offers the ride toward Relay.
+Last-Stop Operations Helper can share or acknowledge the Folded Song Request,
+then return to their practical roles for the **Setup Clearance Walkthrough**:
+the remaining visible setup details clear the service lane enough for the
+steward to open the barrier and the driver to offer the last daylight ride
+toward Relay. Present this as a **Prompt-Driven Playable Montage**, not a full
+manual chore sequence or pure cutscene. The player chooses a prompt such as
+"Help with remaining preparations," then triggers a few authored interaction
+snaps: secure the lantern line, move a chair stack off the lane or tape down a
+cable, flip the shuttle sign to "Last daylight ride." After the snaps, the sky
+warms, the plaza reads more ready, the covering resident keeps watch, and the
+steward opens the gate. The actual dance can remain a promised night-festival
+moment and/or appear in the Guitar Farewell montage.
 
 Locked route-agent: the nervous dance resident is the **hill-shuttle driver**.
 He runs the last practical route up toward the Relay overlook, but he is stuck
-at the festival because the street is still closed and because he cannot bring
-himself to step onto the floor. His daily job, his emotional problem, and the
-player's route blocker should all point at the same practical situation.
+at the festival because the service road is not yet clear and because he cannot
+bring himself to ask about the night dance. His daily job, his emotional
+problem, and the player's route blocker should all point at the same practical
+situation.
 
-Locked romantic partner: the shy **last-stop song-table volunteer**. She helps
-run the event from the song table, answers last-shuttle questions, and keeps the
-final song handoff from stalling. She belongs in this place because her daily
-work sits between the dance, the service-road barrier, and the final shuttle.
-She likes the driver because he is quietly reliable: he waits for her to finish
-packing, remembers nervous passengers, and takes the hill road gently. He likes
-her because she notices small things and keeps the last-stop plaza feeling
+Locked romantic partner: the shy **Last-Stop Operations Helper**. She belongs in
+this place because her daily work sits between the dance, the service-road
+barrier, and the last daylight shuttle without requiring technical explanation.
+She likes the driver because he is quietly reliable: he waits for helpers to
+finish packing, remembers nervous passengers, and takes the hill road gently. He
+likes her because she notices small things and keeps the last-stop plaza feeling
 kind.
 
 The dance teacher can still exist, but as a facilitator rather than the romance
@@ -288,9 +320,18 @@ optional dance/rhythm mini-game can deepen the beat later, but the first ending
 path should not depend on arcade performance.
 
 Cicka does not explain love or grief. She watches from the edge of the dance
-space, perhaps walking through the cleared crossing afterward as if the whole
-thing was obvious. The emotional lesson is that life can continue and new love
-can arrive after loss without replacing what was lost.
+setup, perhaps walking through the cleared lane afterward as if the whole thing
+was obvious. She can also hang out with the **Unnamed Counterpart Cat** near the
+operations table or service gate: loafing together, staring at the same lantern,
+or briefly playing while the humans work. The counterpart cat can visually
+contrast with Cicka, such as a pale or white cat if Cicka reads dark, so that
+Micka's later half-and-half design feels quietly prepared. Do not name him,
+label him as Micka's father, or confirm parentage before the post-ending return.
+The player catches the sunset shuttle to Relay, and the later night festival can
+appear as a **Living Proof Montage** image during the **Guitar Farewell** instead
+of pulling the playable ending away from Cicka. The emotional lesson is that
+life can continue and new love can arrive after loss without replacing what was
+lost.
 
 ## Concert Crossing Beat
 

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -182,9 +182,9 @@ Supporting static residents:
   explains that Relay requires the last daylight hill shuttle
 - festival steward near the barrier: explains that the service road opens only
   after setup is safe and closes again when the night festival begins
-- dance teacher near the floor: can offer gentle facilitation, teach one small
-  step, or notice that two shy people are orbiting each other, but is not the
-  romance target
+- **Dance Teacher** near the floor: offers gentle facilitation, teaches one small
+  step, covers the operations watch once setup is proven safe, and notices that
+  two shy people are orbiting each other, but is not the romance target
 
 Accepted discovery pattern: use a **Practical Wayfinding Loop**, not a quest
 giver. The player arrives asking how to reach Relay, notices the closed
@@ -226,7 +226,7 @@ Possible local reads:
 - traveler: "The driver's been rereading that clipboard for ten minutes."
 - festival steward: "The shuttle waits on the lane. She waits on one perfect
   lantern. He waits on anything except asking."
-- dance teacher: "They both know where the floor is. They are practicing the
+- **Dance Teacher**: "They both know where the floor is. They are practicing the
   art of being unavailable."
 
 This lets the player piece together the relationship from public behavior and
@@ -253,13 +253,11 @@ preserving their dignity.
 
 - Last-Stop Operations Helper: **Operations Handoff Check**. The player helps
   her prove the plaza setup is safe enough by checking a few visible festival
-  details, then getting a trusted resident to keep watch once the night dance
-  starts. The dance teacher is the simplest current cover candidate, but the
-  covering resident can remain flexible if the supporting cast changes. The
-  emotional point is not that someone else can plan better; it is that she has
-  done enough and the event can keep going while she enjoys it.
+  details, then getting the **Dance Teacher** to keep watch once the night dance
+  starts. The emotional point is not that someone else can plan better; it is
+  that she has done enough and the event can keep going while she enjoys it.
 - Hill-shuttle driver: **One-Step Practice**. The player helps him learn exactly
-  one tiny dance step from the dance teacher, privately enough to protect his
+  one tiny dance step from the **Dance Teacher**, privately enough to protect his
   dignity. He does not become good at dancing; he gains one small shared rhythm
   he can offer later.
 
@@ -282,9 +280,11 @@ steward to open the barrier and the driver to offer the last daylight ride
 toward Relay. Present this as a **Prompt-Driven Playable Montage**, not a full
 manual chore sequence or pure cutscene. The player chooses a prompt such as
 "Help with remaining preparations," then triggers a few authored interaction
-snaps: secure the lantern line, move a chair stack off the lane or tape down a
-cable, flip the shuttle sign to "Last daylight ride." After the snaps, the sky
-warms, the plaza reads more ready, the covering resident keeps watch, and the
+snaps. Default symbolic set: secure the lantern line, clear or tape the
+service-lane obstruction, and flip the shuttle sign to "Last daylight ride."
+Treat these as one-action story beats rather than small chore gameplay; they
+can collapse further if the beat needs to move faster. After the snaps, the sky
+warms, the plaza reads more ready, the **Dance Teacher** keeps watch, and the
 steward opens the gate. The actual dance can remain a promised night-festival
 moment and/or appear in the Guitar Farewell montage.
 
@@ -303,11 +303,11 @@ finish packing, remembers nervous passengers, and takes the hill road gently. He
 likes her because she notices small things and keeps the last-stop plaza feeling
 kind.
 
-The dance teacher can still exist, but as a facilitator rather than the romance
-target. They can teach one small step, give the player social cover, or notice
-that two shy people are orbiting each other. Avoid turning the beat into a
-competition for the teacher's attention unless a later tone pass proves it can
-stay gentle.
+The **Dance Teacher** exists as a facilitator rather than the romance target.
+They teach one small step, give the player social cover, cover the operations
+watch after the handoff, and notice that two shy people are orbiting each other.
+Avoid turning the beat into a competition for the teacher's attention unless a
+later tone pass proves it can stay gentle.
 
 Conversation design should use **Recoverable Conversation Choices**. The player
 should feel agency through what they ask, who they approach first, how they

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -120,8 +120,12 @@ Each resting spot should have two tiny visual states:
 
 - **Before area beat resolution**: Cicka uses the spot to draw attention to a
   local problem, route blocker, or emotional handoff.
-- **After area beat resolution**: the spot becomes calmer through a settled
-  pose, tiny mark, changed prop, or quiet absence echo.
+- **Immediately after area beat resolution**: the spot becomes calmer through a
+  settled pose, tiny mark, changed prop, or quiet absence echo.
+
+The Guitar Farewell montage may revisit these changed resting-spot states, but
+it should not be the first time the player sees them. The world should feel
+responsive during play, not only during the ending.
 
 Use practical design labels for these spots:
 

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -1,0 +1,151 @@
+# Ridge Story/Level Bible
+
+> Prose-first design artifact for the next Sketchbook Ridge direction. This file
+> should be accepted before a Ridge runtime or blockout rewrite starts.
+
+## Status
+
+This bible is in-progress. It records resolved story, level-design, character,
+and progression decisions for the core Exploration Map route.
+
+Design order:
+
+1. canonical first ending
+2. Living Proof Gate readiness
+3. final required Resident Room Beat
+4. middle required Resident Room Beat
+5. first required Resident Room Beat
+6. optional residents and Mini-Game Entrances
+
+## Core Promise
+
+The Ridge should read first as a **Sketchbook Neighborhood**: a lived-in paper
+place where the player moves toward the Relay Spire by talking with residents,
+collecting meaningful objects, noticing Cicka, and seeing routes change.
+
+The first ending path should be completable through conversations, collection,
+authored traversal interactions, Resident Room Beats, and visible world changes.
+Mini-games attach to the world as optional alternate paths, proof sources,
+rewards, shortcuts, or pure side fun.
+
+## Canonical Ending
+
+The first ending is the **Cicka Threshold Farewell**. It is the canonical ending
+target; alternate endings are out of scope unless a later story/level pass proves
+they add meaningful replay value without weakening Cicka's farewell.
+
+Accepted ending outline:
+
+1. The player reaches Relay Spire and can stand there before it is ready.
+2. Once Living Proof is enough, the Relay sign becomes readable.
+3. Cicka appears in her final field-presence spot, calm and familiar.
+4. The player shares a quiet **Guitar Farewell** with Cicka, ideally under a
+   warm sunset or other cozy threshold light.
+5. The player activates or sends the sketchbook.
+6. Cicka walks with the player to the threshold, pauses, leaves one final
+   paw/page mark, then departs somewhere unreachable.
+7. The player returns to Ridge after the ending, with the final mark preserved
+   and the world still open.
+
+Tone boundaries:
+
+- no literal death scene
+- no grief monologue
+- no credits-only ending
+- no arcade pass/fail challenge during the Guitar Farewell
+
+## Living Proof Gate
+
+The Relay Spire can be physically reachable before it can send. The blocker is
+that the sketchbook is not ready yet: the path has not created enough visible
+world changes, proofs, and Cicka familiarity.
+
+The gate should feel like emotional and semantic readiness, not an exact visible
+checklist. The route to Relay should naturally provide enough resident help and
+cat familiarity for the first ending.
+
+## Cicka
+
+Cicka is a recurring field presence, not a continuous follower or objective
+giver. Required Resident Room Beats should include authored Cicka appearances,
+but her role should evolve:
+
+- early: subtle attention cue near an obstacle
+- middle: observer of a changed object or resident moment
+- late: quiet trust marker near the threshold
+
+Cicka Home remains a progress memory space, not the only emotional anchor.
+
+## Guitar
+
+The guitar is a meaningful comfort item. It should enter mid-route through a
+Resident Room Beat as an entrusted reward or responsibility, not as a random
+pickup.
+
+After the player receives it, the guitar should become playable in quiet Ridge
+spots, especially Cicka Home, so playing for Cicka at Relay feels remembered
+rather than staged.
+
+Petting can be a smaller recurring affection interaction. A hug is optional and
+should wait until character art can support it cleanly.
+
+## Required Resident Room Beats
+
+Start with 2-3 required main-path Resident Room Beats before the first ending.
+Treat the exact count as a Level Designer and Story/Tone tuning variable.
+
+| Beat | Status | Route role | Cicka role | World change |
+| --- | --- | --- | --- | --- |
+| Final required Resident Room Beat | TBD | Creates the last readiness/insight before Relay | Quiet trust marker | TBD |
+| Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Points attention to guitar case, string, stage, or crossing | Concert continues; crossing opens; guitar entrusted to player |
+| Taped Bridge / Missing Plank | Accepted first beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge | Bridge/crossing opens or is patched |
+
+## Concert Crossing Beat
+
+A blocked concert/traffic crossing halts the route because the local guitarist
+cannot play, the paper-stage setup is tangled, or the guitar needs a small
+repair. The player helps the resident, learns the guitar, and receives or is
+entrusted with the guitar afterward.
+
+The ideal version can include a small Guitar-Hero-like performance mini-game.
+The required route must also have a non-arcade fallback through conversation,
+collection, practice together, or forgiving auto-play.
+
+Avoid making the guitarist a joke-only drunk if it undercuts the later tribute.
+Gentle comedy is welcome; the guitar's emotional role needs room to breathe.
+
+## Taped Bridge / Missing Plank
+
+The first Resident Room Beat should be a required soft gate. It teaches:
+
+```text
+Cicka noticed something -> a resident needs local help -> the route visibly changes
+```
+
+Keep it tiny, obvious, and local. It should not feel like a fetch quest or a
+test of platforming skill.
+
+## Mini-Game Entrances
+
+Mini-game ideas can attach to the Ridge without holding up the core path.
+
+Current candidates:
+
+- Potassium Slip: polished flagship secret/proof candidate.
+- Stampede Sketch: optional Vampire Survivors-style homage/proof candidate.
+- Telegraph / Clair-Obscur-style timing: optional timing/parry proof candidate.
+- Concert guitar performance: small teaching toy for the guitar, with required
+  non-arcade fallback.
+
+Mini-games may unlock alternate paths, extra proof, shortcuts, rewards, or just
+exist for fun. They should not become the default solution for main route
+blockers.
+
+## Open Design Slots
+
+- Final required Resident Room Beat near Relay.
+- Required resident cast names and silhouettes.
+- Optional resident cast and hangout spaces.
+- Guitar acquisition details inside Concert Crossing.
+- Exact Living Proof feedback when Relay is reachable but not ready.
+- Return-to-Ridge state after the Cicka Threshold Farewell.

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -47,16 +47,20 @@ Accepted ending outline:
 1. The player reaches Relay Spire and can stand there before it is ready.
 2. Once Living Proof is enough, the Relay sign becomes readable.
 3. Cicka appears in her final field-presence spot, calm and familiar.
-4. The player shares a quiet **Guitar Farewell** with Cicka, ideally under a
-   warm sunset or other cozy threshold light.
+4. The player uses a **Sit and Play Prompt** near Cicka to share a quiet
+   **Guitar Farewell**, ideally under a warm sunset or other cozy threshold
+   light.
 5. A brief **Living Proof Montage** can appear during the guitar: Blueprint
    Bridge being used, Concert Crossing continuing, Opening Dance beginning at
    night, and Cicka Home carrying accumulated marks.
-6. The player activates or sends the sketchbook.
-7. Cicka walks with the player to the threshold, pauses, leaves one final
-   paw/page mark, then departs somewhere unreachable.
-8. The player returns to Ridge after the ending, with the final mark preserved
-   and the world still open.
+6. Control returns in **Relay Blue Hour** at the Relay sign/spire for a **Send
+   the Sketchbook Prompt**.
+7. Cicka walks with the player to the threshold, pauses, looks back once, leaves
+   one final paw/page mark, then slips into a page fold or light beyond the
+   player's path.
+8. The player returns to the **Open Ridge Return State** after the ending, with
+   the final mark preserved, Cicka's absence felt through favorite spots or
+   marks, and the world still open.
 
 Tone boundaries:
 
@@ -64,6 +68,10 @@ Tone boundaries:
 - no grief monologue
 - no credits-only ending
 - no arcade pass/fail challenge during the Guitar Farewell
+- no explanatory departure speech; a tiny meow or translated fragment is
+  optional only if it stays smaller than the silence
+- no immediate replacement reveal; Micka remains delayed until the later
+  post-ending trigger
 
 ## Living Proof Gate
 
@@ -327,11 +335,16 @@ or briefly playing while the humans work. The counterpart cat can visually
 contrast with Cicka, such as a pale or white cat if Cicka reads dark, so that
 Micka's later half-and-half design feels quietly prepared. Do not name him,
 label him as Micka's father, or confirm parentage before the post-ending return.
-The player catches the sunset shuttle to Relay, and the later night festival can
-appear as a **Living Proof Montage** image during the **Guitar Farewell** instead
-of pulling the playable ending away from Cicka. The emotional lesson is that
-life can continue and new love can arrive after loss without replacing what was
-lost.
+The player catches the sunset shuttle to Relay through a **Short Threshold
+Transition**, not a controllable driving scene. The driver can say a small line
+such as "All aboard the last ride," the vehicle starts over a brief blackout,
+and the player respawns at Relay Spire under sunset. Control resumes at Cicka's
+overlook spot for the **Sit and Play Prompt** and **Guitar Farewell**. The later
+night festival can appear as a **Living Proof Montage** image during the
+farewell instead of pulling the playable ending away from Cicka. After the
+montage, Relay returns in **Relay Blue Hour** for the **Send the Sketchbook
+Prompt** rather than full night. The emotional lesson is that life can continue
+and new love can arrive after loss without replacing what was lost.
 
 ## Concert Crossing Beat
 

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -35,8 +35,10 @@ what is actually blocking progress, and why can this person help?
 The first ending path should be completable through conversations, collection,
 authored traversal interactions, Ridge Areas, Resident Beats, and visible world
 changes.
-Mini-games attach to the world as optional alternate paths, proof sources,
-rewards, shortcuts, or pure side fun.
+Mini-games attach to the world as optional fun, rewards, shortcuts, or future
+alternate ways to finish a level. They should not become required Living Proof
+or the default solution for main route blockers in the current first-ending
+route.
 
 ## Canonical Ending
 
@@ -90,6 +92,11 @@ world changes, proofs, and Cicka familiarity.
 The gate should feel like emotional and semantic readiness, not an exact visible
 checklist. The route to Relay should naturally provide enough resident help and
 cat familiarity for the first ending.
+
+Living Proof should come from the three required Ridge Areas and their
+Resident/world changes, not from optional mini-games or noticing changed Cicka
+Resting Spots. A resting spot is the emotional echo or memory of proof already
+earned elsewhere, not a separate proof token.
 
 ## Cicka
 
@@ -443,15 +450,15 @@ Mini-game ideas can attach to the Ridge without holding up the core path.
 
 Current candidates:
 
-- Potassium Slip: polished flagship secret/proof candidate.
-- Stampede Sketch: optional Vampire Survivors-style homage/proof candidate.
-- Telegraph / Clair-Obscur-style timing: optional timing/parry proof candidate.
+- Potassium Slip: polished flagship secret / future alternate-path candidate.
+- Stampede Sketch: optional Vampire Survivors-style homage / future alternate-path candidate.
+- Telegraph / Clair-Obscur-style timing: optional timing/parry future alternate-path candidate.
 - Concert guitar performance: small teaching toy for the guitar, with required
   non-arcade fallback.
 
-Mini-games may unlock alternate paths, extra proof, shortcuts, rewards, or just
-exist for fun. They should not become the default solution for main route
-blockers.
+Mini-games may unlock alternate paths, shortcuts, rewards, or just exist for
+fun. In the current first-ending route they are not required proof. Future
+passes can let them unlock alternate ways to finish a level.
 
 ## Open Design Slots
 

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -1,7 +1,12 @@
 # Ridge Story/Level Bible
 
-> Prose-first design artifact for the next Sketchbook Ridge direction. This file
-> should be accepted before a Ridge runtime or blockout rewrite starts.
+> Status: active route canon / in-progress design.
+> Prose-first design artifact for the active Sketchbook Ridge direction. Read
+> [`README.md`](./README.md) first for source-of-truth routing and
+> [`decision-intake.md`](./decision-intake.md) before folding in large grilling
+> or research transcripts. Track unresolved gaps in
+> [`open-questions.md`](./open-questions.md). Use
+> [`areas/`](./areas/README.md) for local area details.
 
 ## Status
 
@@ -142,9 +147,9 @@ Use practical design labels for these spots:
 
 | Area | Practical resting spot label | Before resolution | After resolution |
 | --- | --- | --- | --- |
-| Bridge Area | Bridge Resting Spot | Cicka perches near the unsafe crossing or blank plan | Cicka settles near the completed bridge sketch or leaves a tiny mark by the crossing |
-| Concert Area | Concert Resting Spot | Cicka watches the guitar case, stage edge, or blocked crossing | Cicka rests in a quiet listening corner near the opened crossing; this can later become the post-ending echo spot |
-| Dance Festival Area | Dance Festival Resting Spot | Cicka loafs near the operations table, shuttle step, lantern crates, or service gate | Cicka settles near the cleared service gate or finished shuttle sign, optionally beside the Unnamed Counterpart Cat |
+| [Bridge Area](./areas/01-bridge/README.md) | Bridge Resting Spot | Cicka perches near the unsafe crossing or blank plan | Cicka settles near the completed bridge sketch or leaves a tiny mark by the crossing |
+| [Concert Area](./areas/02-concert/README.md) | Concert Resting Spot | Cicka watches the guitar case, stage edge, or blocked crossing | Cicka rests in a quiet listening corner near the opened crossing; this can later become the post-ending echo spot |
+| [Dance Festival Area](./areas/03-dance-festival/README.md) | Dance Festival Resting Spot | Cicka loafs near the operations table, shuttle step, lantern crates, or service gate | Cicka settles near the cleared service gate or finished shuttle sign, optionally beside the Unnamed Counterpart Cat |
 
 ## Guitar
 
@@ -162,10 +167,12 @@ cleanly.
 
 ## Required Ridge Areas
 
-Start with 2-3 required main-path Ridge Areas before the first ending. Each
+Start with three required main-path Ridge Areas before the Relay ending. Each
 Ridge Area can contain one main Resident Beat plus local interiors, optional
-interactions, and runtime Phaser Scenes. Treat the exact count as a Level
-Designer and Story/Tone tuning variable.
+interactions, and runtime Phaser Scenes.
+
+Area-specific accepted details live in [`areas/`](./areas/README.md). Keep this
+bible focused on the route spine, cross-area dependencies, and ending logic.
 
 Current required route spine:
 
@@ -178,239 +185,37 @@ Relay Spire / Guitar Farewell -> I am ready for Cicka's threshold farewell.
 
 | Area | Resident Beat | Status | Route role | Cicka role | World change |
 | --- | --- | --- | --- | --- | --- |
-| Dance Festival Area | Opening Dance Shuttle Beat | Accepted final beat direction; Last-Stop Operations Helper locked as romantic partner role | Creates the last emotional readiness before Relay through afternoon setup for a night dance festival at the foot of the Relay hill | Quiet threshold observer near the lantern crates, operations table, shuttle step, or service gate; may loaf with the Unnamed Counterpart Cat | Festival setup clears enough for one last daylight shuttle to Relay before the night road closure |
-| Concert Area | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Points attention to guitar case, string, stage, or crossing | Concert continues; crossing opens; guitar entrusted to player |
-| Bridge Area | Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
+| [Bridge Area](./areas/01-bridge/README.md) | Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
+| [Concert Area](./areas/02-concert/README.md) | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Points attention to guitar case, string, stage, or crossing | Concert continues; crossing opens; guitar entrusted to player |
+| [Dance Festival Area](./areas/03-dance-festival/README.md) | Opening Dance Shuttle Beat | Accepted final beat direction; Last-Stop Operations Helper locked as romantic partner role | Creates the last emotional readiness before Relay through afternoon setup for a night dance festival at the foot of the Relay hill | Quiet threshold observer near the lantern crates, operations table, shuttle step, or service gate; may loaf with the Unnamed Counterpart Cat | Festival setup clears enough for one last daylight shuttle to Relay before the night road closure |
+| [Relay Ending Area](./areas/04-relay-ending/README.md) | Guitar Farewell / Cicka Threshold Farewell | Active ending direction | Final threshold after Living Proof is enough | Final field-presence spot and threshold departure | Open Ridge Return State preserves the final Relay mark and one quiet Concert echo |
 
 ## Opening Dance Shuttle Beat
 
-The **Dance Festival Area** should contain the final required Resident Beat,
-**Opening Dance Shuttle Beat**. It should be romantic, warm, and
-different from the Guitar Farewell. Two fictional residents like each other but are too
-nervous to step onto the dance floor or talk directly. The night dance festival
-is real, but the player participates in afternoon setup and leaves before the
-festival fully begins. The player helps make the event ready, prepares one
-nervous partner for a future dance, and helps the pair find enough rhythm to
-meet without turning the beat into public matchmaking.
+Detailed local contract:
+[`Dance Festival Area`](./areas/03-dance-festival/README.md).
 
-Accepted geography and blocker: the dance happens in a small town square,
-community hall, or festival street at the foot of the Relay hill, where a local
-dance night naturally belongs. The route to the Relay Spire is blocked by a
-practical final-approach problem: festival setup temporarily occupies the
-service road with barriers, lantern lines, chair stacks, stage/speaker cables,
-and a locked gate. Once setup is safe enough, the steward can open one short
-daylight window for the final hill shuttle before the road closes again for the
-night festival. The player helps the hill-shuttle driver, the Last-Stop
-Operations Helper, and nearby festival helpers finish that setup window, giving
-the driver a believable reason and means to take the player toward the Relay
-overlook at sunset.
+Accepted route summary: the player reaches **Last-Stop Plaza** at the foot of
+the Relay hill during afternoon setup for a night dance festival. Festival
+setup blocks the service road with barriers, lantern lines, chair stacks,
+stage/speaker cables, and a locked gate. The last daylight hill shuttle can
+leave only after the setup lane is safe.
 
-Accepted arrival premise: **Opening Dance Setup + Last Daylight Shuttle**. This
-replaces the previous after-festival **Last Song Table + Final Shuttle Hold**
-candidate. The stable spine is now:
+The player helps the **hill-shuttle driver** and **Last-Stop Operations Helper**
+through two dignity-preserving Readiness Favors: **One-Step Practice** for the
+driver and **Operations Handoff Check** for the helper. The connector is a
+small **Folded Song Request**, followed by a **Setup Clearance Walkthrough** that
+opens the service lane for the final ride to Relay.
 
-```text
-Last-Stop Plaza at the foot of the Relay hill.
-Festival setup blocks the service road.
-Sign: "Service road closes for night dance. Last daylight shuttle after setup check."
-```
-
-On arrival, the hill-shuttle driver stands beside the shuttle near the locked
-service-road gate, checking the same route clipboard too many times. He cannot
-drive yet because setup is still blocking the service lane and the steward will
-not open the barrier until the lane is safe. He is genuinely working the
-afternoon/evening event shuttle shift, but the clipboard is also a safe place to
-hide from asking one small question before the dance begins.
-
-The romantic partner is the shy **Last-Stop Operations Helper**. She works the
-visible plaza table that sits between the shuttle, dance setup, and service-road
-barrier: shuttle questions, setup checklist, lantern tags/signs, volunteer
-handoff, and radioing the steward when the lane is clear. She is not a flashy
-performer; she is the trusted local who keeps the last-stop plaza from becoming
-confused. Emotionally, the operations table lets her keep being useful instead
-of becoming visible enough to be asked to dance.
-
-Supporting static residents:
-
-- traveler near the plaza entry: points the player toward the shuttle and
-  explains that Relay requires the last daylight hill shuttle
-- festival steward near the barrier: explains that the service road opens only
-  after setup is safe and closes again when the night festival begins
-- **Dance Teacher** near the floor: offers gentle facilitation, teaches one small
-  step, covers the operations watch once setup is proven safe, and notices that
-  two shy people are orbiting each other, but is not the romance target
-
-Accepted discovery pattern: use a **Practical Wayfinding Loop**, not a quest
-giver. The player arrives asking how to reach Relay, notices the closed
-service-road barrier and shuttle sign, then learns from practical local roles
-that the final daylight shuttle leaves after setup passes inspection and before
-the road closes for the night dance.
-
-First-read sequence:
-
-```text
-Player arrives at Last-Stop Plaza.
-Festival barriers, lantern lines, and shuttle sign show the route is blocked.
-Traveler says Relay requires the last daylight hill shuttle.
-Driver is visible by the shuttle, stuck on the route clipboard.
-Operations helper is visible near the dance floor, stuck perfecting setup details.
-Steward explains that the road opens after setup check, then closes for night.
-```
-
-The player's natural question should be "How do I get to Relay?", not "How do I
-fix the romance?" The romantic problem should emerge only after the player asks
-why the last daylight shuttle is delayed and notices that the driver and
-operations helper are both hiding inside practical work.
-
-Accepted conversation discovery pattern: **Triangulated Discovery Flow**. The
-player should be able to talk to the driver and Last-Stop Operations Helper first and
-receive practical but incomplete answers:
-
-```text
-Driver: cannot leave until setup clears and the steward opens the service gate.
-Operations helper: cannot stop fixing setup details until someone trusted checks the handoff.
-```
-
-Both answers are true, but they do not explain why the two are hiding inside
-work instead of making a small social move. The player can then return to the
-plaza and ask nearby locals what is going on.
-
-Possible local reads:
-
-- traveler: "The driver's been rereading that clipboard for ten minutes."
-- festival steward: "The shuttle waits on the lane. She waits on one perfect
-  lantern. He waits on anything except asking."
-- **Dance Teacher**: "They both know where the floor is. They are practicing the
-  art of being unavailable."
-
-This lets the player piece together the relationship from public behavior and
-local observations rather than receiving an instant confession or omniscient
-quest explanation.
-
-The player should not be able to solve the beat immediately by confronting the
-driver and Last-Stop Operations Helper with "you like each other." That would likely make
-shy people defensive and would flatten the scene into forced matchmaking.
-Instead, Opening Dance should use two **Readiness Favors**, one for each
-romantic character, before the setup handoff, last daylight shuttle, and later
-night-dance promise can happen.
-
-Current readiness direction:
-
-- driver insecurity: he does not know how to dance and does not want to
-  embarrass himself in front of the Last-Stop Operations Helper
-- Last-Stop Operations Helper insecurity: if she stays useful behind an
-  organizer role, she knows who she is; if she steps onto the floor, she is just
-  someone hoping to be asked
-
-The Readiness Favors should let the player help each person feel prepared while
-preserving their dignity.
-
-- Last-Stop Operations Helper: **Operations Handoff Check**. The player helps
-  her prove the plaza setup is safe enough by checking a few visible festival
-  details, then getting the **Dance Teacher** to keep watch once the night dance
-  starts. The emotional point is not that someone else can plan better; it is
-  that she has done enough and the event can keep going while she enjoys it.
-- Hill-shuttle driver: **One-Step Practice**. The player helps him learn exactly
-  one tiny dance step from the **Dance Teacher**, privately enough to protect his
-  dignity. He does not become good at dancing; he gains one small shared rhythm
-  he can offer later.
-
-After both romantic characters are ready, the connector is **Folded Song
-Request**. The driver writes a tiny folded paper request at the operations
-table, requesting a simple, cute song and asking her for one dance later without
-making a public confession. The request should not lock the beat to bachata or
-any other specific dance genre; it should feel playable on guitar, simple enough
-for a non-dancer, and emotionally compatible with the later Guitar Farewell
-montage. The exact requested song does not need to be shown or heard by the
-player; the only presented music can be the guitar during the farewell. It can
-use her own event paper, handwriting marks, or song-request language so the ask
-feels rooted in her work rather than imposed by the player.
-
-Required relocation should stay minimal. After the player helps, the driver and
-Last-Stop Operations Helper can share or acknowledge the Folded Song Request,
-then return to their practical roles for the **Setup Clearance Walkthrough**:
-the remaining visible setup details clear the service lane enough for the
-steward to open the barrier and the driver to offer the last daylight ride
-toward Relay. Present this as a **Prompt-Driven Playable Montage**, not a full
-manual chore sequence or pure cutscene. The player chooses a prompt such as
-"Help with remaining preparations," then triggers a few authored interaction
-snaps. Default symbolic set: secure the lantern line, clear or tape the
-service-lane obstruction, and flip the shuttle sign to "Last daylight ride."
-Treat these as one-action story beats rather than small chore gameplay; they
-can collapse further if the beat needs to move faster. After the snaps, the sky
-warms, the plaza reads more ready, the **Dance Teacher** keeps watch, and the
-steward opens the gate. The actual dance can remain a promised night-festival
-moment and/or appear in the Guitar Farewell montage.
-
-Locked route-agent: the nervous dance resident is the **hill-shuttle driver**.
-He runs the last practical route up toward the Relay overlook, but he is stuck
-at the festival because the service road is not yet clear and because he cannot
-bring himself to ask about the night dance. His daily job, his emotional
-problem, and the player's route blocker should all point at the same practical
-situation. Do not assign him a proper name yet; the role label is enough until a
-later character pass.
-
-Locked romantic partner: the shy **Last-Stop Operations Helper**. She belongs in
-this place because her daily work sits between the dance, the service-road
-barrier, and the last daylight shuttle without requiring technical explanation.
-She likes the driver because he is quietly reliable: he waits for helpers to
-finish packing, remembers nervous passengers, and takes the hill road gently. He
-likes her because she notices small things and keeps the last-stop plaza feeling
-kind. Do not assign her a proper name yet; the role label is the canonical
-placeholder until her movement and emotional function are stable.
-
-The **Dance Teacher** exists as a facilitator rather than the romance target.
-They teach one small step, give the player social cover, cover the operations
-watch after the handoff, and notice that two shy people are orbiting each other.
-Avoid turning the beat into a competition for the teacher's attention unless a
-later tone pass proves it can stay gentle.
-
-Conversation design should use **Recoverable Conversation Choices**. The player
-should feel agency through what they ask, who they approach first, how they
-encourage the driver, and how they recover from a clumsy read. A failed path can
-create awkwardness, delay, or require extra listening, but it should not
-permanently block the first ending.
-
-Do not use a purely magical or abstract "dance crossing" explanation. This beat
-must answer:
-
-- where a dance naturally belongs in the final approach environment
-- what physical barricade prevents the player from reaching the Relay Spire
-- why the resident being helped has a believable reason and practical way to
-  help with that barricade
-- what small backstory or daily purpose makes each involved resident feel like a
-  local person rather than a route-solving robot
-
-The couple should be emotionally inspired by Danilo and Milena's story without
-being literal stand-ins. Protect the intimacy: carry the emotional truth through
-fictional residents, not a private memory exhibit.
-
-The main solution should be conversation, collection, and gentle setup. An
-optional dance/rhythm mini-game can deepen the beat later, but the first ending
-path should not depend on arcade performance.
-
-Cicka does not explain love or grief. She watches from the edge of the dance
-setup, perhaps walking through the cleared lane afterward as if the whole thing
-was obvious. She can also hang out with the **Unnamed Counterpart Cat** near the
-operations table or service gate: loafing together, staring at the same lantern,
-or briefly playing while the humans work. The counterpart cat can visually
-contrast with Cicka, such as a pale or white cat if Cicka reads dark, so that
-Micka's later half-and-half design feels quietly prepared. Do not name him,
-label him as Micka's father, or confirm parentage before the post-ending return.
-The player catches the sunset shuttle to Relay through a **Short Threshold
-Transition**, not a controllable driving scene. The driver can say a small line
-such as "All aboard the last ride," the vehicle starts over a brief blackout,
-and the player respawns at Relay Spire under sunset. Control resumes at Cicka's
-overlook spot for the **Sit and Play Prompt** and **Guitar Farewell**. The later
-night festival can appear as a **Living Proof Montage** image during the
-farewell instead of pulling the playable ending away from Cicka; the dancing can
-read as an emotional echo of the player's guitar rather than revealing or
-playing the actual requested festival song. After the
-montage, Relay returns in **Relay Blue Hour** for the **Send the Sketchbook
-Prompt** rather than full night. The emotional lesson is that life can continue
-and new love can arrive after loss without replacing what was lost.
+The beat should stay practical first and romantic second. The player's natural
+question is "How do I get to Relay?", while the shy dance promise emerges from
+local behavior and observation. The actual night dance can remain promised and
+then echo in the Guitar Farewell montage.
 
 ## Concert Crossing Beat
+
+Detailed local contract:
+[`Concert Area`](./areas/02-concert/README.md).
 
 A blocked concert/traffic crossing halts the route because the local guitarist
 cannot play, the paper-stage setup is tangled, or the guitar needs a small
@@ -425,6 +230,9 @@ Avoid making the guitarist a joke-only drunk if it undercuts the later tribute.
 Gentle comedy is welcome; the guitar's emotional role needs room to breathe.
 
 ## Blueprint Bridge
+
+Detailed local contract:
+[`Bridge Area`](./areas/01-bridge/README.md).
 
 The **Bridge Area** should contain the first required Resident Beat,
 **Blueprint Bridge**: a required art/drawing soft gate. It teaches:
@@ -462,9 +270,13 @@ passes can let them unlock alternate ways to finish a level.
 
 ## Open Design Slots
 
-- Dance Festival Area layout near Relay.
+Track unresolved gaps in [`open-questions.md`](./open-questions.md). Area-local
+slots live in the matching [`areas/`](./areas/README.md) file.
+
+Current cross-area hot spots:
+
 - Required resident cast names and silhouettes.
 - Optional resident cast and hangout spaces.
-- Guitar acquisition details inside Concert Crossing.
-- Exact Living Proof feedback when Relay is reachable but not ready.
+- Concert guitar acquisition as an ending dependency.
+- Living Proof feedback at Relay when it is reachable but not ready.
 - Return-to-Ridge state after the Cicka Threshold Farewell.

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -52,7 +52,8 @@ Accepted ending outline:
    light.
 5. A brief **Living Proof Montage** can appear during the guitar: Blueprint
    Bridge being used, Concert Crossing continuing, Opening Dance beginning at
-   night, and Cicka Home carrying accumulated marks.
+   night as an emotional echo under the player's guitar, and Cicka Home carrying
+   accumulated marks.
 6. Control returns in **Relay Blue Hour** at the Relay sign/spire for a **Send
    the Sketchbook Prompt**.
 7. Cicka walks with the player to the threshold, pauses, looks back once, leaves
@@ -264,7 +265,12 @@ preserving their dignity.
 
 After both romantic characters are ready, the connector is **Folded Song
 Request**. The driver writes a tiny folded paper request at the operations
-table, asking her for one dance later without making a public confession. It can
+table, requesting a simple, cute song and asking her for one dance later without
+making a public confession. The request should not lock the beat to bachata or
+any other specific dance genre; it should feel playable on guitar, simple enough
+for a non-dancer, and emotionally compatible with the later Guitar Farewell
+montage. The exact requested song does not need to be shown or heard by the
+player; the only presented music can be the guitar during the farewell. It can
 use her own event paper, handwriting marks, or song-request language so the ask
 feels rooted in her work rather than imposed by the player.
 
@@ -341,7 +347,9 @@ such as "All aboard the last ride," the vehicle starts over a brief blackout,
 and the player respawns at Relay Spire under sunset. Control resumes at Cicka's
 overlook spot for the **Sit and Play Prompt** and **Guitar Farewell**. The later
 night festival can appear as a **Living Proof Montage** image during the
-farewell instead of pulling the playable ending away from Cicka. After the
+farewell instead of pulling the playable ending away from Cicka; the dancing can
+read as an emotional echo of the player's guitar rather than revealing or
+playing the actual requested festival song. After the
 montage, Relay returns in **Relay Blue Hour** for the **Send the Sketchbook
 Prompt** rather than full night. The emotional lesson is that life can continue
 and new love can arrive after loss without replacing what was lost.

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -94,11 +94,41 @@ should wait until character art can support it cleanly.
 Start with 2-3 required main-path Resident Room Beats before the first ending.
 Treat the exact count as a Level Designer and Story/Tone tuning variable.
 
+Current required proof arc:
+
+```text
+Taped Bridge / Missing Plank -> I can change the world by making something through art.
+Concert Crossing -> I can turn memory into comfort.
+Last Dance / Bachata Crossing -> Life can keep moving with someone new.
+Relay Spire -> I am ready for Cicka's threshold farewell.
+```
+
 | Beat | Status | Route role | Cicka role | World change |
 | --- | --- | --- | --- | --- |
-| Final required Resident Room Beat | TBD | Creates the last readiness/insight before Relay | Quiet trust marker | TBD |
+| Last Dance / Bachata Crossing | Accepted final beat candidate | Creates the last emotional readiness before Relay through a nervous dance/romance setup | Quiet observer at the edge of the dance space | Dance crossing clears; path to Relay feels emotionally ready |
 | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Points attention to guitar case, string, stage, or crossing | Concert continues; crossing opens; guitar entrusted to player |
-| Taped Bridge / Missing Plank | Accepted first beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge | Bridge/crossing opens or is patched |
+| Taped Bridge / Missing Plank | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge | Bridge/crossing opens or is patched through drawing/art |
+
+## Last Dance / Bachata Crossing
+
+The final required Resident Room Beat should be romantic, warm, and different
+from the Guitar Farewell. Two fictional residents like each other but are too
+nervous to step onto the dance floor or talk directly. The player helps set up
+the dance event with the organizers, prepares one nervous partner for the dance,
+and helps the pair find enough rhythm to meet.
+
+The couple should be emotionally inspired by Danilo and Milena's story without
+being literal stand-ins. Protect the intimacy: carry the emotional truth through
+fictional residents, not a private memory exhibit.
+
+The main solution should be conversation, collection, and gentle setup. An
+optional dance/rhythm mini-game can deepen the beat later, but the first ending
+path should not depend on arcade performance.
+
+Cicka does not explain love or grief. She watches from the edge of the dance
+space, perhaps walking through the cleared crossing afterward as if the whole
+thing was obvious. The emotional lesson is that life can continue and new love
+can arrive after loss without replacing what was lost.
 
 ## Concert Crossing Beat
 
@@ -116,14 +146,17 @@ Gentle comedy is welcome; the guitar's emotional role needs room to breathe.
 
 ## Taped Bridge / Missing Plank
 
-The first Resident Room Beat should be a required soft gate. It teaches:
+The first Resident Room Beat should be a required art/drawing soft gate. It
+teaches:
 
 ```text
 Cicka noticed something -> a resident needs local help -> the route visibly changes
 ```
 
-Keep it tiny, obvious, and local. It should not feel like a fetch quest or a
-test of platforming skill.
+Possible solutions include drawing missing planks, sketching a paper fold,
+helping a resident finish a sign/blueprint, or collecting art scraps that let
+the crossing become real. Keep it tiny, obvious, and local. It should not feel
+like a fetch quest or a test of platforming skill.
 
 ## Mini-Game Entrances
 

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -8,16 +8,17 @@
 This bible is in-progress. It records resolved story, level-design, character,
 and progression decisions for the core Exploration Map route.
 
-Current design focus: work backward from the ending by detailing **Opening
-Dance Shuttle Beat** before Concert Crossing and Blueprint Bridge.
+Current design focus: work backward from the ending by detailing **Dance
+Festival Area / Opening Dance Shuttle Beat** before Concert Area / Concert
+Crossing Beat and Bridge Area / Blueprint Bridge.
 
 Design order:
 
 1. canonical first ending
 2. Living Proof Gate readiness
-3. final required Ridge Area / Resident Beat
-4. middle required Ridge Area / Resident Beat
-5. first required Ridge Area / Resident Beat
+3. Dance Festival Area / Opening Dance Shuttle Beat
+4. Concert Area / Concert Crossing Beat
+5. Bridge Area / Blueprint Bridge
 6. optional residents and Mini-Game Entrances
 
 ## Core Promise
@@ -130,21 +131,22 @@ Designer and Story/Tone tuning variable.
 Current required route spine:
 
 ```text
-Blueprint Bridge -> I can change the world by making something through art.
-Concert Crossing -> I can turn memory into comfort.
-Opening Dance Shuttle Beat -> Life can keep moving with someone new.
+Bridge Area / Blueprint Bridge -> I can change the world by making something through art.
+Concert Area / Concert Crossing Beat -> I can turn memory into comfort.
+Dance Festival Area / Opening Dance Shuttle Beat -> Life can keep moving with someone new.
 Relay Spire / Guitar Farewell -> I am ready for Cicka's threshold farewell.
 ```
 
-| Beat | Status | Route role | Cicka role | World change |
-| --- | --- | --- | --- | --- |
-| Opening Dance Shuttle Beat | Accepted final beat direction; Last-Stop Operations Helper locked as romantic partner role | Creates the last emotional readiness before Relay through afternoon setup for a night dance festival at the foot of the Relay hill | Quiet threshold observer near the lantern crates, operations table, shuttle step, or service gate; may loaf with the Unnamed Counterpart Cat | Festival setup clears enough for one last daylight shuttle to Relay before the night road closure |
-| Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Points attention to guitar case, string, stage, or crossing | Concert continues; crossing opens; guitar entrusted to player |
-| Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
+| Area | Resident Beat | Status | Route role | Cicka role | World change |
+| --- | --- | --- | --- | --- | --- |
+| Dance Festival Area | Opening Dance Shuttle Beat | Accepted final beat direction; Last-Stop Operations Helper locked as romantic partner role | Creates the last emotional readiness before Relay through afternoon setup for a night dance festival at the foot of the Relay hill | Quiet threshold observer near the lantern crates, operations table, shuttle step, or service gate; may loaf with the Unnamed Counterpart Cat | Festival setup clears enough for one last daylight shuttle to Relay before the night road closure |
+| Concert Area | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Points attention to guitar case, string, stage, or crossing | Concert continues; crossing opens; guitar entrusted to player |
+| Bridge Area | Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
 
 ## Opening Dance Shuttle Beat
 
-The final required Ridge Area / Resident Beat should be romantic, warm, and
+The **Dance Festival Area** should contain the final required Resident Beat,
+**Opening Dance Shuttle Beat**. It should be romantic, warm, and
 different from the Guitar Farewell. Two fictional residents like each other but are too
 nervous to step onto the dance floor or talk directly. The night dance festival
 is real, but the player participates in afternoon setup and leaves before the
@@ -385,8 +387,8 @@ Gentle comedy is welcome; the guitar's emotional role needs room to breathe.
 
 ## Blueprint Bridge
 
-The first Ridge Area / Resident Beat should be a required art/drawing soft
-gate. It teaches:
+The **Bridge Area** should contain the first required Resident Beat,
+**Blueprint Bridge**: a required art/drawing soft gate. It teaches:
 
 ```text
 Cicka noticed something -> a resident needs local help -> the route visibly changes
@@ -421,7 +423,7 @@ blockers.
 
 ## Open Design Slots
 
-- Final required Ridge Area / Resident Beat near Relay.
+- Dance Festival Area layout near Relay.
 - Required resident cast names and silhouettes.
 - Optional resident cast and hangout spaces.
 - Guitar acquisition details inside Concert Crossing.

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -108,18 +108,42 @@ as the canonical story-route anchor for the current linear three-beat shape;
 the existing Cicka Home blockout can remain a proof-of-concept implementation
 detail until the route is rewritten.
 
+Initial scope: keep these spots mostly visual. They can hold Cicka posture,
+changed-object memory, tiny marks, and later absence echoes without needing an
+interaction prompt. Do not add a dedicated resting-spot prompt in v0; keep the
+only explicit comfort prompt as **Sit and Play** at Relay for the **Guitar
+Farewell**. A later affection pass can add optional sitting together, petting,
+Cicka jumping into the player's lap, or Cicka loafing on the player while
+resting.
+
+Each resting spot should have two tiny visual states:
+
+- **Before area beat resolution**: Cicka uses the spot to draw attention to a
+  local problem, route blocker, or emotional handoff.
+- **After area beat resolution**: the spot becomes calmer through a settled
+  pose, tiny mark, changed prop, or quiet absence echo.
+
+Use practical design labels for these spots:
+
+| Area | Practical resting spot label | Before resolution | After resolution |
+| --- | --- | --- | --- |
+| Bridge Area | Bridge Resting Spot | Cicka perches near the unsafe crossing or blank plan | Cicka settles near the completed bridge sketch or leaves a tiny mark by the crossing |
+| Concert Area | Concert Resting Spot | Cicka watches the guitar case, stage edge, or blocked crossing | Cicka rests in a quiet listening corner near the opened crossing; this can later become the post-ending echo spot |
+| Dance Festival Area | Dance Festival Resting Spot | Cicka loafs near the operations table, shuttle step, lantern crates, or service gate | Cicka settles near the cleared service gate or finished shuttle sign, optionally beside the Unnamed Counterpart Cat |
+
 ## Guitar
 
 The guitar is a meaningful comfort item. It should enter mid-route through a
 Resident Beat as an entrusted reward or responsibility, not as a random
 pickup.
 
-After the player receives it, the guitar should become playable in quiet Ridge
-spots, especially local Cicka Resting Spots, so playing for Cicka at Relay feels
-remembered rather than staged.
+After the player receives it, the guitar should feel present as a carried
+comfort item, but v0 does not need repeatable guitar prompts at every resting
+spot. The required playable comfort moment is the Relay **Guitar Farewell**.
 
-Petting can be a smaller recurring affection interaction. A hug is optional and
-should wait until character art can support it cleanly.
+Petting, lap resting, and similar affection interactions are later polish
+passes. A hug is optional and should wait until character art can support it
+cleanly.
 
 ## Required Ridge Areas
 

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -94,20 +94,20 @@ should wait until character art can support it cleanly.
 Start with 2-3 required main-path Resident Room Beats before the first ending.
 Treat the exact count as a Level Designer and Story/Tone tuning variable.
 
-Current required proof arc:
+Current required route spine:
 
 ```text
-Taped Bridge / Missing Plank -> I can change the world by making something through art.
+Blueprint Bridge -> I can change the world by making something through art.
 Concert Crossing -> I can turn memory into comfort.
 Last Dance / Bachata Crossing -> Life can keep moving with someone new.
-Relay Spire -> I am ready for Cicka's threshold farewell.
+Relay Spire / Guitar Farewell -> I am ready for Cicka's threshold farewell.
 ```
 
 | Beat | Status | Route role | Cicka role | World change |
 | --- | --- | --- | --- | --- |
 | Last Dance / Bachata Crossing | Accepted final beat candidate | Creates the last emotional readiness before Relay through a nervous dance/romance setup | Quiet observer at the edge of the dance space | Dance crossing clears; path to Relay feels emotionally ready |
 | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Points attention to guitar case, string, stage, or crossing | Concert continues; crossing opens; guitar entrusted to player |
-| Taped Bridge / Missing Plank | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge | Bridge/crossing opens or is patched through drawing/art |
+| Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
 
 ## Last Dance / Bachata Crossing
 
@@ -144,7 +144,7 @@ collection, practice together, or forgiving auto-play.
 Avoid making the guitarist a joke-only drunk if it undercuts the later tribute.
 Gentle comedy is welcome; the guitar's emotional role needs room to breathe.
 
-## Taped Bridge / Missing Plank
+## Blueprint Bridge
 
 The first Resident Room Beat should be a required art/drawing soft gate. It
 teaches:
@@ -153,10 +153,16 @@ teaches:
 Cicka noticed something -> a resident needs local help -> the route visibly changes
 ```
 
-Possible solutions include drawing missing planks, sketching a paper fold,
-helping a resident finish a sign/blueprint, or collecting art scraps that let
-the crossing become real. Keep it tiny, obvious, and local. It should not feel
-like a fetch quest or a test of platforming skill.
+Current recommended solution: help a resident finish a tiny bridge
+drawing/blueprint, then the finished sketch becomes the crossing. Cicka can sit
+on or near the blank/missing part of the plan.
+
+Future optional upgrade: let the player draw directly on the bridge, either as
+a visual customization or a small physics/bridge-building toy. Do not make that
+the required v0 solution.
+
+Keep it tiny, obvious, and local. It should not feel like a fetch quest or a
+test of platforming skill.
 
 ## Mini-Game Entrances
 

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -113,7 +113,7 @@ Relay Spire / Guitar Farewell -> I am ready for Cicka's threshold farewell.
 
 | Beat | Status | Route role | Cicka role | World change |
 | --- | --- | --- | --- | --- |
-| Last Dance / Bachata Crossing | Accepted final beat candidate | Creates the last emotional readiness before Relay through the Last Ticket + Lantern Check at the foot of the Relay hill | Quiet observer near the unstamped ticket, shuttle step, or service gate | Lantern check completes; final shuttle ticket is stamped; festival barriers/service road clear |
+| Last Dance / Bachata Crossing | Accepted final beat candidate | Creates the last emotional readiness before Relay through the Last Song Table and Final Shuttle Hold at the foot of the Relay hill | Quiet observer near the song table, shuttle step, or service gate | Final song happens; shuttle lane clears; festival barriers/service road open |
 | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Points attention to guitar case, string, stage, or crossing | Concert continues; crossing opens; guitar entrusted to player |
 | Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
 
@@ -136,41 +136,43 @@ dance happen lets the organizers clear the street or reopen the service gate,
 and gives the helper a believable reason and means to take the player toward
 the Relay overlook.
 
-Locked arrival state: **Last Ticket + Lantern Check**.
+Locked arrival state: **Last Song Table + Final Shuttle Hold**.
 
 ```text
 Last-Stop Plaza at the foot of the Relay hill.
 Festival barriers block the service road.
-Sign: "Hill road closed during dance hour. Final shuttle leaves after lantern check."
+Sign: "Shuttle lane closed during final dance. Final hill shuttle after last song."
 ```
 
 On arrival, the hill-shuttle driver stands beside the shuttle near the locked
 service-road gate, checking the same route clipboard too many times. He cannot
-drive yet because the road is still closed, the hill lantern check is not
-signed, and the last-stop clerk has not stamped the final ticket batch. He is
-working, but the work is also a safe place to hide from asking for one small
+drive yet because the festival dance uses the service lane and the steward will
+not open the barrier until the last song finishes and the lane is cleared. He
+is working, but the work is also a safe place to hide from asking for one small
 dance.
 
-The lantern/ticket clerk stays at the ticket and lantern booth, closing the
-last-shuttle ledger and checking hill-lantern tokens. She needs the driver's
-route confirmation before she can stamp the final tickets. He needs her lantern
-clearance before he can drive. Their jobs literally require them to coordinate,
-which lets the romance grow out of the plaza's real closing procedure.
+The romantic partner is the shy **last-stop song-table volunteer**. She handles
+the final song table near the dance floor: song slips, basic festival timing,
+and last-shuttle questions. She is not a flashy performer; she is the trusted
+local who keeps the final dance from becoming confused. She cannot easily step
+away because if nobody covers the table, the final song stalls and the shuttle
+lane cannot clear. Emotionally, the table lets her watch the dance while staying
+useful enough not to feel visible.
 
 Supporting static residents:
 
 - traveler near the plaza entry: points the player toward the shuttle and
   explains that Relay requires the last hill shuttle
 - festival steward near the barrier: explains that the service road opens only
-  after the final dance/lantern check closes cleanly
-- dance teacher near the floor: offers gentle facilitation and possibly one
-  small step, but is not the romance target
+  after the final dance ends and the lane is clear
+- dance teacher near the floor: can cover the song table for one song, offer
+  gentle facilitation, and possibly teach one small step, but is not the romance
+  target
 
 Accepted discovery pattern: use a **Practical Wayfinding Loop**, not a quest
 giver. The player arrives asking how to reach Relay, notices the closed
 service-road barrier and shuttle sign, then learns from practical local roles
-that the final shuttle is delayed because the last ticket and lantern check are
-unfinished.
+that the final shuttle leaves after the last song and the lane-clearing handoff.
 
 First-read sequence:
 
@@ -179,43 +181,65 @@ Player arrives at Last-Stop Plaza.
 Closed service-road barrier and shuttle sign show the route is blocked.
 Traveler says Relay requires the last hill shuttle.
 Driver is visible by the shuttle, stuck on the route clipboard.
-Clerk is visible at the booth, stuck on the lantern/ticket ledger.
-Steward explains that the road opens after the final check.
+Song-table volunteer is visible near the dance floor, stuck sorting song slips.
+Steward explains that the road opens after the final song and lane clear.
 ```
 
 The player's natural question should be "How do I get to Relay?", not "How do I
 fix the romance?" The romantic problem should emerge only after the player asks
-why the last shuttle is delayed and notices that the driver and clerk need each
-other's sign-off.
+why the last shuttle is delayed and notices that the driver and song-table
+volunteer are both hiding inside practical work.
 
 Accepted conversation discovery pattern: **Triangulated Discovery Flow**. The
-player should be able to talk to the driver and clerk first and receive
-practical but incomplete answers:
+player should be able to talk to the driver and song-table volunteer first and
+receive practical but incomplete answers:
 
 ```text
-Driver: cannot leave until the lantern check is cleared.
-Clerk: cannot stamp the last tickets until the route is confirmed.
+Driver: cannot leave until the final song ends and the lane clears.
+Song-table volunteer: cannot step away unless someone trusted covers the table.
 ```
 
-Both answers are true, but they do not explain why the two are avoiding the
-simple act of coordinating. The player can then return to the plaza and ask
-nearby locals what is going on.
+Both answers are true, but they do not explain why the two are hiding inside
+work instead of making a small social move. The player can then return to the
+plaza and ask nearby locals what is going on.
 
 Possible local reads:
 
 - traveler: "The driver's been rereading that clipboard for ten minutes."
-- festival steward: "Those two need to sign the same last-run sheet.
-  Separately, apparently."
-- dance teacher: "They both know the steps. They are pretending the paperwork
-  is harder."
+- festival steward: "The shuttle waits on the last song. She waits on someone
+  else to press play. He waits on anything except asking."
+- dance teacher: "They both know where the floor is. They are pretending work
+  is the hard part."
 
 This lets the player piece together the relationship from public behavior and
 local observations rather than receiving an instant confession or omniscient
 quest explanation.
 
+The player should not be able to solve the beat immediately by confronting the
+driver and song-table volunteer with "you like each other." That would likely
+make shy people defensive and would flatten the scene into forced matchmaking.
+Instead, Last Dance should use two **Readiness Favors**, one for each romantic
+character, before the final song, shy dance, and lane-clearing handoff can
+happen.
+
+Current readiness direction:
+
+- driver insecurity: he does not know how to dance and does not want to
+  embarrass himself in front of the song-table volunteer
+- song-table volunteer insecurity: if she stays behind the table, she is useful;
+  if she steps onto the floor, she is just someone hoping to be asked
+
+The Readiness Favors should let the player help each person feel prepared while
+preserving their dignity. Her likely favor is **Cover the Last Song Table for
+One Song**: the player gets the dance teacher or steward to cover the table, so
+she can step away without abandoning the event. After both are ready, a small
+romantic connector such as a shy song request, folded note, or indirect
+invitation can make the final step feel romantic without becoming a public
+confession puzzle.
+
 Required relocation should stay minimal. After the player helps, the driver and
-clerk can move once to the edge of the dance floor for a shy final dance, then
-return to the shuttle/booth roles so the clerk stamps the final ticket, the
+song-table volunteer can move once to the edge of the dance floor for a shy
+final dance, then return to their practical roles so the final song ends, the
 steward clears the barrier, and the driver offers the ride toward Relay.
 
 Locked route-agent: the nervous dance resident is the **hill-shuttle driver**.
@@ -224,10 +248,10 @@ at the festival because the street is still closed and because he cannot bring
 himself to step onto the floor. His daily job, his emotional problem, and the
 player's route blocker should all point at the same practical situation.
 
-Locked romantic partner: the shy **last-stop lantern/ticket clerk**. She stamps
-last-shuttle tickets, helps close the festival street, and sets or checks the
-lanterns for the hill road. She belongs in this place because her daily work
-sits exactly between the dance, the service-road barrier, and the final shuttle.
+Locked romantic partner: the shy **last-stop song-table volunteer**. She helps
+run the event from the song table, answers last-shuttle questions, and keeps the
+final song handoff from stalling. She belongs in this place because her daily
+work sits between the dance, the service-road barrier, and the final shuttle.
 She likes the driver because he is quietly reliable: he waits for her to finish
 packing, remembers nervous passengers, and takes the hill road gently. He likes
 her because she notices small things and keeps the last-stop plaza feeling

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -15,9 +15,9 @@ Design order:
 
 1. canonical first ending
 2. Living Proof Gate readiness
-3. final required Resident Room Beat
-4. middle required Resident Room Beat
-5. first required Resident Room Beat
+3. final required Ridge Area / Resident Beat
+4. middle required Ridge Area / Resident Beat
+5. first required Ridge Area / Resident Beat
 6. optional residents and Mini-Game Entrances
 
 ## Core Promise
@@ -32,7 +32,8 @@ place, a physical blockage, and a resident relationship: where does this happen,
 what is actually blocking progress, and why can this person help?
 
 The first ending path should be completable through conversations, collection,
-authored traversal interactions, Resident Room Beats, and visible world changes.
+authored traversal interactions, Ridge Areas, Resident Beats, and visible world
+changes.
 Mini-games attach to the world as optional alternate paths, proof sources,
 rewards, shortcuts, or pure side fun.
 
@@ -52,16 +53,18 @@ Accepted ending outline:
    light.
 5. A brief **Living Proof Montage** can appear during the guitar: Blueprint
    Bridge being used, Concert Crossing continuing, Opening Dance beginning at
-   night as an emotional echo under the player's guitar, and Cicka Home carrying
-   accumulated marks.
+   night as an emotional echo under the player's guitar, and earlier Cicka
+   Resting Spots carrying accumulated marks.
 6. Control returns in **Relay Blue Hour** at the Relay sign/spire for a **Send
    the Sketchbook Prompt**.
 7. Cicka walks with the player to the threshold, pauses, looks back once, leaves
    one final paw/page mark, then slips into a page fold or light beyond the
-   player's path.
+   player's path. The initial version uses no translated farewell line.
 8. The player returns to the **Open Ridge Return State** after the ending, with
-   the final mark preserved, Cicka's absence felt through favorite spots or
-   marks, and the world still open.
+   the canonical final mark preserved at the Relay threshold, one quieter echo
+   at the Concert Resting Spot, and the world still open. The echo is the
+   empty usual spot plus one small paw/page mark, not the player's guitar left
+   behind.
 
 Tone boundaries:
 
@@ -69,10 +72,13 @@ Tone boundaries:
 - no grief monologue
 - no credits-only ending
 - no arcade pass/fail challenge during the Guitar Farewell
-- no explanatory departure speech; a tiny meow or translated fragment is
-  optional only if it stays smaller than the silence
+- no explanatory departure speech and no written goodbye in the initial version;
+  a tiny raw meow/chirp sound is optional only if it stays smaller than the
+  silence
 - no immediate replacement reveal; Micka remains delayed until the later
   post-ending trigger
+- no scattering sad marks everywhere in the initial return state; use the Relay
+  threshold mark plus one quiet Concert Resting Spot echo first
 
 ## Living Proof Gate
 
@@ -87,32 +93,39 @@ cat familiarity for the first ending.
 ## Cicka
 
 Cicka is a recurring field presence, not a continuous follower or objective
-giver. Required Resident Room Beats should include authored Cicka appearances,
+giver. Required Ridge Areas should include authored Cicka appearances,
 but her role should evolve:
 
 - early: subtle attention cue near an obstacle
 - middle: observer of a changed object or resident moment
 - late: quiet trust marker near the threshold
 
-Cicka Home remains a progress memory space, not the only emotional anchor.
+Each required Ridge Area should include one local **Cicka Resting
+Spot**: a small perch, loafing place, or quiet seat where Cicka can be present
+without making the player return to a central hub. This replaces **Cicka Home**
+as the canonical story-route anchor for the current linear three-beat shape;
+the existing Cicka Home blockout can remain a proof-of-concept implementation
+detail until the route is rewritten.
 
 ## Guitar
 
 The guitar is a meaningful comfort item. It should enter mid-route through a
-Resident Room Beat as an entrusted reward or responsibility, not as a random
+Resident Beat as an entrusted reward or responsibility, not as a random
 pickup.
 
 After the player receives it, the guitar should become playable in quiet Ridge
-spots, especially Cicka Home, so playing for Cicka at Relay feels remembered
-rather than staged.
+spots, especially local Cicka Resting Spots, so playing for Cicka at Relay feels
+remembered rather than staged.
 
 Petting can be a smaller recurring affection interaction. A hug is optional and
 should wait until character art can support it cleanly.
 
-## Required Resident Room Beats
+## Required Ridge Areas
 
-Start with 2-3 required main-path Resident Room Beats before the first ending.
-Treat the exact count as a Level Designer and Story/Tone tuning variable.
+Start with 2-3 required main-path Ridge Areas before the first ending. Each
+Ridge Area can contain one main Resident Beat plus local interiors, optional
+interactions, and runtime Phaser Scenes. Treat the exact count as a Level
+Designer and Story/Tone tuning variable.
 
 Current required route spine:
 
@@ -131,8 +144,8 @@ Relay Spire / Guitar Farewell -> I am ready for Cicka's threshold farewell.
 
 ## Opening Dance Shuttle Beat
 
-The final required Resident Room Beat should be romantic, warm, and different
-from the Guitar Farewell. Two fictional residents like each other but are too
+The final required Ridge Area / Resident Beat should be romantic, warm, and
+different from the Guitar Farewell. Two fictional residents like each other but are too
 nervous to step onto the dance floor or talk directly. The night dance festival
 is real, but the player participates in afternoon setup and leaves before the
 festival fully begins. The player helps make the event ready, prepares one
@@ -293,7 +306,8 @@ He runs the last practical route up toward the Relay overlook, but he is stuck
 at the festival because the service road is not yet clear and because he cannot
 bring himself to ask about the night dance. His daily job, his emotional
 problem, and the player's route blocker should all point at the same practical
-situation.
+situation. Do not assign him a proper name yet; the role label is enough until a
+later character pass.
 
 Locked romantic partner: the shy **Last-Stop Operations Helper**. She belongs in
 this place because her daily work sits between the dance, the service-road
@@ -301,7 +315,8 @@ barrier, and the last daylight shuttle without requiring technical explanation.
 She likes the driver because he is quietly reliable: he waits for helpers to
 finish packing, remembers nervous passengers, and takes the hill road gently. He
 likes her because she notices small things and keeps the last-stop plaza feeling
-kind.
+kind. Do not assign her a proper name yet; the role label is the canonical
+placeholder until her movement and emotional function are stable.
 
 The **Dance Teacher** exists as a facilitator rather than the romance target.
 They teach one small step, give the player social cover, cover the operations
@@ -370,8 +385,8 @@ Gentle comedy is welcome; the guitar's emotional role needs room to breathe.
 
 ## Blueprint Bridge
 
-The first Resident Room Beat should be a required art/drawing soft gate. It
-teaches:
+The first Ridge Area / Resident Beat should be a required art/drawing soft
+gate. It teaches:
 
 ```text
 Cicka noticed something -> a resident needs local help -> the route visibly changes
@@ -406,7 +421,7 @@ blockers.
 
 ## Open Design Slots
 
-- Final required Resident Room Beat near Relay.
+- Final required Ridge Area / Resident Beat near Relay.
 - Required resident cast names and silhouettes.
 - Optional resident cast and hangout spaces.
 - Guitar acquisition details inside Concert Crossing.

--- a/docs/game-design/ridge/summit.md
+++ b/docs/game-design/ridge/summit.md
@@ -1,802 +1,115 @@
 # Sketchbook Ridge Summit
 
-> Concept / production vision. This is the post-competition direction for the
-> playable portfolio game. Shipped behavior still belongs in
-> [`player-manual.md`](../player-manual.md).
+> Product vision for Ridge pre-production.
+> This file protects fantasy, pillars, taste, and scope instincts for the
+> desired game rework. Active route canon lives in
+> [`story-level-bible.md`](./story-level-bible.md) and [`areas/`](./areas/README.md).
+> Shipped behavior belongs in [`player-manual.md`](../player-manual.md).
 
-## Team Frame
+Status: accepted vision. This is not a route implementation spec, backlog, or
+runtime snapshot.
 
-- **Level Designer**: owns the playable world, pacing, and scope.
-- **Story / Tone Designer**: protects warmth, manga sketchbook tone, and the feeling that the world remembers Danilo.
-- **Systems / Production Designer**: protects input simplicity, Phaser/React boundaries, and build order.
-- **Character Designer**: protects NPC silhouettes, interaction charm, and the feeling that the ridge is inhabited.
+Legacy/prototype summit notes moved to
+[`legacy/prototype-summit.md`](./legacy/prototype-summit.md).
 
-The competition winner remains **Sketchbook Ridge**. The production direction is:
+## Product Thesis
 
-> Use Ridge as the playable spine, Summit as the architecture discipline, and
-> Archipelago's stickers as the visible reward language.
+Danilo crosses a compact hand-drawn ridge inside his own sketchbook, helping
+small resident moments come alive across Bridge, Concert, Dance Festival, and
+Relay. The ending should feel like shipping something alive and saying goodbye
+with care, not like completing a checklist.
 
-## Target Player
+The primary audience is Danilo on laptop and mobile phone. Tune for his taste
+first: compact exploration, readable secrets, handmade manga intimacy,
+low-cortisol traversal, optional high-spice toys, and funny-sad sincerity.
 
-The primary audience is **Danilo on laptop and mobile phone**.
+## Active Route
 
-Other people may play it, but the game should be tuned for Danilo's taste first:
+The first complete route is:
 
-- compact exploration like *A Short Hike*
-- readable secrets and manual-page epiphanies like *Tunic*
-- ricochet/run synergy like *Ball x Pit*, already represented by Potassium Slip
-- active timing and parry joy like *Clair Obscur*
-- deterministic toy-system cleverness like *Divinity: Original Sin 2*
-- optional movement mastery like *Hollow Knight*
-- neutral/spacing mind games from fighting games
-- silly substory seriousness like *Yakuza: Like a Dragon*
-- hand-drawn manga intimacy, with *Oyasumi Punpun* as a taste signal for personal, sketchy, funny-sad honesty
-
-## One-Sentence Game
-
-Danilo explores a compact hand-drawn ridge inside his own sketchbook, climbing toward the Relay Spire by playing short hobby mini-games, earning stamps and stickers that visibly change the world, while Potassium Slip remains the flagship arcade secret.
-
-## Core Fantasy
-
-This is **Danilo's tiny private mountain**, not a portfolio theme park.
-
-The goal is to reach the **Relay Spire** and "send the sketchbook." On paper, that means shipping the portfolio. Emotionally, it means noticing that the unfinished jokes, hobbies, game tastes, tools, and half-serious obsessions already form a coherent world. Cicka is the emotional spine of that realization: she starts as a tiny resident, becomes the guide who teaches the player how to notice the Ridge, and makes the first ending a quiet farewell and tribute rather than only a contact/credits beat.
-
-The current static portfolio-building model is not the long-term fantasy. The
-better version is a **scrambled sketchbook**: Danilo's pages, tools, memories,
-and proofs are out of order. The player learns Danilo by restoring meaning
-through play, not by opening resume modals. Basement, Potassium Slip, and the
-Glasses re-read effect are strong anchors; generic information buildings should
-eventually be absorbed into artifacts, mini-games, Cicka notes, manual pages,
-and local Cicka Resting Spot changes.
-
-The ending should not say "you became perfect." It should say:
-
-> You shipped something alive.
-
-It should also say, softly:
-
-> Thank you for walking with me.
-
-## Fun Pillars
-
-1. **One Ridge, Many Returns**  
-   The overworld is one compact side-view route with shortcuts and changed landmarks, not a huge map.
-
-2. **Opt-In Toys**  
-   Mini-games are entered from clear hobby props. The player always knows what they are opting into, how long it takes, and what it might reward.
-
-3. **Potassium Owns Ricochet**  
-   Potassium Slip is the Ball x Pit lane. Do not build a second ricochet scene near it.
-
-4. **Stickers Change The World**  
-   Rewards are visible on return: patched planks, inked-in signs, doodled arrows, new margin jokes, background characters, and route readability.
-
-5. **Low-Cortisol Overworld, High-Spice Mini-Games**  
-   The ridge is calm, curious, and forgiving. Mini-games can be intense, but they are short and replayable.
-
-6. **Mobile Is Real**  
-   No required input pattern should depend on keyboard-only dexterity. Every scene needs a touch-first control plan.
-
-7. **Never Hike Alone**  
-   The ridge should have a small cast of memorable NPCs and one very important cat presence, so exploration feels companionable instead of empty.
-
-8. **Learn Danilo By Restoring The Sketchbook**  
-   Portfolio facts should be discovered as objects, mementos, skills, jokes,
-   manual insights, and lived scenes. Avoid turning the Ridge into buildings
-   that open static information modals.
-
-## Overworld Plan
-
-The overworld is a side-view ridge that can be crossed quickly once learned.
-Long-term, it should use **Hollow Knight topology, A Short Hike mood, and
-Tunic re-reading**: connected 2D side-view rooms/screens, vertical shafts,
-shortcut relief, gentle movement rewards, and old props becoming newly legible.
-The player sees the Relay Spire early, like a destination silhouette.
-
-Do not pivot the main world toward top-down, isometric, or 3D-like exploration
-without a deliberate future spike. Phaser's 2D strengths fit a layered
-side-view Ridge better, and the current Ridge shell should grow into that
-direction rather than being discarded.
-
-### Zone 1: Outskirts / Trailhead
-
-Purpose: orient the player and connect to existing shipped content.
-
-Landmarks:
-
-- current street / city edge
-- Developer Basement hatch
-- Glasses pickup and "re-read the world" moment
-- Potassium hint object
-- early scrambled-sketchbook artifacts that replace generic portfolio buildings
-- Cicka's first perch
-- first distant view of Relay Spire
-
-Design beat:
-
-The current street should become the **Outskirts** rather than being replaced immediately. Before Glasses, the ridge feels like a rough sketch with a few obvious prompts. After Glasses, certain props jitter, margin notes appear, and the banana/Potassium path becomes legible.
-
-The current building/modal portfolio pattern should be treated as transitional.
-Outskirts should eventually teach Danilo through found objects and playable
-memory beats: tools on the ground, half-labeled project artifacts, Cicka
-reactions, and manual scraps that make old props readable after a return.
-
-### Zone 2: Hobby Ridge
-
-Purpose: the main opt-in mini-game strip.
-
-Landmarks:
-
-- picnic blanket / ink swarm entrance for **Stampede Sketch**
-- cliffside bag or terrace for **Telegraph Terrace**
-- messy desk / service elevator for **Domino Desk**
-- manual scraps tucked into signs, nests, vending machines, or printer jams
-- low crawlspaces and scent marks that only make sense after Cicka teaches the player how to notice them
-- optional sparring notebook and scratch shaft entrances later
-
-Level shape:
-
-- 3 to 5 screens wide at first
-- one main clockwise trail
-- one late vertical shortcut shaft
-- no separate biomes in v1
-- palette shifts through ink density, paper texture, and stickers rather than new tile sets
-- future expansion can add double-jump / wall-cling style mobility, but the
-  main path should stay low-cortisol and mobile-feasible
-- the first Cicka farewell ending should not require wall cling or double jump;
-  save those as optional or later topology payoffs unless a mobile control
-  spike proves they are effortless
-
-### Zone 3: Relay Spire / Farewell Peak
-
-Purpose: final shipping/contact/credits route, and the first Cicka farewell.
-
-Gate:
-
-- for the current first-ending route, the three required Ridge Areas and their
-  resident/world changes should provide enough Living Proof
-- plus one Cicka / translator / manual insight that decodes the Relay sign
-- Relay Spire can be physically reachable before the gate is ready; the blocker
-  is that the sketchbook does not have enough living proof to send yet.
-- Treat these as proof categories, not an exact visible checklist. The path to
-  Relay should itself create enough resident help, world change, and Cicka
-  familiarity for the first ending.
-- Optional mini-games are fun, rewards, shortcuts, or future alternate ways to
-  finish a level; they are not required proof for the current first ending.
-- Local Cicka Resting Spot changes are memory and emotional continuity, not
-  separate Living Proof Gate tokens.
-
-The gate should feel earned but not tedious. It should not require every
-mini-game or every optional mastery scene, but it should ask the player to spend
-real time with the Ridge before the farewell.
-
-Ending beat:
-
-- Cicka accompanies the player to the Relay Spire as a guide to a threshold.
-- The player understands she is going somewhere the player cannot follow.
-- Before the final send, the player can play guitar for Cicka as the last
-  ordinary shared comfort moment. This should echo the guitar's earlier story
-  role and visual Cicka Resting Spot presence rather than requiring repeatable
-  resting-spot guitar interactions in the initial route.
-- The farewell is tender but not literal-heavy: no on-screen death scene, no long grief speech.
-- Cicka leaves a final paw mark or page mark, and the Ridge remains replayable after the ending.
-- Design this as the canonical first ending. Do not add multiple endings unless
-  a later story/level pass proves an alternate ending creates meaningful replay
-  value without diluting the Cicka farewell.
-- Micka, a small kitten/child presence, appears only after the player returns
-  to the normal Ridge and completes or replays one mini-game post-ending, not
-  during the ending sequence.
-
-## Main Loop
-
-1. Walk the ridge.
-2. Notice a landmark.
-3. Find an artifact, prop, or scrambled memory.
-4. Read a **Trail Card** overlay when the prop leads to an opt-in scene.
-5. Enter the mini-game, inspect the artifact, or keep hiking.
-6. Clear, fail, or quit back to ridge.
-7. Receive a stamp, manual page, sticker, memento, shortcut, or glide pip.
-8. Revisit the landmark or a local Cicka Resting Spot and see that the
-   sketchbook changed.
-
-The repeatable pleasure is not just "new content." It is returning to the same place and feeling that the sketchbook remembers.
-
-## Reward Language
-
-- **Stamps**: durable record that a hobby scene was cleared.
-- **Stickers**: visible world changes. These are the emotional reward.
-- **Manual Pages**: one-screen clues that reinterpret a route, sign, or mechanic.
-- **Artifacts**: found personal objects, tools, scraps, or odd props that teach
-  Danilo through context instead of static profile text. Major work/project
-  artifacts should be easy to notice; smaller skill scraps such as languages,
-  libraries, and tools can be tucked into optional re-read details.
-- **Mementos**: small memory objects from mini-games that physically change a
-  local Cicka Resting Spot or nearby landmark. They are memory and relationship,
-  not currency.
-- **Glide Pips**: movement upgrades inspired by *A Short Hike* feathers.
-- **Shortcuts**: route changes inspired by *Hollow Knight* relief moments.
-- **Circuit**: Potassium Slip's major reward and a possible future alternate-path proof. Derive this from the existing inventory item instead of duplicating `potassium.circuitOwned` in progress.
-- **Cicka Notes**: tiny cat-side observations that reinterpret nearby props without becoming a full language system.
-- **Developer Laptop**: a future portable or resting-spot-adjacent terminal that
-  extends the Basement computer fantasy. It may support debug/dev commands and
-  artifact inspection after the player has the right key and Glasses, but it
-  should not make typing mandatory for mobile progression.
-
-Bridge-owned progress should stay small and serializable. Exact naming should follow the current bridge store shape. A likely implementation is to extend `BridgeProgressState` with a `ridge` object and add explicit award actions:
-
-```ts
-type RidgeProgress = {
-  stamps: string[];
-  manualPages: string[];
-  mobility: {
-    glidePips: number;
-  };
-  shortcuts: string[];
-};
+```text
+Bridge Area / Blueprint Bridge
+  -> Concert Area / Concert Crossing Beat
+  -> Dance Festival Area / Opening Dance Shuttle Beat
+  -> Relay Spire / Guitar Farewell / Cicka Threshold Farewell
 ```
 
-Stickers can be derived from stamps/manual pages until there is a proven need to store them separately.
-
-## Mini-Game Roadmap
-
-### 0. Potassium Slip
-
-Status: existing flagship.
-
-Role:
-
-- anchor secret
-- Ball x Pit fun already captured
-- possible future alternate-path proof through Circuit, not required for the
-  current first ending
-- benchmark for mini-game depth and documentation
-
-Do:
-
-- keep Circuit as a major reward and possible future alternate-path hook
-- let Ridge signs and NPCs acknowledge Potassium
-- preserve vertical-board controls
-
-Do not:
-
-- add another ricochet scene
-- build a generic arcade framework because Potassium is large
-- make every future mini-game as deep as Potassium
-
-### 1. Stampede Sketch
-
-First new mini-game.
-
-Inspiration: *Vampire Survivors*.
-
-Theme: Danilo is chased by inky ideas, deadline icons, and overexcited notebook
-creatures around a picnic blanket. Nearby enemies chase Danilo; enemies that
-lose his attention may drift toward the blanket and crowd the calm patch.
-
-Purpose: protect one calm picnic-blanket patch from a stampede of runaway ideas.
-See [`stampede-sketch.md`](../mini-games/stampede-sketch.md) for the active narrative and
-asset brief.
-
-Core verb: **Kite**.
-
-Controls:
-
-- laptop: WASD/arrows
-- mobile: drag-to-move or virtual stick
-- attacks are automatic
-
-First-slice scope:
-
-- 60-90 second internal prototype, then expand to a 3-minute fixed run
-- one arena
-- capped enemy count
-- 3 auto-attacks
-- 3 upgrade choices per level
-- one first-clear glide pip
-- simple results overlay
-
-Why first:
-
-- fastest fun read
-- mobile-friendly
-- balances Potassium's skill-heavy ricochet with low-input chaos
-- easy to tune as a lunch-break toy
-
-### 2. Telegraph Terrace
-
-Second priority if Muay Thai / reactive combat becomes the next obsession.
-
-Inspiration: *Clair Obscur* plus Muay Thai pad work.
-
-Theme: a cliffside training terrace where a sketchy coach, heavy bag, or `TODO: AI` dummy treats a tiny sparring session like a world-title bout.
-
-Core verb: **Parry**.
-
-Controls:
-
-- one large parry button
-- optional dodge/jump later
-- clear audio and visual telegraphs
-- assist timing mode for mobile
-
-First version:
-
-- three short enemy "verses"
-- successful parries build Tempo
-- Tempo powers a simple counter-combo
-- misses cost confidence, not a long restart
-
-Keep it small:
-
-- no full party system
-- no AP encyclopedia
-- no frame-data lab in v1
-
-The fun is that enemy turns are not waiting. They are performance.
-
-### 3. Margin Manual Hunt
-
-Inspiration: *Tunic*.
-
-Theme: torn sketchbook pages explain things the player has been walking past.
-
-Core verb: **Re-see**.
-
-Controls:
-
-- pure overworld interaction
-- React Manual overlay with large readable pages
-
-Rules:
-
-- each page fits on one screen
-- each page teaches one idea
-- no ARG, no cryptography homework
-- manual pages should make Danilo say "oh, wait" rather than "I need a spreadsheet"
-
-Use this to support the Relay Spire gate.
-
-### 4. Cicka Daydream
-
-Optional small mini-scene / Ridge modifier.
-
-Inspiration: the wish to understand Cicka for a day, *A Short Hike* low-stakes movement, and *Tunic* re-reading familiar places.
-
-Theme: Cicka says "meow" and the whole Ridge briefly admits that this is probably a complete sentence.
-
-Core verb: **Notice**.
-
-Controls:
-
-- laptop: move, jump, interact/meow
-- mobile: drag or swipe movement, tap to meow/interact
-- no precision platforming
-
-First version:
-
-- 90-second cat daydream
-- play as Cicka on a tiny version of the Ridge
-- crawl under two props Danilo cannot enter
-- follow scent/sound trails instead of quest markers
-- knock one small object into a new place
-- unlock one Cicka Note or sticker when the daydream ends
-
-Kitty translator rule:
-
-- before translator: Cicka dialogue is only "meow", posture, timing, and punctuation
-- after translator: subtitles are affectionate guesses, not perfect literal speech
-- examples: "meow" becomes "this box has historical importance" or "you are standing on the good paper"
-
-Keep it small:
-
-- no full pet system
-- no cat inventory
-- no permanent second campaign
-- no complex animal-language grammar
-- no required resting-spot affection system in the initial route
-- no dedicated Cicka Resting Spot prompts before a later affection pass
-
-Why it belongs:
-
-- it makes the world less lonely
-- it turns a personal real-life presence into a playable secret
-- it supports the core Ridge idea: new knowledge makes old places different
-
-### 5. Domino Desk
-
-Inspiration: *Divinity: Original Sin 2* surfaces and deterministic systems.
-
-Theme: a messy desk battlefield with coffee rings, tape, staples, sticky notes, and overheated laptop tiles.
-
-Core verb: **Push-turn**.
-
-Controls:
-
-- tap/select piece
-- swipe cardinal direction
-- undo for fat-finger mistakes
-
-First version:
-
-- two compact puzzles
-- deterministic chain reactions
-- no stats
-- no dice
-- reward: service elevator shortcut
-
-The fun is feeling clever, not managing a CRPG.
-
-### 6. Neutral Notebook
-
-Inspiration: fighting games.
-
-Theme: Danilo spars with an onion-paper sketch of his past self.
-
-Core verb: **Poke**.
-
-Controls:
-
-- move/backdash macro zones
-- one poke button
-- one dash button
-- no motion inputs
-
-Keep:
-
-- spacing
-- whiff punish
-- corner tension
-- three-hit rounds
-
-Avoid:
-
-- combo trials
-- netcode
-- full character roster
-
-This is a later scene because the design tuning is subtle.
-
-### 7. Shaft of Scratches
-
-Inspiration: *Hollow Knight* pogo mastery.
-
-Theme: a scratchy utility shaft with doodled hazards.
-
-Core verb: **Pogo**.
-
-Controls:
-
-- jump
-- air-tap/down-strike bounce
-- generous coyote time
-
-Role:
-
-- optional skill souvenir
-- unlocks a satisfying shortcut rope
-
-This should be small and slightly spicy. It should never block the main ending.
-
-## NPC And Dialogue Tone
-
-The tone is **warm weirdos with tiny stakes delivered like destiny**.
-
-Character Designer rule: every NPC should be readable by silhouette first, voice second, and function third. If an NPC exists only to explain a menu, it should be a sign instead.
-
-Examples:
-
-- A training dummy named `TODO: AI` demands an honorable duel before it has implemented legs.
-- A clipboard officer treats banana ricochets as workplace law.
-- A ridge guide gives sincere advice, then worries about font licensing.
-- A printer oracle speaks in jammed paper prophecies.
-- A tiny NPC takes a sticker placement dispute more seriously than the finale.
-- Cicka says "meow" with the emotional specificity of a 900-page novel.
-
-Rules:
-
-- short dialogue
-- sincere under the joke
-- no generic portfolio exposition
-- no recruiter-facing sales pitch
-- the bit should reveal a real Danilo taste, habit, hobby, or worry
-- the cast should stay tiny; no NPC schedules until static characters already feel alive
-
-## Character Layer
-
-Characters should make the Ridge feel inhabited without turning the project into an RPG.
-
-### Cast Size
-
-First target:
-
-- **Cicka**: cat, translator mystery, companionable re-seeing of the Ridge.
-- **Ridge Guide**: gentle A Short Hike-style orientation and small encouragement.
-- **Potassium Compliance Officer**: already the absurd authority of the banana arcade world.
-- **TODO: AI**: training dummy / sparring partner for Telegraph Terrace or Neutral Notebook.
-- **Printer Oracle**: manual-page hint giver, dramatic about paper jams.
-
-That is enough for v1. More characters should arrive only when a new mini-game needs a face.
-
-### Interaction Shape
-
-Each NPC gets:
-
-- one first-meeting line
-- one post-stamp line
-- one optional joke or vulnerability line
-- one clear interaction affordance if they launch a scene or overlay
-
-No NPC should require a dialogue tree in v1. The goal is presence, not conversation management.
-
-### Cicka
-
-Cicka should feel like a real tiny resident of the sketchbook, not a mascot pasted on top.
-
-Behavior:
-
-- appears on perches, boxes, warm laptop vents, and suspiciously important paper
-- sometimes blocks a path for no reason until the player returns with a sticker or manual clue
-- reacts to cleared mini-games with new "meow" punctuation
-- leaves paw-print margin marks near hidden details
-- grows from side resident into the emotional guide for the first ending
-- leaves through a symbolic farewell at the Relay Spire, toward somewhere the player cannot follow
-
-Design:
-
-- small black-ink silhouette with very readable tail shapes
-- stepped animation: blink, loaf, stretch, suspicious turn, tiny hop
-- subtitles should use paper-cut dialogue bubbles, but only after the translator moment
-
-Ending and tribute rule:
-
-- Cicka's farewell is a tribute beat, not a literal death scene.
-- Use presence, absence, paw marks, silence, and optionally a tiny raw sound
-  instead of translated farewell text or heavy exposition in the initial ending.
-- After the ending, the Ridge remains open for replay. Cicka's canonical final
-  mark should persist at the Relay threshold, with one quieter echo at the
-  Concert Resting Spot for the initial return state. The echo is the empty usual
-  spot plus one small paw/page mark, not the player's guitar left behind.
-- Micka appears after the player returns to the Ridge from completing or
-  replaying one post-ending mini-game. She is continuity, not replacement.
-
-Translator fantasy:
-
-The kitty translator is not a universal decoder. It is a playful empathy device. It teaches the player that Cicka has been commenting on the Ridge the whole time, but the translations are intentionally a little questionable.
-
-Good translations:
-
-- "This cardboard is load-bearing."
-- "You forgot to smell the shortcut."
-- "The banana place is loud in a legally interesting way."
-- "Nap here and the world becomes 12% more true."
-
-Bad direction:
-
-- long exposition
-- exact lore dumps
-- Cicka solving puzzles for the player
-- making Cicka sound like a normal human
-
-## Manga And Sketchbook Feel
-
-The style guide remains **Digital Sketchbook**: off-white paper, black ink, hand-drawn silhouettes, paper-cut UI, stepped animation.
-
-The manga influence should come through as:
-
-- panel-like compositions for Trail Cards and Manual Pages
-- expressive black shapes and negative space
-- funny-sad little observations in margins
-- a handmade feeling that tolerates roughness
-
-Use the *Oyasumi Punpun* taste signal carefully. The goal is not to make the portfolio bleak. The useful ingredient is the contrast: simple drawings can carry real interior feeling.
-
-## Level Design Rules
-
-1. The Relay Spire must be visible early.
-2. A landmark should be readable by silhouette before text explains it.
-3. Every first clear should change the ridge visually.
-4. Backtracking must get faster after rewards.
-5. Falling should not punish the player in the overworld.
-6. No main-path jump should require precision platforming.
-7. Optional mastery paths can be hard, but must be clearly optional.
-8. A mobile player should be able to reach the first Trail Card within one minute.
-9. Long-term topology should stay 2D side-view and interconnected, not
-   top-down/isometric by default.
-10. Wall cling / double jump are desirable long-term movement flavors, but not
-    required gates for the first farewell ending.
-
-## Architecture Rules For This Plan
-
-Respect the current React + Phaser architecture:
-
-- **Scenes** are Phaser worlds.
-- **Overlays** are React surfaces.
-- **Triggers** are scene-owned.
-- Durable cross-scene progress belongs in the bridge store.
-- Trail Cards, Manual Pages, upgrade choices, and results screens are React overlays through `OverlayHost`.
-- Mini-games should be separate scene folders, not modes inside one mega-scene.
-- Do not introduce a generic mini-game framework until at least three shipped scenes prove repeated pain.
-- Arcade scenes with direct pointer input should intentionally use a non-`portrait-cover` presentation mode so they do not sit under the mobile gesture overlay. Potassium already uses `vertical-board`; future scenes should extend scene presentation policy deliberately.
-- If Ridge glide needs touch-hold behavior, add durable touch state such as `jumpHeld` or `glideHeld`, not another one-shot. Make glide opt-in for Ridge so Hobbies/Basement do not inherit it by accident.
-
-Likely folders when implementation starts:
-
-- Proposed Ridge scene folder.
-- Proposed Stampede Sketch scene folder.
-- Proposed Telegraph Terrace scene folder.
-- Proposed Cicka Daydream scene folder, only if the cat daydream becomes a separate scene.
-- Proposed Domino Desk scene folder.
-- scene-local overlays under each scene's `overlays/`
-- shared/global Manual or Trail Card overlays only if repeated use justifies it
-
-## Development Plan
-
-### Slice 0: Production Baseline
-
-Goal: make the current state legible before adding more.
-
-Tasks:
-
-- treat Potassium Slip as the mini-game benchmark
-- document the final expected Circuit reward path from existing inventory ownership
-- decide the minimal bridge progress keys
-- confirm current return-to-overworld behavior and overlay pause behavior still work
-
-Done when:
-
-- Potassium can be referenced by future Ridge gates without ambiguity
-- there is no new architecture invented for hypothetical mini-games
-- the plan is clear that mini-game run state stays inside each scene, while the bridge stores only durable rewards
-
-### Slice 1: Ridge Shell
-
-Goal: make the main game shape playable.
-
-Tasks:
-
-- add a compact side-view Ridge scene
-- show Relay Spire silhouette
-- add three landmark triggers with Trail Cards
-- place Cicka's first perch and one static NPC who makes the Ridge feel inhabited
-- support return to Ridge from child scenes
-- add placeholder sticker changes for cleared content
-
-Done when Danilo can:
-
-- enter the Ridge
-- see the destination
-- interact with at least three hobby props
-- back out without losing place
-- understand that mini-games are optional
-
-### Slice 2: Stampede Sketch
-
-Goal: ship the first new mini-game.
-
-Tasks:
-
-- implement move-only survivor arena
-- add automatic attacks
-- add XP pickups and three-choice upgrades
-- cap entities for phone performance
-- add results overlay
-- reward first clear with one glide pip and a visible sticker
-
-Done when:
-
-- the first 60 seconds are fun without reading instructions
-- a mobile player can survive through movement alone
-- clearing it changes traversal or visuals on the Ridge
-
-### Slice 3: Ridge Memory
-
-Goal: make rewards emotionally visible.
-
-Tasks:
-
-- sticker layer changes signs, planks, background doodles, or route hints
-- one shortcut opens
-- glide pip affects overworld movement
-- manual page overlay explains one existing sign
-- first Cicka Note, memory reaction, or pre-translator interaction makes an old
-  prop feel newly readable
-
-Done when:
-
-- returning to the Ridge after a clear feels different
-- the player can explain what changed without opening an inventory
-
-### Slice 4: Telegraph Terrace
-
-Goal: test the Muay Thai / Clair Obscur direction at indie scope.
-
-Tasks:
-
-- build one-button parry scene
-- use 3 short attack patterns
-- successful defense builds Tempo
-- Tempo triggers a clear counter
-- add assist timing mode
-- reward a manual page for Relay rhythm glyphs
-
-Done when:
-
-- defense feels active
-- missing is recoverable
-- the scene works with one thumb
-
-### Slice 5: Relay Spire First Ending
-
-Goal: close the loop with Cicka as the emotional spine.
-
-Tasks:
-
-- add final gate logic
-- require the three required Ridge Areas / resident-world changes as the current
-  first-ending proof spine
-- require one Cicka / translator / manual insight
-- add short ending overlay / paper-cut farewell beat
-- return player to Ridge after ending
-- keep mini-games replayable after the ending
-- introduce Micka after the player returns from completing or replaying one
-  post-ending mini-game, not inside the ending sequence
-
-Done when:
-
-- Danilo can finish a complete route in roughly 20 to 35 minutes
-- the ending feels like shipping a living sketchbook and saying goodbye with care
-
-## Design Validation
-
-Before adding another mini-game, the current build should pass these checks:
-
-- Danilo smiles before any long text explains the premise.
-- The Ridge is memorable enough to describe from memory.
-- Phone controls do not feel like a compromise.
-- Every mini-game has one sentence, one verb, one reward.
-- The first reward visibly changes the world.
-- The first NPC interaction makes the Ridge feel less lonely without starting a dialogue tree.
-- Potassium still feels special.
-- The main ending does not require beating the hardest optional scene.
+The existing folded/Cicka Home/platformer-like Phaser Ridge can donate useful
+runtime lessons, asset experiments, validation ideas, and tooling patterns. It
+does not dictate the desired route shape.
+
+## Pillars
+
+1. **One Ridge, Many Returns**
+   The world is compact and memorable. Returning to the same place should feel
+   different because the sketchbook remembers.
+2. **Resident Help Before Checklist**
+   Required progress should read as people and places changing, not as visible
+   chores or arcade gates.
+3. **Low-Cortisol Main Route**
+   The first ending should not require precision platforming, wall jumps,
+   double jumps, or difficult mini-game clears.
+4. **Opt-In Toys**
+   Mini-games and hobby props can be rich, spicy, replayable, and rewarding, but
+   they are side fun or future alternate-path candidates by default.
+5. **Cicka Is The Emotional Spine**
+   Cicka is a small resident, field presence, comfort ritual, and threshold
+   guide. She is not a mascot button, quest token, or exposition machine.
+6. **Digital Sketchbook**
+   Off-white paper, black ink, silhouette clarity, stepped motion, margin humor,
+   and sticker-like world changes carry the identity.
+7. **Mobile Is Real**
+   Every required route interaction needs a touch-first plan.
+
+## Ending Promise
+
+The ending order is protected:
+
+1. Living Proof readiness
+2. Cicka appears at the Relay threshold
+3. Guitar Farewell at sunset
+4. Send the Sketchbook Prompt in blue hour
+5. Cicka Threshold Farewell
+6. Open Ridge Return State
+
+The farewell is a tribute beat, not a literal-heavy explanation. Use presence,
+absence, paw marks, silence, guitar, and the return-state Ridge to carry it.
+
+Micka appears after the player returns to normal Ridge and completes or replays
+one post-ending mini-game. She is continuity, not replacement, and should not
+enter the ending sequence itself.
+
+## Optional Toy Stance
+
+Potassium Slip remains the flagship arcade secret and a useful benchmark for
+mini-game depth. Stampede Sketch, Telegraph Terrace, Cicka Daydream, Domino
+Desk, Neutral Notebook, and similar ideas are candidates, not required proof for
+the first ending unless route canon explicitly reopens that.
+
+Before adding or prioritizing another mini-game, ask whether Bridge, Concert,
+Dance Festival, Relay, Living Proof feedback, and the Cicka farewell are clearer
+than they were before.
 
 ## Scope Cuts
 
-Cut or defer these until the core loop is proven:
+Defer these until the first route is proven:
 
-- full fighting-game engine
-- full Clair Obscur party/AP system
-- full Tunic cipher language
-- second ricochet mini-game
 - large overworld map
-- top-down/isometric overworld pivot before a dedicated spike
-- multi-biome asset set
 - generic mini-game framework
-- meta-progression shop
-- complex NPC schedules
 - required precision platforming
+- required mini-game clears for first ending
+- complex NPC schedules or dialogue trees
+- multi-ending structure
+- full translator grammar or Cicka pet system
+- top-down/isometric overworld pivot without a deliberate spike
 
-## Current Open Knobs For Danilo
+## Taste Checks
 
-These are the choices to iterate on next:
+The route is on track when:
 
-- **Tone mix**: default to 70% goofy, 30% quiet ache.
-- **Avatar**: Danilo-as-Danilo, a sketchbook stand-in, or a tiny abstract mascot.
-- **First ending length**: default to 20 to 35 minutes.
-- **Next mini-game after Stampede**: default to Muay Thai / Telegraph Terrace.
-- **Manual difficulty**: default to one-screen aha clues, no real cipher.
-- **Cicka timing**: default to first perch in Slice 1, translator/daydream after Ridge Memory proves return play.
-- **World scale**: default to one ridge before any new area.
-
-## Level Designer Verdict
-
-Build the smallest version that already feels like the real game:
-
-1. a visible Relay Spire
-2. a compact ridge
-3. Potassium as the secret arcade anchor
-4. Stampede Sketch as the first new opt-in toy
-5. stickers that make the ridge remember
-6. Cicka's first perch, so the sketchbook is not lonely
-
-That is enough for the game to have a soul before it has a backlog.
+- Danilo can describe the Ridge from memory
+- the Relay Spire is visible early and emotionally legible late
+- each required resident help beat changes the route or staging
+- Cicka feels present before she becomes important
+- the ending feels tender without overexplaining itself
+- optional toys feel inviting without stealing the main spine

--- a/docs/game-design/ridge/summit.md
+++ b/docs/game-design/ridge/summit.md
@@ -157,6 +157,11 @@ Gate:
 - at least three major clears / proofs, with Potassium Circuit counting as one
   proof rather than a solo bypass
 - plus one Cicka / translator / manual insight that decodes the Relay sign
+- Relay Spire can be physically reachable before the gate is ready; the blocker
+  is that the sketchbook does not have enough living proof to send yet.
+- Treat these as proof categories, not an exact visible checklist. The path to
+  Relay should itself create enough resident help, world change, and Cicka
+  familiarity for the first ending.
 
 The gate should feel earned but not tedious. It should not require every
 mini-game or every optional mastery scene, but it should ask the player to spend
@@ -164,10 +169,16 @@ real time with the Ridge before the farewell.
 
 Ending beat:
 
-- Cicka is present at the Relay Spire as a guide to a threshold.
+- Cicka accompanies the player to the Relay Spire as a guide to a threshold.
 - The player understands she is going somewhere the player cannot follow.
+- Before the final send, the player can play guitar for Cicka as the last
+  ordinary shared comfort moment. This should echo earlier Cicka Home/Ridge
+  guitar interactions rather than appearing only at the ending.
 - The farewell is tender but not literal-heavy: no on-screen death scene, no long grief speech.
 - Cicka leaves a final paw mark or page mark, and the Ridge remains replayable after the ending.
+- Design this as the canonical first ending. Do not add multiple endings unless
+  a later story/level pass proves an alternate ending creates meaningful replay
+  value without diluting the Cicka farewell.
 - Micka, a small kitten/child presence, appears only after the player returns
   to the normal Ridge and completes or replays one mini-game post-ending, not
   during the ending sequence.

--- a/docs/game-design/ridge/summit.md
+++ b/docs/game-design/ridge/summit.md
@@ -172,8 +172,9 @@ Ending beat:
 - Cicka accompanies the player to the Relay Spire as a guide to a threshold.
 - The player understands she is going somewhere the player cannot follow.
 - Before the final send, the player can play guitar for Cicka as the last
-  ordinary shared comfort moment. This should echo earlier Cicka Resting Spot
-  or quiet Ridge guitar interactions rather than appearing only at the ending.
+  ordinary shared comfort moment. This should echo the guitar's earlier story
+  role and visual Cicka Resting Spot presence rather than requiring repeatable
+  resting-spot guitar interactions in the initial route.
 - The farewell is tender but not literal-heavy: no on-screen death scene, no long grief speech.
 - Cicka leaves a final paw mark or page mark, and the Ridge remains replayable after the ending.
 - Design this as the canonical first ending. Do not add multiple endings unless
@@ -388,6 +389,8 @@ Keep it small:
 - no cat inventory
 - no permanent second campaign
 - no complex animal-language grammar
+- no required resting-spot affection system in the initial route
+- no dedicated Cicka Resting Spot prompts before a later affection pass
 
 Why it belongs:
 

--- a/docs/game-design/ridge/summit.md
+++ b/docs/game-design/ridge/summit.md
@@ -154,14 +154,18 @@ Purpose: final shipping/contact/credits route, and the first Cicka farewell.
 
 Gate:
 
-- at least three major clears / proofs, with Potassium Circuit counting as one
-  proof rather than a solo bypass
+- for the current first-ending route, the three required Ridge Areas and their
+  resident/world changes should provide enough Living Proof
 - plus one Cicka / translator / manual insight that decodes the Relay sign
 - Relay Spire can be physically reachable before the gate is ready; the blocker
   is that the sketchbook does not have enough living proof to send yet.
 - Treat these as proof categories, not an exact visible checklist. The path to
   Relay should itself create enough resident help, world change, and Cicka
   familiarity for the first ending.
+- Optional mini-games are fun, rewards, shortcuts, or future alternate ways to
+  finish a level; they are not required proof for the current first ending.
+- Local Cicka Resting Spot changes are memory and emotional continuity, not
+  separate Living Proof Gate tokens.
 
 The gate should feel earned but not tedious. It should not require every
 mini-game or every optional mastery scene, but it should ask the player to spend
@@ -200,19 +204,19 @@ The repeatable pleasure is not just "new content." It is returning to the same p
 
 ## Reward Language
 
-- **Stamps**: durable proof that a hobby scene was cleared.
+- **Stamps**: durable record that a hobby scene was cleared.
 - **Stickers**: visible world changes. These are the emotional reward.
 - **Manual Pages**: one-screen clues that reinterpret a route, sign, or mechanic.
 - **Artifacts**: found personal objects, tools, scraps, or odd props that teach
   Danilo through context instead of static profile text. Major work/project
   artifacts should be easy to notice; smaller skill scraps such as languages,
   libraries, and tools can be tucked into optional re-read details.
-- **Mementos**: small proof objects from mini-games that physically change a
+- **Mementos**: small memory objects from mini-games that physically change a
   local Cicka Resting Spot or nearby landmark. They are memory and relationship,
   not currency.
 - **Glide Pips**: movement upgrades inspired by *A Short Hike* feathers.
 - **Shortcuts**: route changes inspired by *Hollow Knight* relief moments.
-- **Circuit**: Potassium Slip's major reward and one major proof toward the Relay Spire gate. Derive this from the existing inventory item instead of duplicating `potassium.circuitOwned` in progress.
+- **Circuit**: Potassium Slip's major reward and a possible future alternate-path proof. Derive this from the existing inventory item instead of duplicating `potassium.circuitOwned` in progress.
 - **Cicka Notes**: tiny cat-side observations that reinterpret nearby props without becoming a full language system.
 - **Developer Laptop**: a future portable or resting-spot-adjacent terminal that
   extends the Basement computer fantasy. It may support debug/dev commands and
@@ -244,12 +248,13 @@ Role:
 
 - anchor secret
 - Ball x Pit fun already captured
-- one major proof toward the first ending through Circuit
+- possible future alternate-path proof through Circuit, not required for the
+  current first ending
 - benchmark for mini-game depth and documentation
 
 Do:
 
-- integrate the Circuit into Ridge progression as one major proof
+- keep Circuit as a major reward and possible future alternate-path hook
 - let Ridge signs and NPCs acknowledge Potassium
 - preserve vertical-board controls
 
@@ -728,8 +733,8 @@ Goal: close the loop with Cicka as the emotional spine.
 Tasks:
 
 - add final gate logic
-- require at least three major clears / proofs, with Potassium Circuit counting
-  as one proof
+- require the three required Ridge Areas / resident-world changes as the current
+  first-ending proof spine
 - require one Cicka / translator / manual insight
 - add short ending overlay / paper-cut farewell beat
 - return player to Ridge after ending

--- a/docs/game-design/ridge/summit.md
+++ b/docs/game-design/ridge/summit.md
@@ -48,7 +48,7 @@ and proofs are out of order. The player learns Danilo by restoring meaning
 through play, not by opening resume modals. Basement, Potassium Slip, and the
 Glasses re-read effect are strong anchors; generic information buildings should
 eventually be absorbed into artifacts, mini-games, Cicka notes, manual pages,
-and visible Cicka Home changes.
+and local Cicka Resting Spot changes.
 
 The ending should not say "you became perfect." It should say:
 
@@ -172,8 +172,8 @@ Ending beat:
 - Cicka accompanies the player to the Relay Spire as a guide to a threshold.
 - The player understands she is going somewhere the player cannot follow.
 - Before the final send, the player can play guitar for Cicka as the last
-  ordinary shared comfort moment. This should echo earlier Cicka Home/Ridge
-  guitar interactions rather than appearing only at the ending.
+  ordinary shared comfort moment. This should echo earlier Cicka Resting Spot
+  or quiet Ridge guitar interactions rather than appearing only at the ending.
 - The farewell is tender but not literal-heavy: no on-screen death scene, no long grief speech.
 - Cicka leaves a final paw mark or page mark, and the Ridge remains replayable after the ending.
 - Design this as the canonical first ending. Do not add multiple endings unless
@@ -192,8 +192,8 @@ Ending beat:
 5. Enter the mini-game, inspect the artifact, or keep hiking.
 6. Clear, fail, or quit back to ridge.
 7. Receive a stamp, manual page, sticker, memento, shortcut, or glide pip.
-8. Return to Cicka Home or revisit the landmark and see that the sketchbook
-   changed.
+8. Revisit the landmark or a local Cicka Resting Spot and see that the
+   sketchbook changed.
 
 The repeatable pleasure is not just "new content." It is returning to the same place and feeling that the sketchbook remembers.
 
@@ -206,13 +206,14 @@ The repeatable pleasure is not just "new content." It is returning to the same p
   Danilo through context instead of static profile text. Major work/project
   artifacts should be easy to notice; smaller skill scraps such as languages,
   libraries, and tools can be tucked into optional re-read details.
-- **Mementos**: small proof objects from mini-games that physically change
-  Cicka Home. They are memory and relationship, not currency.
+- **Mementos**: small proof objects from mini-games that physically change a
+  local Cicka Resting Spot or nearby landmark. They are memory and relationship,
+  not currency.
 - **Glide Pips**: movement upgrades inspired by *A Short Hike* feathers.
 - **Shortcuts**: route changes inspired by *Hollow Knight* relief moments.
 - **Circuit**: Potassium Slip's major reward and one major proof toward the Relay Spire gate. Derive this from the existing inventory item instead of duplicating `potassium.circuitOwned` in progress.
 - **Cicka Notes**: tiny cat-side observations that reinterpret nearby props without becoming a full language system.
-- **Developer Laptop**: a future portable or Cicka Home-adjacent terminal that
+- **Developer Laptop**: a future portable or resting-spot-adjacent terminal that
   extends the Basement computer fantasy. It may support debug/dev commands and
   artifact inspection after the player has the right key and Glasses, but it
   should not make typing mandatory for mobile progression.
@@ -542,8 +543,12 @@ Design:
 Ending and tribute rule:
 
 - Cicka's farewell is a tribute beat, not a literal death scene.
-- Use presence, absence, paw marks, and one or two translated lines instead of heavy exposition.
-- After the ending, the Ridge remains open for replay, and Cicka's final mark should persist.
+- Use presence, absence, paw marks, silence, and optionally a tiny raw sound
+  instead of translated farewell text or heavy exposition in the initial ending.
+- After the ending, the Ridge remains open for replay. Cicka's canonical final
+  mark should persist at the Relay threshold, with one quieter echo at the
+  Concert Resting Spot for the initial return state. The echo is the empty usual
+  spot plus one small paw/page mark, not the player's guitar left behind.
 - Micka appears after the player returns to the Ridge from completing or
   replaying one post-ending mini-game. She is continuity, not replacement.
 


### PR DESCRIPTION
## Summary
- Reoriented Ridge planning around the new pre-production route: Bridge -> Concert -> Dance Festival -> Relay / Cicka farewell
- Split active source-of-truth docs from legacy prototype material so agents can quickly tell what to read, what to update, and what is historical
- Updated ADR, design, and agent guidance so runtime/prototype decisions do not override the active Ridge route canon
- Reworked Summit and Milestone planning into shorter active docs and moved older prototype history into `ridge/legacy/`
- Clarified that optional mini-games are side fun / reward candidates, not required first-ending Living Proof

## Testing
- `git diff --check`
- Markdown link validation across the updated docs set
- No runtime tests run (docs-only change)