### PR TITLE
Refine Ridge pre-production docs and ending flow

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -261,22 +261,23 @@ _Avoid_: companion AI, quest marker, follower pet, objective dispenser
 
 **Cicka Threshold Farewell**:
 The first ending beat where Cicka accompanies the player to the Relay Spire
-threshold, looks back, leaves one final paw/page mark, then slips into a page
-fold or light beyond the player's path without translated farewell text in the
-initial version.
+threshold, looks back, then slips into a page fold, light, or other threshold
+beyond the player's path without translated farewell text in the initial
+version. Any final trace should be treated as optional visual staging only if
+the route has already taught that language.
 _Avoid_: literal death scene, grief monologue, Cicka leaving with the player, written goodbye
 
 **Open Ridge Return State**:
 The immediate post-ending Ridge state where the world remains playable with the
-canonical final mark at the Relay threshold and one quiet echo at the Concert
-Resting Spot before any later Micka trigger; the echo should read as an empty
-usual spot with one small paw/page mark, not the player's guitar left behind.
+farewell complete, the guitar still with the player, and any minimal absence
+echo treated as visual staging rather than a required mark mechanic before any
+later Micka trigger.
 _Avoid_: closed ending, sad objective, immediate replacement reveal, scattered sadness marks, abandoned inventory
 
 **Guitar Farewell**:
-The final shared Cicka moment where the player plays guitar for her at the Relay
-Spire, echoing the visual presence, tiny marks, and accumulated memory from
-Cicka Resting Spots across the Ridge.
+The final shared Cicka moment where the player chooses Sit and Play at the Relay
+Spire, plays the familiar Concert guitar phrase for her, and commits to the
+ending through a quiet, short, non-arcade farewell sequence.
 _Avoid_: generic music mini-game, melodrama, one-off ending prop
 
 **Concert Guitar**:
@@ -291,9 +292,9 @@ and play a tiny guitar phrase without changing route progression.
 _Avoid_: hidden required prompt, affection checklist, extra proof token
 
 **Sit and Play Prompt**:
-The final Relay Spire interaction that starts the Guitar Farewell when the
-player chooses to sit near Cicka and play guitar.
-_Avoid_: rhythm UI, fail state, final skill check, objective popup
+The final Relay Spire interaction that starts the Guitar Farewell and commits to
+the first ending when the player chooses to sit near Cicka and play guitar.
+_Avoid_: rhythm UI, fail state, final skill check, objective popup, unseeded second ending prompt
 
 **Living Proof Montage**:
 A previous name for the brief ending montage, now better treated as **Route
@@ -302,7 +303,7 @@ _Avoid_: full recap, credits roll, visible checklist, objective summary
 
 **Route Memory Montage**:
 A brief Guitar Farewell montage that wordlessly shows the fixed route's resident
-help, world changes, and Cicka Resting Spot echoes before the final send.
+help, world changes, and Cicka Resting Spot echoes during the final song.
 _Avoid_: full recap, credits roll, visible checklist, objective summary
 
 **Area Barricade Chain**:
@@ -317,20 +318,20 @@ progress without requiring one continuous walkable overworld geography.
 _Avoid_: unexplained teleport, giant continuous map requirement, hard distance scale
 
 **Send the Sketchbook Prompt**:
-The post-Guitar Farewell Relay Spire interaction that begins the Cicka Threshold
-Farewell after the player has shared the quiet song with Cicka.
-_Avoid_: automatic send, guitar-as-send-button, boss gate, extra skill check
+A retired/provisional ending prompt. Do not use it in v0 unless the sketchbook
+becomes a seeded object or interaction across the route first.
+_Avoid_: unintroduced final symbol, automatic send, guitar-as-send-button, boss gate, extra skill check
 
-**Relay Holding State**:
-The small post-Guitar Farewell state where Cicka remains present at Relay and
-the player may linger, but cannot return to the wider Ridge route until choosing
-Send the Sketchbook.
-_Avoid_: open backtracking, menu-only ending choice, automatic cutscene trigger
+**Pre-Ending Relay Linger**:
+The small Relay state before choosing Sit and Play where Cicka is present and
+the player may look around, sit nearby, or share a quiet optional comfort beat
+before committing to the ending.
+_Avoid_: open backtracking after the final song, menu-only ending choice, automatic cutscene trigger
 
 **Relay Blue Hour**:
-The final send lighting state after the Guitar Farewell, where Relay has moved
-from sunset warmth into blue-hour threshold light while the night festival begins
-elsewhere.
+A retired/provisional name for a post-song send lighting state. Current v0
+direction keeps the Guitar Farewell and Cicka Threshold Farewell at sunset unless
+blockout proves another lighting transition is needed.
 _Avoid_: full night farewell, hard time cut, cold death-coded darkness
 
 **Concert Crossing Beat**:
@@ -553,17 +554,17 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   and helping them act without making the player directly manage their feelings.
 - The **Cicka Threshold Farewell** resolves Cicka's recurring field guidance
   without closing the **Sketchbook Neighborhood**; the Ridge remains replayable
-  with Cicka's Relay threshold mark and one Concert Resting Spot echo.
+  after the farewell.
 - The **Cicka Threshold Farewell** departure should be physical and mostly
-  silent: walk together, pause, look back, final mark, then page-fold/light
-  departure. The initial version should use no translated farewell line; a tiny
-  raw meow/chirp sound can remain optional if it supports the staging.
+  silent: walk together, pause, look back, then page-fold/light departure. The
+  initial version should use no translated farewell line; a tiny raw meow/chirp
+  sound can remain optional if it supports the staging. Do not rely on
+  paw/page marks as a required symbol unless the route has seeded that visual
+  language first.
 - The immediate return after the **Cicka Threshold Farewell** should be the
-  **Open Ridge Return State**: replayable, quiet, and minimally absence-marked,
-  with the canonical final mark at the Relay threshold, one quieter echo at
-  the **Concert Resting Spot**, and Micka still delayed until the later
-  post-ending trigger. The echo should be an empty usual spot with one small
-  paw/page mark, not the guitar left behind.
+  **Open Ridge Return State**: replayable, quiet, and minimally absence-marked
+  only if that visual language has been seeded, with Micka still delayed until
+  the later post-ending trigger. The guitar stays with the player.
 - The **Guitar Farewell** should be established before the ending through the
   guitar's story role and visual Cicka Resting Spot presence. The initial route
   does not need repeatable resting-spot interactions; sitting together, petting,
@@ -578,13 +579,12 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   should stay brief and keep Cicka as the emotional focus; the player's guitar
   is the only music the player needs to hear during the montage.
 - The **Sit and Play Prompt** starts the **Guitar Farewell** at Relay Spire
-  without turning it into a rhythm challenge.
-- The **Send the Sketchbook Prompt** should happen after the **Guitar Farewell**,
-  keeping the final send as an active player choice while preserving the song as
-  comfort rather than a send button.
-- The Relay ending should use sunset for **Sit and Play Prompt**, then a
-  **Relay Holding State** for **Send the Sketchbook Prompt**; the **Route Memory
-  Montage** can show the night festival beginning elsewhere.
+  without turning it into a rhythm challenge, and it is the v0 final trigger.
+- Do not use **Send the Sketchbook Prompt** in v0 unless the sketchbook becomes
+  a seeded object or interaction across the route first.
+- The Relay ending should use sunset for **Sit and Play Prompt** and the
+  **Cicka Threshold Farewell**; the **Route Memory Montage** can show the night
+  festival beginning elsewhere.
 - The **Concert Crossing Beat** can teach the guitar through a small
   Guitar-Hero-like mini-game, but the **Guitar Farewell** itself should remain a
   cozy remembrance interaction rather than an arcade pass/fail challenge.
@@ -656,13 +656,13 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 > **Domain expert:** "No — the **Cicka Threshold Farewell** means she walks with the player to the threshold, then departs somewhere the player cannot follow."
 
 > **Dev:** "Should Cicka's final departure include translated text?"
-> **Domain expert:** "No — the initial **Cicka Threshold Farewell** should be fully nonverbal. Use staging, the final mark, silence, and optionally a tiny raw sound instead of a written goodbye."
+> **Domain expert:** "No — the initial **Cicka Threshold Farewell** should be fully nonverbal. Use staging, silence, and optionally a tiny raw sound instead of a written goodbye."
 
-> **Dev:** "Where does Cicka's final mark persist after the ending?"
-> **Domain expert:** "Use a minimal **Open Ridge Return State**: the canonical final mark persists at the Relay threshold, with one quieter echo at the **Concert Resting Spot** and no scattershot sad marks."
+> **Dev:** "Should the ending rely on paw/page marks?"
+> **Domain expert:** "No — only use a final trace or absence echo as visual staging if the route has already taught that language. Do not make paw/page marks a surprise mechanic or required symbol in v0."
 
 > **Dev:** "Should the Cicka Resting Spot echo leave the guitar there?"
-> **Domain expert:** "No — the guitar stays with the player. The echo should be the empty usual spot plus one small paw/page mark."
+> **Domain expert:** "No — the guitar stays with the player. Any echo should be a small absence cue at the usual spot, not an abandoned inventory object."
 
 > **Dev:** "Should each bridge/concert/dance area have a small Cicka resting spot?"
 > **Domain expert:** "Yes — give each required **Ridge Area** one local **Cicka Resting Spot**. It keeps Cicka present across a linear route without turning any area into a hub."

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -122,10 +122,33 @@ directly, potentially with simple bridge-building physics.
 _Avoid_: required v0 route blocker, full simulation before route MVP
 
 **Concert Area**:
-The middle required Ridge Area: a compact city-like concert block with small
-buildings, bars, street details, the Concert Crossing Beat, the Concert Resting
-Spot, and the guitar's first entrusted use.
-_Avoid_: calling the whole area Concert Crossing, music hub
+The middle required Ridge Area: a compact small-town / varos-like concert block
+at evening or night with bars, street details, the Concert Crossing Beat, the
+Concert Resting Spot, and the guitar's first entrusted use.
+_Avoid_: calling the whole area Concert Crossing, night-club gig, music hub
+
+**Travel Interlude**:
+A short between-area passage that implies meaningful distance, time change, or
+rest between compact Ridge Areas without becoming a required vehicle mini-game.
+_Avoid_: unexplained teleport, mandatory driving game, full overworld commute
+
+**Concert-to-Dance Rest Interlude**:
+The post-Concert night-to-morning passage where the player rests after the
+concert, then travels toward Dance Festival through a short non-driving
+transition using the Band Roadie Van Ride.
+_Avoid_: walking all night, required driving mini-game, unexplained time skip
+
+**Band Roadie Van Ride**:
+The grounded Concert-to-Dance morning transition where a practical band roadie /
+van driver gives the player a lift because the player helped the concert and the
+band is already packing up gear.
+_Avoid_: making the roadie the festival-sleep joke, required driving mini-game, random bus substitute
+
+**Festival Superfan**:
+A desired recurring comic resident who talks up the Dance Festival in earlier
+areas, then sleeps through the festival when it finally happens; likely
+immediate post-v0 scope unless cheap to reserve in v0.
+_Avoid_: making him the required driver without vehicle setup, stealing focus from area residents
 
 **Dance Festival Area**:
 The final required Ridge Area at the foot of the Relay hill. It contains the
@@ -279,6 +302,11 @@ The fixed first-ending route structure where Bridge, Concert, and Dance
 Festival each contain one concrete local barricade whose resolution opens the
 next area and finally brings the player to Relay.
 _Avoid_: optional proof checklist, hub progression, abstract emotional gate
+
+**Compact Area Transition**:
+A short transition between separate compact Ridge Areas that preserves linear
+progress without requiring one continuous walkable overworld geography.
+_Avoid_: unexplained teleport, giant continuous map requirement, hard distance scale
 
 **Send the Sketchbook Prompt**:
 The post-Guitar Farewell Relay Spire interaction that begins the Cicka Threshold
@@ -463,6 +491,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - The first-ending route currently uses an **Area Barricade Chain**: Bridge
   Area clears into Concert Area, Concert Area clears into Dance Festival Area,
   and Dance Festival clears into Relay Ending.
+- The first playable route should use **Compact Area Transitions** between
+  separate compact maps, allowing different time of day, environment, and
+  staging per area while distant Relay cues imply route progress.
 - A mini-game may use its own **Mini-Game Movement System** instead of
   **Exploration Traversal**.
 - The first ending path should be completable through conversation, collection,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,8 +84,9 @@ and teaches that helping a resident can visibly change the route.
 _Avoid_: calling the whole area Blueprint Bridge, bridge hub
 
 **Concert Area**:
-The middle required Ridge Area. It contains the Concert Crossing Beat, the
-Concert Resting Spot, and the guitar's first entrusted use.
+The middle required Ridge Area: a compact city-like concert block with small
+buildings, bars, street details, the Concert Crossing Beat, the Concert Resting
+Spot, and the guitar's first entrusted use.
 _Avoid_: calling the whole area Concert Crossing, music hub
 
 **Dance Festival Area**:
@@ -171,9 +172,10 @@ the first resident-help route change.
 _Avoid_: tutorial UI marker, required backtracking perch
 
 **Concert Resting Spot**:
-The Cicka Resting Spot in the Concert Area, where the guitar first becomes a
-comfort object and where the Open Ridge Return State can show one quiet
-empty-spot echo after the farewell.
+The Cicka Resting Spot in the Concert Area: first a hidden musician-side place
+where crowd-shy Cicka watches the delay, then a relaxed band-side spot near the
+opened exit where the Open Ridge Return State can show one quiet empty-spot echo
+after the farewell.
 _Avoid_: abandoned guitar, shrine, required sad objective
 
 **Dance Festival Resting Spot**:
@@ -264,6 +266,11 @@ incapacitated local guitarist who hurt his hand or wrist while trying to prove
 he was still young after a kid teased him, clear the crowd, and receive the
 Concert Guitar during a goodbye beat at the opened exit.
 _Avoid_: joke-only drunk musician, random item pickup, final-farewell skill gate
+
+**Compact-Area Discovery**:
+A discovery pattern where a small Ridge Area relies on readable staging,
+optional chatter, and player wandering instead of a strict breadcrumb chain.
+_Avoid_: over-breadcrumbed objective path, hidden critical clue, giant search space
 
 **Forgiving Practice Riff**:
 The simple guitar phrase the injured Concert guitarist teaches the player so v0

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -133,16 +133,24 @@ rest between compact Ridge Areas without becoming a required vehicle mini-game.
 _Avoid_: unexplained teleport, mandatory driving game, full overworld commute
 
 **Concert-to-Dance Rest Interlude**:
-The post-Concert night-to-morning passage where the player rests after the
+The post-Concert night-to-daytime passage where the player rests after the
 concert, then travels toward Dance Festival through a short non-driving
-transition using the Band Roadie Van Ride.
+transition using the Band Roadie Van Ride; the rest can be implied or skipped in
+v0, while a campfire/tent hangout can be later liveliness scope.
 _Avoid_: walking all night, required driving mini-game, unexplained time skip
 
 **Band Roadie Van Ride**:
-The grounded Concert-to-Dance morning transition where a practical band roadie /
+The grounded Concert-to-Dance daytime transition where a practical band roadie /
 van driver gives the player a lift because the player helped the concert and the
-band is already packing up gear.
-_Avoid_: making the roadie the festival-sleep joke, required driving mini-game, random bus substitute
+band is already packing up gear; the band is headed somewhere else nearby and
+drops the player near Dance Festival because it is on the way.
+_Avoid_: making the roadie the festival-sleep joke, required driving mini-game, making the band attend Dance Festival by default, random bus substitute
+
+**Sneaky Cicka Arrival**:
+An optional travel flavor where Cicka is present around the Concert rest/travel
+beat or sneaks into/around the roadie van, while v0 can simply place her near
+Dance Festival without explaining the trip.
+_Avoid_: managed pet passenger, required travel explanation, companion logistics
 
 **Festival Superfan**:
 A desired recurring comic resident who talks up the Dance Festival in earlier
@@ -345,9 +353,9 @@ a later rhythm mini-game exists.
 _Avoid_: required hard rhythm check, mastery test, full song system in MVP
 
 **Opening Dance Shuttle Beat**:
-A final-route Resident Beat where afternoon festival setup blocks the Relay
-hill service road until the player helps prepare the night dance and catches the
-last daylight shuttle to the Relay Spire.
+A final-route Resident Beat where daytime festival setup progresses toward late
+afternoon, blocks the Relay hill service road until the player helps prepare the
+night dance, and ends with the last daylight shuttle to the Relay Spire.
 _Avoid_: Last Dance, Final Shuttle Hold, after-festival closure gate
 
 **Last-Stop Operations Helper**:
@@ -581,8 +589,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   Guitar-Hero-like mini-game, but the **Guitar Farewell** itself should remain a
   cozy remembrance interaction rather than an arcade pass/fail challenge.
 - The **Opening Dance Shuttle Beat** keeps the dance festival as a night event,
-  but the required route action happens during daytime setup so the player can
-  reach the Relay Spire for the sunset **Guitar Farewell**.
+  but the required route action starts during daytime setup, progresses toward
+  late afternoon, and gets the player to Relay Spire for the sunset **Guitar
+  Farewell**.
 - The **Opening Dance Shuttle Beat** centers the hill-shuttle driver and the
   **Last-Stop Operations Helper** as colleagues whose practical work and private
   nervousness both delay the last daylight ride.
@@ -671,7 +680,7 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 > **Domain expert:** "Yes — use the **Concert Crossing Beat** to earn the guitar through a tiny performance/help moment, then let local **Cicka Resting Spots** turn it into comfort."
 
 > **Dev:** "Does the dance festival happen at night?"
-> **Domain expert:** "Yes — but the required route beat is the **Opening Dance Shuttle Beat**, where daytime setup opens one last daylight ride to Relay before the night festival begins."
+> **Domain expert:** "Yes — but the required route beat is the **Opening Dance Shuttle Beat**, where daytime setup progresses toward one last daylight ride to Relay before the night festival begins."
 
 > **Dev:** "Is the driver's crush the DJ?"
 > **Domain expert:** "No — she is the **Last-Stop Operations Helper**, a visible plaza worker whose setup checklist and service-road handoff make her role immediately readable."

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,6 +83,21 @@ The first required Ridge Area. It contains the Blueprint Bridge Resident Beat
 and teaches that helping a resident can visibly change the route.
 _Avoid_: calling the whole area Blueprint Bridge, bridge hub
 
+**Blueprint Bridge**:
+The first required Resident Beat where the player helps the Bridge Draftsperson
+complete a missing middle span on a bridge drawing or blueprint so the finished
+sketch becomes the physical crossing.
+_Avoid_: required physics puzzle, fetch quest, platforming test
+
+**Bridge Draftsperson**:
+The nervous or blocked resident responsible for the Blueprint Bridge plan.
+_Avoid_: wizard, quest board, generic artist-god, final proper name too early
+
+**Bridge Drawing Toy**:
+A future optional upgrade where the player draws or customizes the bridge more
+directly, potentially with simple bridge-building physics.
+_Avoid_: required v0 route blocker, full simulation before route MVP
+
 **Concert Area**:
 The middle required Ridge Area: a compact city-like concert block with small
 buildings, bars, street details, the Concert Crossing Beat, the Concert Resting

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,11 +89,28 @@ complete a missing middle span on a bridge drawing or blueprint so the finished
 sketch becomes the physical crossing.
 _Avoid_: required physics puzzle, fetch quest, platforming test
 
-**Toy Car Theft**:
-The first Cicka encounter where she steals the Bridge Draftsperson's tiny
-weight-test car and pulls the player toward the unsafe crossing and unfinished
-bridge blueprint.
-_Avoid_: generic fetch quest, inventory tutorial, permanent follower setup
+**Toy Car Play**:
+The first Cicka encounter where she peacefully plays with the Bridge
+Draftsperson's tiny weight-test car before the player later realizes it is
+needed for the bridge test.
+_Avoid_: generic fetch quest, thief tutorial, permanent follower setup
+
+**Cicka Parallel Play**:
+The gentle Bridge interaction where the player sits or relaxes near Cicka until
+she treats the toy car as shared play and lets it become usable for the bridge
+test.
+_Avoid_: taking the toy by force, obedient quest-item handoff, food-fetch gate
+
+**Toy Car Bridge Test**:
+The v0 auto-success presentation where the retrieved toy car rolls across the
+completed bridge drawing and proves the sketch can become the physical crossing.
+_Avoid_: required physics failure, hidden pass criteria, simulation-first MVP
+
+**Cicka Treat Shortcut**:
+A future optional Bridge interaction where nearby cabin food can persuade Cicka
+to release the toy car, acting as an alternate path around a richer toy-car play
+mini-game.
+_Avoid_: required food fetch, first-route errand, replacing parallel play in v0
 
 **Bridge Draftsperson**:
 The nervous or blocked resident responsible for the Blueprint Bridge plan.
@@ -465,8 +482,13 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - **Cicka Field Presence** complements **Cicka Resting Spots** by making Cicka
   recur across the **Sketchbook Neighborhood** without turning her into a
   follower, solver, vendor, or quest board.
-- **Toy Car Theft** can introduce Cicka in Bridge Area, but it should lead into
+- **Toy Car Play** can introduce Cicka in Bridge Area, but it should lead into
   recurring **Cicka Field Presence**, not continuous follower behavior.
+- **Cicka Parallel Play** retrieves the toy car by joining Cicka's play rather
+  than commanding her, taking the toy, or adding a food-fetch gate.
+- The first Bridge prototype should use an auto-success **Toy Car Bridge Test**;
+  **Bridge Drawing Toy**, toy-car ping-pong, and **Cicka Treat Shortcut** are
+  later optional layers after the route MVP is proven.
 - A **Resident Help Beat** may use **Cicka Field Presence** to draw attention to
   a route blocker, but the solution should come from a resident, artifact,
   mini-game clear, or visible environment change.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,6 +89,12 @@ complete a missing middle span on a bridge drawing or blueprint so the finished
 sketch becomes the physical crossing.
 _Avoid_: required physics puzzle, fetch quest, platforming test
 
+**Toy Car Theft**:
+The first Cicka encounter where she steals the Bridge Draftsperson's tiny
+weight-test car and pulls the player toward the unsafe crossing and unfinished
+bridge blueprint.
+_Avoid_: generic fetch quest, inventory tutorial, permanent follower setup
+
 **Bridge Draftsperson**:
 The nervous or blocked resident responsible for the Blueprint Bridge plan.
 _Avoid_: wizard, quest board, generic artist-god, final proper name too early
@@ -459,6 +465,8 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - **Cicka Field Presence** complements **Cicka Resting Spots** by making Cicka
   recur across the **Sketchbook Neighborhood** without turning her into a
   follower, solver, vendor, or quest board.
+- **Toy Car Theft** can introduce Cicka in Bridge Area, but it should lead into
+  recurring **Cicka Field Presence**, not continuous follower behavior.
 - A **Resident Help Beat** may use **Cicka Field Presence** to draw attention to
   a route blocker, but the solution should come from a resident, artifact,
   mini-game clear, or visible environment change.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -208,6 +208,17 @@ Spire, echoing the visual presence, tiny marks, and accumulated memory from
 Cicka Resting Spots across the Ridge.
 _Avoid_: generic music mini-game, melodrama, one-off ending prop
 
+**Concert Guitar**:
+The literal guitar entrusted to the player after Concert Crossing; it remains
+with the player for the rest of the first-ending route and becomes the
+instrument used for the Guitar Farewell.
+_Avoid_: abstract music ability, temporary quest prop, separate ending guitar
+
+**Optional Guitar Comfort Interaction**:
+A later-polish interaction where the player may sit near a Cicka Resting Spot
+and play a tiny guitar phrase without changing route progression.
+_Avoid_: hidden required prompt, affection checklist, extra proof token
+
 **Sit and Play Prompt**:
 The final Relay Spire interaction that starts the Guitar Farewell when the
 player chooses to sit near Cicka and play guitar.
@@ -247,9 +258,18 @@ elsewhere.
 _Avoid_: full night farewell, hard time cut, cold death-coded darkness
 
 **Concert Crossing Beat**:
-A mid-route Resident Beat where a blocked concert/traffic crossing becomes
-the way the player earns the guitar through a small music performance problem.
+A mid-route Resident Beat where a crowd or traffic line blocks the crossing
+while waiting for a delayed concert, leading the player to take over for an
+incapacitated local guitarist who hurt his hand or wrist while trying to prove
+he was still young after a kid teased him, clear the crowd, and receive the
+Concert Guitar during a goodbye beat at the opened exit.
 _Avoid_: joke-only drunk musician, random item pickup, final-farewell skill gate
+
+**Forgiving Practice Riff**:
+The simple guitar phrase the injured Concert guitarist teaches the player so v0
+can resolve the concert through auto-success or highly forgiving prompts before
+a later rhythm mini-game exists.
+_Avoid_: required hard rhythm check, mastery test, full song system in MVP
 
 **Opening Dance Shuttle Beat**:
 A final-route Resident Beat where afternoon festival setup blocks the Relay
@@ -458,6 +478,11 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   does not need repeatable resting-spot interactions; sitting together, petting,
   lap loafing, or playing guitar at local spots can wait for a later affection
   pass.
+- The **Concert Guitar** is the same physical instrument used in the **Guitar
+  Farewell**, not an abstract music unlock or a different ending-only prop.
+- The only required guitar uses in the first-ending route are the Concert
+  performance and Relay **Sit and Play Prompt**; any guitar use at local
+  **Cicka Resting Spots** should be an **Optional Guitar Comfort Interaction**.
 - The **Guitar Farewell** can include a **Route Memory Montage**, but the montage
   should stay brief and keep Cicka as the emotional focus; the player's guitar
   is the only music the player needs to hear during the montage.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -137,8 +137,8 @@ _Avoid_: shared overworld movement
 **Mini-Game Entrance**:
 An opt-in world attachment that can offer a hobby toy, reward, shortcut,
 alternate solution, or just fun without being required for the core ending path.
-For the current first-ending route, mini-games are optional fun and do not need
-to count as Living Proof; future passes may let them unlock alternate ways to
+For the current first-ending route, mini-games are optional fun and do not
+count as first-ending proof; future passes may let them unlock alternate ways to
 finish a level.
 _Avoid_: mandatory arcade gate, generic content silo
 
@@ -214,16 +214,31 @@ player chooses to sit near Cicka and play guitar.
 _Avoid_: rhythm UI, fail state, final skill check, objective popup
 
 **Living Proof Montage**:
-A brief Guitar Farewell montage that wordlessly shows the resident help and
-world changes that made the sketchbook ready to send; the Opening Dance image is
-an emotional echo scored by the player's guitar while the actual festival song
-request stays implied and offscreen.
+A previous name for the brief ending montage, now better treated as **Route
+Memory Montage** unless a later design restores a separate proof system.
 _Avoid_: full recap, credits roll, visible checklist, objective summary
+
+**Route Memory Montage**:
+A brief Guitar Farewell montage that wordlessly shows the fixed route's resident
+help, world changes, and Cicka Resting Spot echoes before the final send.
+_Avoid_: full recap, credits roll, visible checklist, objective summary
+
+**Area Barricade Chain**:
+The fixed first-ending route structure where Bridge, Concert, and Dance
+Festival each contain one concrete local barricade whose resolution opens the
+next area and finally brings the player to Relay.
+_Avoid_: optional proof checklist, hub progression, abstract emotional gate
 
 **Send the Sketchbook Prompt**:
 The post-Guitar Farewell Relay Spire interaction that begins the Cicka Threshold
 Farewell after the player has shared the quiet song with Cicka.
 _Avoid_: automatic send, guitar-as-send-button, boss gate, extra skill check
+
+**Relay Holding State**:
+The small post-Guitar Farewell state where Cicka remains present at Relay and
+the player may linger, but cannot return to the wider Ridge route until choosing
+Send the Sketchbook.
+_Avoid_: open backtracking, menu-only ending choice, automatic cutscene trigger
 
 **Relay Blue Hour**:
 The final send lighting state after the Guitar Farewell, where Relay has moved
@@ -343,13 +358,9 @@ insecurity, not act as arbitrary busywork.
 _Avoid_: generic fetch quest, public romantic confrontation, puppet-master solve
 
 **Living Proof Gate**:
-A quiet ending gate where the player can physically reach the Relay Spire, but
-the sketchbook cannot send until the route has created enough visible world
-changes, proofs, and Cicka familiarity to make the destination legible.
-For the current first ending, the three required Ridge Areas and their
-Resident/world changes should provide enough Living Proof by themselves.
-Changed Cicka Resting Spots can echo that proof emotionally, but they should
-not be counted as separate proof sources.
+A retired or provisional ending-gate term. The current first-ending route uses
+the fixed **Area Barricade Chain** instead of a separate proof resource,
+checklist, or optional readiness system.
 _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 
 ## Relationships
@@ -384,14 +395,17 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   presentation, but its blocker, helper, and resolution should feel practical
   and locally motivated.
 - The **Exploration Map** uses **Exploration Traversal**.
+- The first-ending route currently uses an **Area Barricade Chain**: Bridge
+  Area clears into Concert Area, Concert Area clears into Dance Festival Area,
+  and Dance Festival clears into Relay Ending.
 - A mini-game may use its own **Mini-Game Movement System** instead of
   **Exploration Traversal**.
 - The first ending path should be completable through conversation, collection,
   authored traversal, Ridge Areas, Resident Beats, and world changes without
   requiring full arcade mini-games.
 - **Mini-Game Entrances** can provide optional rewards, shortcuts, alternate
-  path unlocks, or pure side fun, but they should not be required Living Proof
-  for the current first ending. Future passes may let them unlock alternate
+  path unlocks, or pure side fun, but they should not be required first-ending
+  proof for the current first ending. Future passes may let them unlock alternate
   ways to finish a level.
 - **Exploration Traversal** treats jump as non-core for the v0 main path;
   vertical movement should come from **Authored Traversal Interactions** unless
@@ -444,7 +458,7 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   does not need repeatable resting-spot interactions; sitting together, petting,
   lap loafing, or playing guitar at local spots can wait for a later affection
   pass.
-- The **Guitar Farewell** can include a **Living Proof Montage**, but the montage
+- The **Guitar Farewell** can include a **Route Memory Montage**, but the montage
   should stay brief and keep Cicka as the emotional focus; the player's guitar
   is the only music the player needs to hear during the montage.
 - The **Sit and Play Prompt** starts the **Guitar Farewell** at Relay Spire
@@ -452,8 +466,8 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - The **Send the Sketchbook Prompt** should happen after the **Guitar Farewell**,
   keeping the final send as an active player choice while preserving the song as
   comfort rather than a send button.
-- The Relay ending should use sunset for **Sit and Play Prompt**, then
-  **Relay Blue Hour** for **Send the Sketchbook Prompt**; the **Living Proof
+- The Relay ending should use sunset for **Sit and Play Prompt**, then a
+  **Relay Holding State** for **Send the Sketchbook Prompt**; the **Route Memory
   Montage** can show the night festival beginning elsewhere.
 - The **Concert Crossing Beat** can teach the guitar through a small
   Guitar-Hero-like mini-game, but the **Guitar Farewell** itself should remain a
@@ -497,8 +511,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - Required **Resident Beats** that contain arcade-like interactions should
   also have a non-arcade fallback through conversation, collection, practice, or
   a forgiving auto-resolve path.
-- A **Living Proof Gate** blocks the **Cicka Threshold Farewell** emotionally and
-  semantically, not by making the Relay Spire physically unreachable.
+- **Living Proof Gate** language should not imply a required proof resource in
+  the current first-ending route; use **Area Barricade Chain** for progression
+  and **Route Memory Montage** for the ending echo.
 - The old Overworld and Hobbies scenes are transitional surfaces. Long-term,
   their best content should fold into the **Exploration Map** as artifacts,
   entrances, Cicka reactions, Basement/Potassium paths, and mini-game props.
@@ -542,7 +557,7 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 > **Domain expert:** "Yes — make it the **Guitar Farewell**, but establish guitar as a quiet comfort interaction before Relay so it carries memory instead of exposition."
 
 > **Dev:** "Can the Guitar Farewell show what happened to the residents?"
-> **Domain expert:** "Yes — use a brief **Living Proof Montage** of resident/world changes, not a full recap."
+> **Domain expert:** "Yes — use a brief **Route Memory Montage** of resident/world changes, not a full recap."
 
 > **Dev:** "Can the guitar come from a concert problem?"
 > **Domain expert:** "Yes — use the **Concert Crossing Beat** to earn the guitar through a tiny performance/help moment, then let local **Cicka Resting Spots** turn it into comfort."
@@ -596,7 +611,7 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 > **Domain expert:** "No — the first ending path should work through residents, conversations, collection, and world changes; **Mini-Game Entrances** can add alternate paths or side fun."
 
 > **Dev:** "Should the Relay Spire require a boss or hard climb?"
-> **Domain expert:** "No — use a **Living Proof Gate** so the player can reach it early but cannot send until the path has created enough visible change and emotional tie to Cicka."
+> **Domain expert:** "No — use the **Area Barricade Chain** so the player reaches Relay after clearing the Bridge, Concert, and Dance Festival barricades."
 
 ## Flagged Ambiguities
 
@@ -631,7 +646,7 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   **Opening Dance Shuttle Beat** for the final dance-festival route beat.
 - "bachata" is loose discarded inspiration, not canonical genre; use a simple,
   cute, guitar-friendly implied request for the **Folded Song Request** while
-  the later **Living Proof Montage** dance image is emotionally scored by the
+  the later **Route Memory Montage** dance image is emotionally scored by the
   player's guitar.
 - "festival helper" is too generic for the driver's colleague; resolved: use
   **Last-Stop Operations Helper**.

--- a/docs/game-design/ridge/README.md
+++ b/docs/game-design/ridge/README.md
@@ -25,7 +25,7 @@ Use each file for exactly one concern:
 | --- | --- | --- |
 | Domain language | [`../../../CONTEXT.md`](../../../CONTEXT.md) | Use these terms exactly. Add only stable domain terms and ambiguities. |
 | Shipped behavior | [`../player-manual.md`](../player-manual.md) | Update only when behavior ships. |
-| Current Ridge route canon | [`story-level-bible.md`](./story-level-bible.md) | Route spine, cross-area Cicka/guitar logic, Living Proof, ending order. |
+| Current Ridge route canon | [`story-level-bible.md`](./story-level-bible.md) | Route spine, area barricade chain, cross-area Cicka/guitar logic, ending order. |
 | Area-specific design canon | [`areas/`](./areas/README.md) | Local geography, blockers, residents, prompts, staging, Cicka Resting Spots, visual/audio notes. |
 | Current runtime/prototype truth | [`ridge-snapshot.md`](./ridge-snapshot.md) | What exists now in the Phaser prototype, what can be reused, and what is disposable. |
 | Active open questions | [`open-questions.md`](./open-questions.md) | Unresolved ending, Dance Festival, dependency, and scope gaps. |
@@ -66,7 +66,7 @@ Treat these as prototype/reference unless a task explicitly says to adapt them:
 - Folded-desk route order.
 - Required jump/platformer traversal.
 - Main-path slopes, ramps, wall jumps, double jumps, or precision platforming.
-- Mini-game clears as required Living Proof for the first ending.
+- Mini-game clears as required first-ending proof.
 
 Useful legacy pieces may still be preserved or adapted: the Ridge Blockout
 Source contract, compiler, generated facts, validation, and preview/debugger

--- a/docs/game-design/ridge/areas/01-bridge/README.md
+++ b/docs/game-design/ridge/areas/01-bridge/README.md
@@ -22,11 +22,14 @@ art.**
 
 - The main blocker is a missing, unsafe, or unfinished crossing.
 - Bridge Area can be the first time the player meets Cicka.
-- Cicka introduces herself by stealing the tiny toy car / weight-test prop from
-  the Bridge Draftsperson's blueprint setup.
-- The player follows or investigates the stolen prop, finds Cicka near the
-  unsafe crossing or unfinished blueprint, and is pulled naturally into the
-  Bridge Draftsperson's problem.
+- The game can begin with a simple walk-right control introduction from a hill
+  or nature edge before the bridge problem is visible.
+- Cicka first appears peacefully playing with the tiny toy car / weight-test
+  prop. The player can meet her through a tiny pet/play interaction before
+  knowing the toy matters.
+- The player then reaches the blocked bridge and learns from the Bridge
+  Draftsperson that the test car is missing. The player can infer that Cicka has
+  it and return to retrieve it through **Cicka Parallel Play**.
 - The local resident role is the **Bridge Draftsperson**: a tiny nervous or
   blocked planner responsible for the crossing blueprint.
 - The Bridge Draftsperson's problem is a missing middle span on the blueprint:
@@ -39,6 +42,10 @@ art.**
   finished sketch becomes the crossing.
 - For v0, this can be a basic authored drawing/completion visual rather than a
   full freeform drawing system.
+- For v0, the bridge test should be auto-success presentation: after Cicka
+  Parallel Play returns the toy car, the player places or brings it to the
+  completed blueprint, the toy car rolls across the drawn bridge, and the sketch
+  becomes the real crossing.
 - Cicka gives an obvious but nonverbal attention cue near the unsafe edge,
   blank plan, or missing part of the bridge.
 - After this first encounter, Cicka should become a recurring authored field
@@ -50,12 +57,31 @@ art.**
 
 Use **Bridge Resting Spot** as the practical label.
 
-- Before resolution: Cicka steals or carries the toy car / weight-test prop,
-  then perches near the unsafe crossing or blank plan.
+- Before resolution: Cicka peacefully plays with or carries the toy car /
+  weight-test prop, then the player recontextualizes the toy as the missing
+  bridge test car.
 - After resolution: Cicka settles near the completed bridge sketch or leaves a
   tiny mark by the crossing.
 
 The resting spot is readable flavor, not a gate.
+
+## Prototype Floor
+
+The first blockout only needs:
+
+- walk-right nature/hill intro
+- peaceful Cicka + toy car first encounter
+- basic sit/play interaction
+- blocked bridge
+- Bridge Draftsperson + missing middle span blueprint
+- return to Cicka for Cicka Parallel Play
+- toy car bridge test
+- simple bridge drawing completion visual
+- bridge becomes crossing
+- Cicka settles near the completed crossing
+
+Cabin, food, physics simulation, and toy-car ping-pong are later optional
+layers.
 
 ## Boundaries
 
@@ -63,10 +89,18 @@ The resting spot is readable flavor, not a gate.
 - Do not make the required v0 solution depend on physics drawing.
 - Do not turn the beat into a fetch quest.
 - Do not turn Cicka into a continuous follower after the first encounter.
+- Do not make Cicka obediently hand over the toy car as a quest item; the player
+  should join her play until she chooses to share it.
 - Future optional upgrade: let the player draw directly on the bridge as a
   small customization or bridge-building toy, potentially with simple
   bridge-building physics that tests whether the drawn bridge can carry a car
   or similar weight.
+- Future optional upgrade: turn Cicka Parallel Play into a tiny toy-car
+  back-and-forth game, like a low-stakes ping-pong riff using the car instead of
+  a ball.
+- Future optional upgrade: add a nearby cabin/treat interaction that lets the
+  player bring Cicka food as an alternate way to retrieve the toy car, such as a
+  shortcut around the toy-car ping-pong version rather than a required v0 step.
 
 ## Open Local Slots
 
@@ -74,6 +108,9 @@ The resting spot is readable flavor, not a gate.
 - exact bridge topology and camera framing
 - prop kit for the unfinished sketch/blueprint
 - failed doodles, eraser marks, or toy car/weight-test prop staging
-- tiny toy car theft trail and first Cicka encounter staging
+- Toy Car Play first Cicka encounter and gentle retrieval staging
+- Cicka Parallel Play timing and prompt wording
+- auto-success toy car test staging
 - one or two prompts that make the crossing change feel authored
+- future cabin/treat shortcut scope and placement
 - future drawing/bridge-physics toy scope after the route MVP is proven

--- a/docs/game-design/ridge/areas/01-bridge/README.md
+++ b/docs/game-design/ridge/areas/01-bridge/README.md
@@ -21,8 +21,18 @@ art.**
 ## Accepted Local Contract
 
 - The main blocker is a missing, unsafe, or unfinished crossing.
+- The local resident role is the **Bridge Draftsperson**: a tiny nervous or
+  blocked planner responsible for the crossing blueprint.
+- The Bridge Draftsperson's problem is a missing middle span on the blueprint:
+  they keep erasing and redrawing it because they are overthinking whether the
+  structure will hold.
+- Nearby failed doodles, eraser marks, or a tiny toy car/weight-test prop can
+  make the problem readable and support a future bridge-physics toy.
 - The solution is a tiny art/drawing soft gate: help a resident finish a bridge
-  drawing or blueprint, then the finished sketch becomes the crossing.
+  drawing or blueprint by drawing or visually completing the bridge, then the
+  finished sketch becomes the crossing.
+- For v0, this can be a basic authored drawing/completion visual rather than a
+  full freeform drawing system.
 - Cicka gives an obvious but nonverbal attention cue near the unsafe edge,
   blank plan, or missing part of the bridge.
 - The route change must be visible in the world, not only in dialogue.
@@ -44,11 +54,15 @@ The resting spot is readable flavor, not a gate.
 - Do not make the required v0 solution depend on physics drawing.
 - Do not turn the beat into a fetch quest.
 - Future optional upgrade: let the player draw directly on the bridge as a
-  small customization or bridge-building toy.
+  small customization or bridge-building toy, potentially with simple
+  bridge-building physics that tests whether the drawn bridge can carry a car
+  or similar weight.
 
 ## Open Local Slots
 
-- resident role, silhouette, and eventual name
+- Bridge Draftsperson silhouette, personality, and eventual name
 - exact bridge topology and camera framing
 - prop kit for the unfinished sketch/blueprint
+- failed doodles, eraser marks, or toy car/weight-test prop staging
 - one or two prompts that make the crossing change feel authored
+- future drawing/bridge-physics toy scope after the route MVP is proven

--- a/docs/game-design/ridge/areas/01-bridge/README.md
+++ b/docs/game-design/ridge/areas/01-bridge/README.md
@@ -21,6 +21,12 @@ art.**
 ## Accepted Local Contract
 
 - The main blocker is a missing, unsafe, or unfinished crossing.
+- Bridge Area can be the first time the player meets Cicka.
+- Cicka introduces herself by stealing the tiny toy car / weight-test prop from
+  the Bridge Draftsperson's blueprint setup.
+- The player follows or investigates the stolen prop, finds Cicka near the
+  unsafe crossing or unfinished blueprint, and is pulled naturally into the
+  Bridge Draftsperson's problem.
 - The local resident role is the **Bridge Draftsperson**: a tiny nervous or
   blocked planner responsible for the crossing blueprint.
 - The Bridge Draftsperson's problem is a missing middle span on the blueprint:
@@ -35,6 +41,8 @@ art.**
   full freeform drawing system.
 - Cicka gives an obvious but nonverbal attention cue near the unsafe edge,
   blank plan, or missing part of the bridge.
+- After this first encounter, Cicka should become a recurring authored field
+  presence rather than a continuous follower.
 - The route change must be visible in the world, not only in dialogue.
 - The beat should be tiny, obvious, local, and kind.
 
@@ -42,7 +50,8 @@ art.**
 
 Use **Bridge Resting Spot** as the practical label.
 
-- Before resolution: Cicka perches near the unsafe crossing or blank plan.
+- Before resolution: Cicka steals or carries the toy car / weight-test prop,
+  then perches near the unsafe crossing or blank plan.
 - After resolution: Cicka settles near the completed bridge sketch or leaves a
   tiny mark by the crossing.
 
@@ -53,6 +62,7 @@ The resting spot is readable flavor, not a gate.
 - Do not make Bridge Area a platforming test.
 - Do not make the required v0 solution depend on physics drawing.
 - Do not turn the beat into a fetch quest.
+- Do not turn Cicka into a continuous follower after the first encounter.
 - Future optional upgrade: let the player draw directly on the bridge as a
   small customization or bridge-building toy, potentially with simple
   bridge-building physics that tests whether the drawn bridge can carry a car
@@ -64,5 +74,6 @@ The resting spot is readable flavor, not a gate.
 - exact bridge topology and camera framing
 - prop kit for the unfinished sketch/blueprint
 - failed doodles, eraser marks, or toy car/weight-test prop staging
+- tiny toy car theft trail and first Cicka encounter staging
 - one or two prompts that make the crossing change feel authored
 - future drawing/bridge-physics toy scope after the route MVP is proven

--- a/docs/game-design/ridge/areas/02-concert/README.md
+++ b/docs/game-design/ridge/areas/02-concert/README.md
@@ -15,13 +15,20 @@ something" toward "carrying comfort forward."
 
 The emotional idea is: **I can turn memory into comfort.**
 
+The area identity is a compact city-like concert block: small buildings, bars,
+stage-adjacent storefronts, alleys, and lived-in street details around the
+blocked crossing. The first prototype can keep most buildings as facade
+atmosphere, while later passes may add enterable bars/building interiors,
+extra residents, and optional hangout spaces to make the block feel more alive.
+
 ## Accepted Local Contract
 
 - A blocked concert/traffic crossing halts the route.
 - The crossing is blocked by a crowd, traffic line, or gathering waiting for the
   concert to start.
-- The player discovers the delay by asking what everyone is waiting for, then
-  finds the local guitarist away from the crowd.
+- The player discovers the delay through compact-area exploration: annoyed
+  crowd members can mention that the concert is late, but the player can also
+  simply wander the small area and find the musician-side space naturally.
 - The local guitarist cannot play because of a clumsy show-off mishap: after a
   kid teased that he was old, he tried to prove he was still young by doing an
   absurd concert stunt, such as playing guitar while riding a skateboard on one
@@ -46,14 +53,36 @@ The emotional idea is: **I can turn memory into comfort.**
   performance and the Relay **Sit and Play** interaction.
 - The beat must make the later **Guitar Farewell** feel earned.
 
+## Prototype Floor
+
+The first blockout only needs:
+
+- blocked crowd/traffic crossing
+- 2-3 annoyed crowd NPCs
+- hidden musician-side nook
+- injured guitarist
+- one forgiving practice interaction
+- auto-success concert start
+- crowd clears
+- goodbye/reward beat at the opened exit
+- guitar received
+- Cicka hidden before resolution and chilling with the band after resolution
+
+Small-city facades, bars, and building silhouettes should frame the area even in
+the prototype, but enterable buildings and extra residents are later liveliness
+scope.
+
 ## Cicka Resting Spot
 
 Use **Concert Resting Spot** as the practical label.
 
-- Before resolution: Cicka watches the guitar case, string, stage edge, or
-  blocked crossing.
-- After resolution: Cicka rests in a quiet listening corner near the opened
-  crossing.
+- Before resolution: Cicka avoids the crowd and watches from a hidden or
+  musician-side place, such as behind stage props, near the guitar case, or
+  close to where the injured guitarist/band is waiting.
+- During the concert: Cicka stays off to the side rather than entering the
+  crowd, reading as curious but crowd-shy.
+- After resolution: Cicka chills with the musicians near the opened exit; the
+  injured guitarist or another band member may quietly pet her.
 
 This can later become the post-ending echo spot. The echo should be an empty
 usual spot plus one small paw/page mark, not the player's guitar left behind.
@@ -64,6 +93,8 @@ usual spot plus one small paw/page mark, not the player's guitar left behind.
   expression.
 - The required route must have a non-arcade fallback.
 - Do not block the first route MVP on building the full rhythm mini-game.
+- Do not over-breadcrumb the injured guitarist in v0; compact exploration and
+  believable crowd chatter should be enough unless playtests prove otherwise.
 - Avoid making the guitarist a joke-only drunk if it undercuts the tribute.
 - Gentle comedy is welcome if the guitar's emotional role still has room to
   breathe.
@@ -71,6 +102,8 @@ usual spot plus one small paw/page mark, not the player's guitar left behind.
 ## Open Local Slots
 
 - exact crossing geometry and why it blocks progress
+- small-city block layout, bars, building facades, and possible later interiors
+- how many annoyed crowd/band flavor lines are enough for discovery
 - exact post-concert goodbye staging near the opened exit
 - guitarist/resident role, silhouette, simplified staging for the skateboard
   stunt, and eventual name

--- a/docs/game-design/ridge/areas/02-concert/README.md
+++ b/docs/game-design/ridge/areas/02-concert/README.md
@@ -32,7 +32,7 @@ spaces to make the block feel more alive.
   crowd members can mention that the concert is late, but the player can also
   simply wander the small area and find the musician-side space naturally.
 - The local guitarist cannot play because of a clumsy show-off mishap: after a
-  kid teased that he was old, he tried to prove he was still young by doing an
+  kid teased him about being old, he tried to prove he was still young by doing an
   absurd concert stunt, such as playing guitar while riding a skateboard on one
   leg, and hurt his hand or wrist.
 - The player helps by learning one **Forgiving Practice Riff** from the injured
@@ -44,7 +44,7 @@ spaces to make the block feel more alive.
   use Danilo's real guitar/song material and dynamically generate button prompts
   from authored song data.
 - Once the performance begins, the crowd or traffic clears the crossing.
-- After the concert, the map clears up: the crowd leaves or moves aside, the
+- After the concert, the area clears up: the crowd leaves or moves aside, the
   crossing opens, and the musician or band waits near the exit for a short
   goodbye/reward beat.
 - During that exit beat, the guitarist entrusts the guitar to the player as a

--- a/docs/game-design/ridge/areas/02-concert/README.md
+++ b/docs/game-design/ridge/areas/02-concert/README.md
@@ -15,11 +15,13 @@ something" toward "carrying comfort forward."
 
 The emotional idea is: **I can turn memory into comfort.**
 
-The area identity is a compact city-like concert block: small buildings, bars,
-stage-adjacent storefronts, alleys, and lived-in street details around the
-blocked crossing. The first prototype can keep most buildings as facade
-atmosphere, while later passes may add enterable bars/building interiors,
-extra residents, and optional hangout spaces to make the block feel more alive.
+The area identity is a compact small-town / varos-like concert block at evening
+or night: small buildings, bars, stage-adjacent storefronts, alleys, street
+lights, and lived-in festival details around the blocked crossing. The concert
+should feel like a memorable local night event rather than a nightclub gig. The
+first prototype can keep most buildings as facade atmosphere, while later passes
+may add enterable bars/building interiors, extra residents, and optional hangout
+spaces to make the block feel more alive.
 
 ## Accepted Local Contract
 

--- a/docs/game-design/ridge/areas/02-concert/README.md
+++ b/docs/game-design/ridge/areas/02-concert/README.md
@@ -18,11 +18,32 @@ The emotional idea is: **I can turn memory into comfort.**
 ## Accepted Local Contract
 
 - A blocked concert/traffic crossing halts the route.
-- The crossing is blocked because the local guitarist cannot play, the
-  paper-stage setup is tangled, or the guitar needs a small repair.
-- The player helps the resident through conversation, collection, practice
-  together, forgiving auto-play, or another non-arcade fallback.
-- The guitar is entrusted to the player afterward as a meaningful comfort item.
+- The crossing is blocked by a crowd, traffic line, or gathering waiting for the
+  concert to start.
+- The player discovers the delay by asking what everyone is waiting for, then
+  finds the local guitarist away from the crowd.
+- The local guitarist cannot play because of a clumsy show-off mishap: after a
+  kid teased that he was old, he tried to prove he was still young by doing an
+  absurd concert stunt, such as playing guitar while riding a skateboard on one
+  leg, and hurt his hand or wrist.
+- The player helps by learning one **Forgiving Practice Riff** from the injured
+  guitarist, then taking over the concert.
+- In v0, the concert performance can be auto-success or highly forgiving so the
+  main route is not blocked by rhythm-game production.
+- After the first playable route lands, a Guitar-Hero-like or Baka Mitai-style
+  button-rhythm guitar mini-game can become the richer expression. It may later
+  use Danilo's real guitar/song material and dynamically generate button prompts
+  from authored song data.
+- Once the performance begins, the crowd or traffic clears the crossing.
+- After the concert, the map clears up: the crowd leaves or moves aside, the
+  crossing opens, and the musician or band waits near the exit for a short
+  goodbye/reward beat.
+- During that exit beat, the guitarist entrusts the guitar to the player as a
+  meaningful comfort item and reward.
+- This is the same physical guitar the player carries for the rest of the game
+  and uses at Relay for the **Guitar Farewell**.
+- The only required guitar uses in the first-ending route are the Concert
+  performance and the Relay **Sit and Play** interaction.
 - The beat must make the later **Guitar Farewell** feel earned.
 
 ## Cicka Resting Spot
@@ -42,6 +63,7 @@ usual spot plus one small paw/page mark, not the player's guitar left behind.
 - A Guitar-Hero-like performance mini-game is allowed as an ideal or optional
   expression.
 - The required route must have a non-arcade fallback.
+- Do not block the first route MVP on building the full rhythm mini-game.
 - Avoid making the guitarist a joke-only drunk if it undercuts the tribute.
 - Gentle comedy is welcome if the guitar's emotional role still has room to
   breathe.
@@ -49,7 +71,10 @@ usual spot plus one small paw/page mark, not the player's guitar left behind.
 ## Open Local Slots
 
 - exact crossing geometry and why it blocks progress
-- guitarist/resident role, silhouette, and eventual name
-- how the guitar is repaired, taught, or entrusted
+- exact post-concert goodbye staging near the opened exit
+- guitarist/resident role, silhouette, simplified staging for the skateboard
+  stunt, and eventual name
+- exact Forgiving Practice Riff prompts and auto-success performance beat
+- future rhythm mini-game song-data format and generated button prompt rules
 - first playable guitar interaction, if any, before Relay
 - visual/audio distinction from Dance Festival and Relay sunset

--- a/docs/game-design/ridge/areas/02-concert/README.md
+++ b/docs/game-design/ridge/areas/02-concert/README.md
@@ -86,8 +86,9 @@ Use **Concert Resting Spot** as the practical label.
 - After resolution: Cicka chills with the musicians near the opened exit; the
   injured guitarist or another band member may quietly pet her.
 
-This can later become the post-ending echo spot. The echo should be an empty
-usual spot plus one small paw/page mark, not the player's guitar left behind.
+This can later become the post-ending echo spot. If used, the echo should be a
+small visual absence cue at Cicka's usual spot, not the player's guitar left
+behind and not an unseeded paw/page mark mechanic.
 
 ## Boundaries
 

--- a/docs/game-design/ridge/areas/03-dance-festival/README.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/README.md
@@ -14,8 +14,9 @@ Dance Festival Area is the final required Ridge Area before Relay Spire.
 
 The emotional idea is: **Life can keep moving with someone new.**
 
-The player participates in afternoon setup for a real night dance festival and
-leaves before the festival fully begins. The beat is romantic, warm, and
+The player arrives during daytime setup for a real night dance festival, then
+the area progresses toward the late-afternoon last daylight shuttle. The
+player leaves before the festival fully begins. The beat is romantic, warm, and
 different from the Guitar Farewell: two fictional residents like each other but
 are too nervous to step onto the dance floor or talk directly. The player helps
 the place become ready and gives both residents enough dignity to meet later
@@ -33,6 +34,8 @@ without turning the scene into public matchmaking.
 
 - Accepted arrival premise: **Opening Dance Setup + Last Daylight Shuttle**.
 - Last-Stop Plaza sits at the foot of the Relay hill.
+- The player may arrive in daytime; the local beat can progress through
+  setup toward the late-afternoon shuttle window.
 - Festival setup blocks the service road with barriers, lantern lines, chair
   stacks, stage/speaker cables, and a locked gate.
 - The last daylight hill shuttle can leave only after the setup lane is safe.

--- a/docs/game-design/ridge/areas/03-dance-festival/README.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/README.md
@@ -44,7 +44,7 @@ without turning the scene into public matchmaking.
 - Setup clears through a short **Prompt-Driven Playable Montage**, not a chore
   list or pure cutscene.
 - The player catches a **Short Threshold Transition** to Relay under sunset.
-- The night dance can appear later as a Living Proof Montage echo during the
+- The night dance can appear later as a Route Memory Montage echo during the
   Guitar Farewell.
 
 ## Boundaries

--- a/docs/game-design/ridge/areas/03-dance-festival/interaction-flow.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/interaction-flow.md
@@ -176,11 +176,11 @@ such as "All aboard the last ride," the vehicle starts over a brief blackout,
 and the player respawns at Relay Spire under sunset.
 
 Control resumes at Cicka's overlook spot for the **Sit and Play Prompt** and
-**Guitar Farewell**. The later night festival can appear as a **Living Proof
+**Guitar Farewell**. The later night festival can appear as a **Route Memory
 Montage** image during the farewell instead of pulling the playable ending away
 from Cicka; the dancing can read as an emotional echo of the player's guitar
 rather than revealing or playing the actual requested festival song. After the
-montage, Relay returns in **Relay Blue Hour** for the **Send the Sketchbook
+montage, Relay enters the **Relay Holding State** for the **Send the Sketchbook
 Prompt** rather than full night.
 
 The emotional lesson is that life can continue and new love can arrive after

--- a/docs/game-design/ridge/areas/03-dance-festival/interaction-flow.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/interaction-flow.md
@@ -179,9 +179,9 @@ Control resumes at Cicka's overlook spot for the **Sit and Play Prompt** and
 **Guitar Farewell**. The later night festival can appear as a **Route Memory
 Montage** image during the farewell instead of pulling the playable ending away
 from Cicka; the dancing can read as an emotional echo of the player's guitar
-rather than revealing or playing the actual requested festival song. After the
-montage, Relay enters the **Relay Holding State** for the **Send the Sketchbook
-Prompt** rather than full night.
+rather than revealing or playing the actual requested festival song. The Sit and
+Play Prompt is the v0 final trigger rather than a setup for a separate
+post-song send prompt.
 
 The emotional lesson is that life can continue and new love can arrive after
 loss without replacing what was lost.

--- a/docs/game-design/ridge/areas/03-dance-festival/interaction-flow.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/interaction-flow.md
@@ -17,7 +17,7 @@ dance.
 First-read sequence:
 
 ```text
-Player arrives at Last-Stop Plaza.
+Player arrives at Last-Stop Plaza during daytime setup.
 Festival barriers, lantern lines, and shuttle sign show the route is blocked.
 Traveler says Relay requires the last daylight hill shuttle.
 Driver is visible by the shuttle, stuck on the route clipboard.

--- a/docs/game-design/ridge/areas/03-dance-festival/layout.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/layout.md
@@ -14,11 +14,12 @@ route to the Relay Spire is blocked by a practical final-approach problem:
 festival setup temporarily occupies the service road with barriers, lantern
 lines, chair stacks, stage/speaker cables, and a locked gate.
 
-Once setup is safe enough, the steward can open one short daylight window for
-the final hill shuttle before the road closes again for the night festival. The
-player helps the hill-shuttle driver, the Last-Stop Operations Helper, and
-nearby festival helpers finish that setup window, giving the driver a believable
-reason and means to take the player toward the Relay overlook at sunset.
+The player can arrive during daytime setup. Once setup is safe enough, the
+steward can open one short late-afternoon daylight window for the final hill
+shuttle before the road closes again for the night festival. The player helps
+the hill-shuttle driver, the Last-Stop Operations Helper, and nearby festival
+helpers finish that setup window, giving the driver a believable reason and
+means to take the player toward the Relay overlook at sunset.
 
 Accepted arrival premise: **Opening Dance Setup + Last Daylight Shuttle**. This
 replaces the previous after-festival **Last Song Table + Final Shuttle Hold**
@@ -65,7 +66,7 @@ actual full dance stays mostly offscreen or appears later in the ending montage.
 
 Open art/audio choices:
 
-- afternoon-to-sunset palette
+- daytime setup progressing toward a late-afternoon-to-sunset palette
 - signage language
 - crowd ambience level
 - music texture before the dance begins

--- a/docs/game-design/ridge/areas/04-relay-ending/README.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/README.md
@@ -17,9 +17,9 @@ The emotional idea is: **I am ready for Cicka's threshold farewell.**
 
 ## Accepted Local Contract
 
-- Relay Spire can be physically reachable before it is ready for the farewell.
 - In the current first-ending route, the Dance Festival clear is the practical
-  route action that brings the player to Relay.
+  route action that brings the player to Relay; do not add a separate pre-ready
+  Relay access state for v0.
 - Cicka appears in her final field-presence spot, calm and familiar.
 - The player uses **Sit and Play** near Cicka to share the **Guitar Farewell**.
   The first playable version should be mostly quiet, player-triggered, and

--- a/docs/game-design/ridge/areas/04-relay-ending/README.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/README.md
@@ -17,27 +17,27 @@ The emotional idea is: **I am ready for Cicka's threshold farewell.**
 
 ## Accepted Local Contract
 
-- Relay Spire can be physically reachable before it is ready to send.
+- Relay Spire can be physically reachable before it is ready for the farewell.
 - In the current first-ending route, the Dance Festival clear is the practical
   route action that brings the player to Relay.
 - Cicka appears in her final field-presence spot, calm and familiar.
 - The player uses **Sit and Play** near Cicka to share the **Guitar Farewell**.
-- A brief **Route Memory Montage** may appear during the guitar.
-- Control returns in a small **Relay Holding State** for **Send the Sketchbook
-  Prompt**.
-- During the Relay Holding State, Cicka remains physically present and calm.
-  The player may stay near her, sit again, play the guitar phrase again, walk a
-  small Relay clearing, or use an optional comfort interaction if supported.
-- The player cannot return to the wider Ridge route during the Relay Holding
-  State. **Send the Sketchbook Prompt** is the only completion action.
-- **Send the Sketchbook Prompt** is the final trigger for the ending. Exact
-  staging is provisional until blockout, but the action should read as the
-  player letting the sketchbook carry the completed farewell forward.
-- Cicka walks with the player to the threshold, pauses, looks back once, leaves
-  one final paw/page mark, then slips into a page fold or light beyond the
-  player's path.
+  The first playable version should be mostly quiet, player-triggered, and
+  short: sit beside Cicka, play the familiar Concert guitar phrase, and avoid
+  any pass/fail challenge.
+- A brief **Route Memory Montage** may appear during the guitar with 2-3 memory
+  flashes from the route.
+- **Sit and Play** is the final completion trigger for v0. Do not add **Send the
+  Sketchbook Prompt** unless the sketchbook becomes a seeded object or
+  interaction across the route first.
+- After the final guitar phrase, Cicka walks with the player to the threshold,
+  pauses, looks back once, then slips into a page fold, light, or other
+  threshold beyond the player's path.
+- Any final Relay trace or Concert Resting Spot echo should read as optional
+  visual staging only if earlier route art has taught that language; do not make
+  paw/page marks a mechanic or required symbol in v0.
 - The player returns to the **Open Ridge Return State** with the canonical final
-  mark preserved at Relay and one quiet Concert Resting Spot echo.
+  farewell complete and the guitar still with the player.
 
 ## Tone Boundaries
 
@@ -47,28 +47,28 @@ The emotional idea is: **I am ready for Cicka's threshold farewell.**
 - no arcade pass/fail challenge during the Guitar Farewell
 - no explanatory departure speech and no written goodbye in the initial version
 - no immediate replacement reveal; Micka remains delayed
-- no scattering sad marks everywhere in the initial return state
+- no scattering sad traces everywhere in the initial return state
 
 ## Route Readiness Feedback
 
 Provisional. The current first-ending route does not require a separate Living
-Proof checklist or optional-area readiness system. The main feedback need is
-the transition from Dance Festival clearance to Relay arrival, then from sunset
-Guitar Farewell to the Relay Holding State.
+Proof checklist, optional-area readiness system, or post-song send prompt. The
+main feedback need is the transition from Dance Festival clearance to Relay
+arrival, then from sunset Guitar Farewell into Cicka's threshold departure.
 
 ## Cicka Threshold Staging
 
 Unresolved. This area still needs exact decisions for camera behavior, input
-handoff, animation beats, silence, audio, mark placement, threshold geometry,
-and post-ending interactability.
+handoff, animation beats, silence, audio, visual trace placement if any,
+threshold geometry, and post-ending interactability.
 
 ## Open Local Slots
 
 - physical Relay topology and threshold geometry
 - final Cicka field-presence spot
-- camera and input handoff for Sit and Play
-- guitar audio texture and silence timing
-- Route Memory Montage length and image order
-- Send the Sketchbook Prompt presentation
+- exact camera and input handoff for Sit and Play
+- exact guitar audio texture and silence timing
+- exact Route Memory Montage image order
+- threshold departure presentation after Sit and Play
 - Open Ridge Return State interactions
 - delayed Micka trigger

--- a/docs/game-design/ridge/areas/04-relay-ending/README.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/README.md
@@ -5,24 +5,34 @@
 > [`../README.md`](../README.md) before editing this file.
 
 This file owns local design detail for **Relay Spire / Guitar Farewell / Cicka
-Threshold Farewell**. The route-level ending order and Living Proof rules live
+Threshold Farewell**. The route-level ending order and fixed area chain live
 in [`../../story-level-bible.md`](../../story-level-bible.md).
 
 ## Route Role
 
-Relay Ending Area is the final threshold after Bridge, Concert, and Dance
-Festival have created enough Living Proof.
+Relay Ending Area is the final threshold after the player clears the fixed
+Bridge, Concert, and Dance Festival area barricades.
 
 The emotional idea is: **I am ready for Cicka's threshold farewell.**
 
 ## Accepted Local Contract
 
 - Relay Spire can be physically reachable before it is ready to send.
-- Once Living Proof is enough, the Relay sign becomes readable.
+- In the current first-ending route, the Dance Festival clear is the practical
+  route action that brings the player to Relay.
 - Cicka appears in her final field-presence spot, calm and familiar.
 - The player uses **Sit and Play** near Cicka to share the **Guitar Farewell**.
-- A brief **Living Proof Montage** may appear during the guitar.
-- Control returns in **Relay Blue Hour** for **Send the Sketchbook Prompt**.
+- A brief **Route Memory Montage** may appear during the guitar.
+- Control returns in a small **Relay Holding State** for **Send the Sketchbook
+  Prompt**.
+- During the Relay Holding State, Cicka remains physically present and calm.
+  The player may stay near her, sit again, play the guitar phrase again, walk a
+  small Relay clearing, or use an optional comfort interaction if supported.
+- The player cannot return to the wider Ridge route during the Relay Holding
+  State. **Send the Sketchbook Prompt** is the only completion action.
+- **Send the Sketchbook Prompt** is the final trigger for the ending. Exact
+  staging is provisional until blockout, but the action should read as the
+  player letting the sketchbook carry the completed farewell forward.
 - Cicka walks with the player to the threshold, pauses, looks back once, leaves
   one final paw/page mark, then slips into a page fold or light beyond the
   player's path.
@@ -39,16 +49,12 @@ The emotional idea is: **I am ready for Cicka's threshold farewell.**
 - no immediate replacement reveal; Micka remains delayed
 - no scattering sad marks everywhere in the initial return state
 
-## Living Proof Feedback
+## Route Readiness Feedback
 
-Unresolved. The player needs a readable state for:
-
-- Relay reachable but not ready
-- Relay ready after the three required Ridge Areas
-- transition from sunset Guitar Farewell to Relay Blue Hour
-
-The feedback should feel like emotional and semantic readiness, not an exact
-visible checklist.
+Provisional. The current first-ending route does not require a separate Living
+Proof checklist or optional-area readiness system. The main feedback need is
+the transition from Dance Festival clearance to Relay arrival, then from sunset
+Guitar Farewell to the Relay Holding State.
 
 ## Cicka Threshold Staging
 
@@ -62,7 +68,7 @@ and post-ending interactability.
 - final Cicka field-presence spot
 - camera and input handoff for Sit and Play
 - guitar audio texture and silence timing
-- Living Proof Montage length and image order
+- Route Memory Montage length and image order
 - Send the Sketchbook Prompt presentation
 - Open Ridge Return State interactions
 - delayed Micka trigger

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -31,7 +31,7 @@ questions.
   [`../decision-intake.md`](../decision-intake.md).
 - Put unresolved decisions in [`../open-questions.md`](../open-questions.md)
   unless they are purely local notes inside one area doc.
-- If an area decision changes the route order, area barricade logic, Cicka's
+- If an area decision changes the route order, Area Barricade Chain, Cicka's
   cross-area role, or guitar/ending dependency, update
   [`../story-level-bible.md`](../story-level-bible.md) too.
 - If a design becomes implementation work, publish or update a GitHub Issue

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -10,7 +10,7 @@ This folder holds the local source-of-truth docs for the active Ridge route:
 ```
 
 Use [`../story-level-bible.md`](../story-level-bible.md) for the route spine,
-ending order, Living Proof rules, and cross-area Cicka/guitar logic. Use these
+ending order, area barricade chain, and cross-area Cicka/guitar logic. Use these
 area files for local geography, blockers, residents, prompts, traversal,
 staging, Cicka Resting Spot details, visual/audio notes, and area-specific open
 questions.
@@ -31,7 +31,7 @@ questions.
   [`../decision-intake.md`](../decision-intake.md).
 - Put unresolved decisions in [`../open-questions.md`](../open-questions.md)
   unless they are purely local notes inside one area doc.
-- If an area decision changes the route order, Living Proof logic, Cicka's
+- If an area decision changes the route order, area barricade logic, Cicka's
   cross-area role, or guitar/ending dependency, update
   [`../story-level-bible.md`](../story-level-bible.md) too.
 - If a design becomes implementation work, publish or update a GitHub Issue

--- a/docs/game-design/ridge/decision-intake.md
+++ b/docs/game-design/ridge/decision-intake.md
@@ -11,7 +11,7 @@ each claim to one canonical home.
 | Claim type | Destination |
 | --- | --- |
 | New stable domain term or ambiguity | [`../../../CONTEXT.md`](../../../CONTEXT.md) |
-| Accepted route spine, ending order, Cicka, guitar, or Living Proof decision | [`story-level-bible.md`](./story-level-bible.md) |
+| Accepted route spine, ending order, area barricade chain, Cicka, guitar, or route-readiness decision | [`story-level-bible.md`](./story-level-bible.md) |
 | Accepted area-local Bridge, Concert, Dance Festival, or Relay detail | matching file or subdoc under [`areas/`](./areas/README.md) |
 | Current implemented/runtime truth | [`ridge-snapshot.md`](./ridge-snapshot.md) or runtime source |
 | Hard-to-reverse surprising trade-off | numbered ADR under [`../../adr/`](../../adr/) |

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -47,8 +47,8 @@ doc instead.
   and exit conditions.
 - **P2 First Playable Route Blockout**: prove the route can be walked end to
   end with placeholder art and no required precision platforming.
-- **P3 Living Proof Feedback**: make resident help, world changes, and Relay
-  readiness readable without a visible chore checklist.
+- **P3 Route Readiness Feedback**: make area barricades, resident help, world
+  changes, and Relay arrival readable without a visible chore checklist.
 - **P4 Ending Pass**: land Guitar Farewell, Send the Sketchbook Prompt, Cicka
   Threshold Farewell, Open Ridge Return State, and later Micka timing.
 
@@ -62,8 +62,8 @@ For Ridge rework issues, link the smallest relevant set:
 
 - [`README.md`](./README.md): source matrix and update protocol
 - [`summit.md`](./summit.md): product fantasy, pillars, and scope instincts
-- [`story-level-bible.md`](./story-level-bible.md): route spine, Living Proof,
-  Cicka/guitar logic, ending order
+- [`story-level-bible.md`](./story-level-bible.md): route spine, area barricade
+  chain, Cicka/guitar logic, ending order
 - [`areas/`](./areas/README.md): Bridge, Concert, Dance Festival, Relay detail
 - [`open-questions.md`](./open-questions.md): unresolved design gaps
 - [`ridge-snapshot.md`](./ridge-snapshot.md): current Phaser prototype/runtime
@@ -100,7 +100,7 @@ Do not inherit these as active route requirements:
 - Cicka Home as central hub
 - folded-desk route order
 - platformer-like traversal
-- required mini-game clears as Living Proof
+- required mini-game clears as first-ending proof
 - Stampede-gated Cicka memory as first-ending dependency
 - old M0-M7 sequence as live backlog
 

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -22,8 +22,8 @@ The first complete route should prove:
 2. Relay Spire is visible early
 3. required Resident Help Beats visibly change the Ridge
 4. Cicka feels present through field appearances and resting spots
-5. Guitar Farewell, Send the Sketchbook Prompt, Cicka Threshold Farewell, and
-   Open Ridge Return State land without arcade gating
+5. Guitar Farewell, Cicka Threshold Farewell, and Open Ridge Return State land
+   without arcade gating or an unseeded extra final prompt
 6. optional mini-games remain side fun, rewards, shortcuts, or future
    alternate-path candidates rather than required first-ending proof
 
@@ -49,8 +49,8 @@ doc instead.
   end with placeholder art and no required precision platforming.
 - **P3 Route Readiness Feedback**: make area barricades, resident help, world
   changes, and Relay arrival readable without a visible chore checklist.
-- **P4 Ending Pass**: land Guitar Farewell, Send the Sketchbook Prompt, Cicka
-  Threshold Farewell, Open Ridge Return State, and later Micka timing.
+- **P4 Ending Pass**: land Guitar Farewell as the final trigger, Cicka Threshold
+  Farewell, Open Ridge Return State, and later Micka timing.
 
 Optional mini-games, old Cicka Home mutation work, and folded-desk topology
 enter these milestones only when an active route doc or issue pulls a specific

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -11,33 +11,34 @@ the narrowest subdoc inside that area folder.
 
 ## Ending
 
-- **Guitar Farewell staging:** What are the camera, input handoff, animation,
-  silence, and audio beats from Sit and Play through the Relay Holding State?
-- **Relay Holding State:** What small movement, repeat guitar, sitting, or
-  comfort interactions are available before Send the Sketchbook, and how is the
-  wider Ridge route blocked without feeling gamey?
-- **Send the Sketchbook staging:** What exactly happens to the sketchbook, the
-  accumulated marks, and the threshold when the final trigger is selected?
+- **Guitar Farewell micro-staging:** Given the accepted quiet, short Sit and
+  Play shape, what are the exact camera, input handoff, animation, silence, and
+  audio beats from guitar phrase through Cicka's threshold departure?
+- **Pre-ending Relay linger:** What small movement, sitting, or comfort
+  interactions are available before the player chooses Sit and Play, and how is
+  the wider Ridge route blocked without feeling gamey?
 - **Cicka Threshold Farewell staging:** What exact physical sequence carries
-  Cicka's final walk, look back, mark, and page-fold/light departure?
+  Cicka's final walk, look back, and page-fold/light departure without relying
+  on unseeded paw/page marks as a mechanic?
 - **Open Ridge Return State:** What interactions remain available immediately
-  after the ending, and what exact state is preserved at Relay and the Concert
-  Resting Spot?
+  after the ending, and what minimal visual absence echo, if any, is preserved
+  at Relay or the Concert Resting Spot?
 - **Micka timing:** What post-ending action eventually introduces Micka, and
   what must stay hidden until then?
 
 ## Route Transitions
 
 - **Concert-to-Dance travel staging:** What exact beats show the accepted
-  implied post-concert rest and morning Band Roadie Van Ride without becoming a
-  required driving mini-game?
+  implied post-concert rest and post-rest Band Roadie Van Ride without becoming
+  a required driving mini-game?
 - **Band roadie destination flavor:** Is the band roadie taking the injured
   guitarist to a local hospital/clinic, heading to another gig route, going to
   band storage, or leaving the destination unexplained while dropping the player
   near Dance Festival because it is on the way?
-- **Recurring festival superfan:** Should Bridge and Concert include a recurring
-  comic resident who keeps talking about the Dance Festival, only to sleep
-  through it, and should he enter v0 or the immediate post-v0 liveliness pass?
+- **Recurring festival superfan placement:** Where should the desired comic
+  resident be seeded at Bridge and Concert, where does he sleep through Dance,
+  and is he cheap enough for v0 or better saved for the immediate post-v0
+  liveliness pass?
 
 ## Dance Festival Area
 
@@ -64,11 +65,15 @@ the narrowest subdoc inside that area folder.
 - **Concert guitarist stunt staging:** How much of the guitarist's absurd
   skateboard stunt needs to be shown, implied, or reconstructed through props
   so the joke lands without becoming expensive animation scope?
-- **Bridge dependency:** How much does Blueprint Bridge need to teach about
-  resident help and visible world change before later beats depend on it?
-- **Cicka Resting Spots:** What tiny before/after visual state does each
-  required Ridge Area need before those states can echo in the Route Memory
-  Montage?
+- **Bridge blockout validation:** What must be visible in the Bridge blockout
+  to prove the accepted tutorial chain is readable: Cicka noticed something,
+  resident needs local help, route visibly changes?
+- **Cicka Resting Spots v0 states:** Which exact before/after prop, posture, or
+  visual trace is the smallest readable version for each required Ridge Area,
+  and which of those states should echo in the Route Memory Montage?
+- **Whole-route v0 scope floor:** What is the smallest playable route from
+  Bridge through Relay that preserves the emotional arc without waiting for
+  later mini-games, interiors, campfire, or extra resident liveliness?
 
 ## Resolution Rule
 

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -29,8 +29,12 @@ the narrowest subdoc inside that area folder.
 ## Route Transitions
 
 - **Concert-to-Dance travel staging:** What exact beats show the accepted
-  post-concert campfire/tent rest and morning Band Roadie Van Ride without
-  becoming a required driving mini-game?
+  implied post-concert rest and morning Band Roadie Van Ride without becoming a
+  required driving mini-game?
+- **Band roadie destination flavor:** Is the band roadie taking the injured
+  guitarist to a local hospital/clinic, heading to another gig route, going to
+  band storage, or leaving the destination unexplained while dropping the player
+  near Dance Festival because it is on the way?
 - **Recurring festival superfan:** Should Bridge and Concert include a recurring
   comic resident who keeps talking about the Dance Festival, only to sleep
   through it, and should he enter v0 or the immediate post-v0 liveliness pass?

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -11,10 +11,13 @@ the narrowest subdoc inside that area folder.
 
 ## Ending
 
-- **Living Proof feedback:** What does the player see, hear, or read when Relay
-  is physically reachable but not ready to send?
 - **Guitar Farewell staging:** What are the camera, input handoff, animation,
-  silence, and audio beats from Sit and Play through Relay Blue Hour?
+  silence, and audio beats from Sit and Play through the Relay Holding State?
+- **Relay Holding State:** What small movement, repeat guitar, sitting, or
+  comfort interactions are available before Send the Sketchbook, and how is the
+  wider Ridge route blocked without feeling gamey?
+- **Send the Sketchbook staging:** What exactly happens to the sketchbook, the
+  accumulated marks, and the threshold when the final trigger is selected?
 - **Cicka Threshold Farewell staging:** What exact physical sequence carries
   Cicka's final walk, look back, mark, and page-fold/light departure?
 - **Open Ridge Return State:** What interactions remain available immediately
@@ -50,7 +53,7 @@ the narrowest subdoc inside that area folder.
 - **Bridge dependency:** How much does Blueprint Bridge need to teach about
   resident help and visible world change before later beats depend on it?
 - **Cicka Resting Spots:** What tiny before/after visual state does each
-  required Ridge Area need before those states can echo in the Living Proof
+  required Ridge Area need before those states can echo in the Route Memory
   Montage?
 
 ## Resolution Rule

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -48,8 +48,9 @@ the narrowest subdoc inside that area folder.
 
 ## Dependencies
 
-- **Concert dependency:** How exactly does Concert Crossing entrust the guitar
-  so the Guitar Farewell feels earned?
+- **Concert guitarist stunt staging:** How much of the guitarist's absurd
+  skateboard stunt needs to be shown, implied, or reconstructed through props
+  so the joke lands without becoming expensive animation scope?
 - **Bridge dependency:** How much does Blueprint Bridge need to teach about
   resident help and visible world change before later beats depend on it?
 - **Cicka Resting Spots:** What tiny before/after visual state does each

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -26,6 +26,15 @@ the narrowest subdoc inside that area folder.
 - **Micka timing:** What post-ending action eventually introduces Micka, and
   what must stay hidden until then?
 
+## Route Transitions
+
+- **Concert-to-Dance travel staging:** What exact beats show the accepted
+  post-concert campfire/tent rest and morning Band Roadie Van Ride without
+  becoming a required driving mini-game?
+- **Recurring festival superfan:** Should Bridge and Concert include a recurring
+  comic resident who keeps talking about the Dance Festival, only to sleep
+  through it, and should he enter v0 or the immediate post-v0 liveliness pass?
+
 ## Dance Festival Area
 
 - **Spatial layout:** What is the room topology for Last-Stop Plaza, service

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -36,7 +36,7 @@ the narrowest subdoc inside that area folder.
   band storage, or leaving the destination unexplained while dropping the player
   near Dance Festival because it is on the way?
 - **Recurring festival superfan placement:** Where should the desired comic
-  resident be seeded at Bridge and Concert, where does he sleep through Dance,
+  resident be seeded at Bridge and Concert, where he sleeps through Dance,
   and is he cheap enough for v0 or better saved for the immediate post-v0
   liveliness pass?
 

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -173,8 +173,8 @@ story/level pass proves they create meaningful replay value without weakening
 the Cicka farewell.
 The first prose artifact should be a short ending sequence outline before the
 required Ridge Areas and their Resident Beats are designed: arrival state, Relay
-readiness, Cicka's final field presence, farewell action, final mark, and
-return-to-Ridge state.
+readiness, Cicka's final field presence, farewell action, threshold departure,
+and return-to-Ridge state.
 
 Accepted first ending outline:
 
@@ -182,20 +182,17 @@ Accepted first ending outline:
    and Dance Festival Area before Relay.
 2. Clearing the Dance Festival barricade grants the last daylight ride to Relay.
 3. Cicka appears in her final field-presence spot, calm and familiar.
-4. The player shares a quiet Guitar Farewell with Cicka, ideally under a warm
-   sunset or other cozy threshold light.
-5. Control returns in a small **Relay Holding State** for a **Send the
-   Sketchbook Prompt**.
-6. Cicka remains physically present while the player can linger near Relay, but
-   the wider Ridge route does not reopen until the sketchbook is sent.
-7. Cicka walks with the player to the threshold, pauses, looks back once, leaves
-   one final paw/page mark, then slips into a page fold or light beyond the
-   player's path. The initial version uses no translated farewell line.
-8. The player returns to the **Open Ridge Return State** after the ending, with
-   the canonical final mark preserved at the Relay threshold, one quieter echo
-   at the Concert Resting Spot, and the world still open. The echo is the
-   empty usual spot plus one small paw/page mark, not the player's guitar left
-   behind.
+4. The player uses **Sit and Play** to share a quiet Guitar Farewell with Cicka,
+   ideally under a warm sunset or other cozy threshold light. This is the v0
+   final trigger, not setup for a separate post-song send prompt.
+5. Cicka walks with the player to the threshold, pauses, looks back once, then
+   slips into a page fold, light, or other threshold beyond the player's path.
+   The initial version uses no translated farewell line.
+6. A final Relay trace or Concert Resting Spot echo can exist only as visual
+   staging if earlier route art has taught that language. Do not present
+   paw/page marks as a mechanic or required symbol in v0.
+7. The player returns to the **Open Ridge Return State** after the ending, with
+   the world still open and the guitar still with the player.
 
 The guitar should be established earlier as a meaningful comfort item:
 something the player can pick up and carry before the Relay **Guitar Farewell**.
@@ -310,34 +307,27 @@ The target asks for:
 - Guitar Farewell can include a brief **Route Memory Montage**: Blueprint Bridge
   being used, Concert Crossing continuing, Opening Dance beginning at night as
   an emotional echo under the player's guitar, and earlier Cicka Resting Spots
-  carrying accumulated marks. Keep it wordless or nearly wordless so the focus
-  stays on Cicka.
-- Relay time should progress from sunset for **Sit and Play Prompt** to the
-  **Relay Holding State** for **Send the Sketchbook Prompt**. The montage can
-  show the night festival beginning elsewhere, but Relay should not become full
-  night before the farewell.
+  carrying changed visual states. Keep it wordless or nearly wordless so the
+  focus stays on Cicka.
+- Relay should use sunset for **Sit and Play Prompt** and the Cicka Threshold
+  Farewell. The montage can show the night festival beginning elsewhere, but
+  Relay should not become full night before the farewell.
 - The shuttle ride from Last-Stop Plaza to Relay should be a **Short Threshold
   Transition**, not a controllable driving segment: the driver can say "All
   aboard the last ride," the vehicle starts over a brief blackout, the player
   respawns at Relay Spire under sunset, and control resumes at Cicka's overlook
   spot.
 - The final Relay Spire interaction should be a **Sit and Play Prompt** near
-  Cicka. It starts the Guitar Farewell without rhythm UI, fail state, or final
-  skill check.
-- After the Guitar Farewell, control returns at the Relay sign/spire in a
-  **Relay Holding State** for a **Send the Sketchbook Prompt**. This starts the
-  Cicka Threshold Farewell while keeping the guitar as comfort rather than the
-  send button.
+  Cicka. It starts the Guitar Farewell and commits to the ending without rhythm
+  UI, fail state, final skill check, or separate post-song send prompt.
 - Cicka's departure should be physical and mostly silent: walk together, pause,
-  look back, final mark, then page-fold/light departure. The initial version
-  should use no translated farewell line; a tiny raw meow/chirp sound can remain
-  optional if it supports the staging.
+  look back, then page-fold/light departure. The initial version should use no
+  translated farewell line; a tiny raw meow/chirp sound can remain optional if
+  it supports the staging.
 - Immediate post-ending play should use the **Open Ridge Return State**:
-  replayable, quiet, and minimally absence-marked. The canonical final mark
-  persists at the Relay threshold, one quieter echo appears at the Concert
-  Resting Spot, and Micka remains delayed until the later post-ending trigger
-  rather than appearing immediately. The echo should be an empty usual spot with
-  one small paw/page mark, not the guitar left behind.
+  replayable, quiet, and minimally absence-marked only if the route has seeded
+  that visual language. Micka remains delayed until the later post-ending
+  trigger rather than appearing immediately. The guitar stays with the player.
 - Cicka field presence in every required Resident Help Beat, with one local
   **Cicka Resting Spot** per required Ridge Area: Bridge Resting Spot, Concert
   Resting Spot, and Dance Festival Resting Spot. Her role can vary from subtle

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -178,17 +178,20 @@ return-to-Ridge state.
 
 Accepted first ending outline:
 
-1. The player reaches Relay Spire and can stand there before it is ready.
-2. Once Living Proof is enough, the Relay sign becomes readable.
+1. The fixed main route carries the player through Bridge Area, Concert Area,
+   and Dance Festival Area before Relay.
+2. Clearing the Dance Festival barricade grants the last daylight ride to Relay.
 3. Cicka appears in her final field-presence spot, calm and familiar.
 4. The player shares a quiet Guitar Farewell with Cicka, ideally under a warm
    sunset or other cozy threshold light.
-5. Control returns in **Relay Blue Hour** at the Relay sign/spire for a **Send
-   the Sketchbook Prompt**.
-6. Cicka walks with the player to the threshold, pauses, looks back once, leaves
+5. Control returns in a small **Relay Holding State** for a **Send the
+   Sketchbook Prompt**.
+6. Cicka remains physically present while the player can linger near Relay, but
+   the wider Ridge route does not reopen until the sketchbook is sent.
+7. Cicka walks with the player to the threshold, pauses, looks back once, leaves
    one final paw/page mark, then slips into a page fold or light beyond the
    player's path. The initial version uses no translated farewell line.
-7. The player returns to the **Open Ridge Return State** after the ending, with
+8. The player returns to the **Open Ridge Return State** after the ending, with
    the canonical final mark preserved at the Relay threshold, one quieter echo
    at the Concert Resting Spot, and the world still open. The echo is the
    empty usual spot plus one small paw/page mark, not the player's guitar left
@@ -221,14 +224,11 @@ fallback: conversation, collection, practice together, or a forgiving auto-play
 path can resolve the main route while the Guitar-Hero-like mini-game remains the
 ideal or optional version.
 
-The final blocker should be a **Living Proof Gate**. The Relay Spire can be
-physically reachable early, but it should not send the sketchbook until the path
-has created enough resident/world changes and Cicka familiarity to make the
-destination emotionally and semantically ready. The three required Ridge Areas
-should be enough proof for the current first ending. Avoid an
-exact visible checklist unless testing shows the player needs clearer feedback.
-Changed Cicka Resting Spots should not count as proof by themselves; they are
-emotional echoes of resident/world changes already earned elsewhere.
+The final route structure should be an **Area Barricade Chain**. Bridge,
+Concert, and Dance Festival each contain one concrete local barricade; clearing
+the Dance Festival barricade brings the player to Relay. Earlier "Living Proof"
+language should now be treated as poetic shorthand for completed area changes,
+not a separate proof resource, checklist, or optional readiness system.
 Planning assumption: start with 2-3 required main-path Resident Help Beats
 before the first ending, plus optional extra residents for return play. Treat the
 exact count as a Level Designer and Story/Tone tuning variable, not a fixed
@@ -237,12 +237,8 @@ rule.
 The target asks for:
 
 - a readable mostly forward neighborhood route toward Relay Spire
-- Relay Spire physically reachable before it can send
-- Living Proof Gate made from enough visible world changes and Cicka familiarity
-  rather than an exact checklist; the three required Ridge Areas should be
-  enough for the current first ending
-- changed Cicka Resting Spots as emotional echoes of proof, not separate proof
-  sources
+- fixed Bridge -> Concert -> Dance Festival -> Relay Area Barricade Chain
+- changed Cicka Resting Spots as emotional echoes, not separate proof sources
 - first ending path completable through conversations, collection, authored
   traversal, Ridge Areas, Resident Beats, and world changes without requiring
   full arcade mini-games
@@ -311,15 +307,15 @@ The target asks for:
   comfort, Dance Festival Area / Opening Dance Shuttle Beat means life can keep
   moving with someone new, then Relay Spire / Guitar Farewell resolves Cicka's
   threshold farewell
-- Guitar Farewell can include a brief **Living Proof Montage**: Blueprint Bridge
+- Guitar Farewell can include a brief **Route Memory Montage**: Blueprint Bridge
   being used, Concert Crossing continuing, Opening Dance beginning at night as
   an emotional echo under the player's guitar, and earlier Cicka Resting Spots
   carrying accumulated marks. Keep it wordless or nearly wordless so the focus
   stays on Cicka.
-- Relay time should progress from sunset for **Sit and Play Prompt** to **Relay
-  Blue Hour** for **Send the Sketchbook Prompt**. The montage can show the night
-  festival beginning elsewhere, but Relay should not become full night before
-  the farewell.
+- Relay time should progress from sunset for **Sit and Play Prompt** to the
+  **Relay Holding State** for **Send the Sketchbook Prompt**. The montage can
+  show the night festival beginning elsewhere, but Relay should not become full
+  night before the farewell.
 - The shuttle ride from Last-Stop Plaza to Relay should be a **Short Threshold
   Transition**, not a controllable driving segment: the driver can say "All
   aboard the last ride," the vehicle starts over a brief blackout, the player
@@ -328,9 +324,10 @@ The target asks for:
 - The final Relay Spire interaction should be a **Sit and Play Prompt** near
   Cicka. It starts the Guitar Farewell without rhythm UI, fail state, or final
   skill check.
-- After the Guitar Farewell, control returns at the Relay sign/spire for a
-  **Send the Sketchbook Prompt**. This starts the Cicka Threshold Farewell while
-  keeping the guitar as comfort rather than the send button.
+- After the Guitar Farewell, control returns at the Relay sign/spire in a
+  **Relay Holding State** for a **Send the Sketchbook Prompt**. This starts the
+  Cicka Threshold Farewell while keeping the guitar as comfort rather than the
+  send button.
 - Cicka's departure should be physical and mostly silent: walk together, pause,
   look back, final mark, then page-fold/light departure. The initial version
   should use no translated farewell line; a tiny raw meow/chirp sound can remain

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -159,7 +159,7 @@ Use practical design labels for these spots:
 | Area | Practical resting spot label | Before resolution | After resolution |
 | --- | --- | --- | --- |
 | [Bridge Area](./areas/01-bridge/README.md) | Bridge Resting Spot | Cicka perches near the unsafe crossing or blank plan | Cicka settles near the completed bridge sketch or leaves a tiny mark by the crossing |
-| [Concert Area](./areas/02-concert/README.md) | Concert Resting Spot | Cicka watches the guitar case, stage edge, or blocked crossing | Cicka rests in a quiet listening corner near the opened crossing; this can later become the post-ending echo spot |
+| [Concert Area](./areas/02-concert/README.md) | Concert Resting Spot | Cicka avoids the crowd and watches from a hidden musician-side place near the guitar case, stage props, or injured guitarist | Cicka chills with the musicians near the opened exit, optionally being quietly pet by the injured guitarist or another band member; this can later become the post-ending echo spot |
 | [Dance Festival Area](./areas/03-dance-festival/README.md) | Dance Festival Resting Spot | Cicka loafs near the operations table, shuttle step, lantern crates, or service gate | Cicka settles near the cleared service gate or finished shuttle sign, optionally beside the Unnamed Counterpart Cat |
 
 ## Guitar
@@ -201,7 +201,7 @@ Relay Spire / Guitar Farewell -> I am ready for Cicka's threshold farewell.
 | Area | Resident Beat | Status | Route role | Cicka role | World change |
 | --- | --- | --- | --- | --- | --- |
 | [Bridge Area](./areas/01-bridge/README.md) | Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
-| [Concert Area](./areas/02-concert/README.md) | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Points attention to guitar case, string, stage, or crossing | Concert continues; crossing opens; guitar entrusted to player |
+| [Concert Area](./areas/02-concert/README.md) | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Crowd-shy observer near hidden musician-side space, then relaxed with the band after the crossing opens | Concert continues; crossing opens; guitar entrusted to player |
 | [Dance Festival Area](./areas/03-dance-festival/README.md) | Opening Dance Shuttle Beat | Accepted final beat direction; Last-Stop Operations Helper locked as romantic partner role | Creates the last emotional readiness before Relay through afternoon setup for a night dance festival at the foot of the Relay hill | Quiet threshold observer near the lantern crates, operations table, shuttle step, or service gate; may loaf with the Unnamed Counterpart Cat | Festival setup clears enough for one last daylight shuttle to Relay before the night road closure |
 | [Relay Ending Area](./areas/04-relay-ending/README.md) | Guitar Farewell / Cicka Threshold Farewell | Active ending direction | Final threshold after the Dance Festival barricade is cleared | Final field-presence spot and threshold departure | Open Ridge Return State preserves the final Relay mark and one quiet Concert echo |
 
@@ -232,27 +232,40 @@ then echo in the Guitar Farewell montage.
 Detailed local contract:
 [`Concert Area`](./areas/02-concert/README.md).
 
+Concert Area should read as a compact city-like concert block with small
+buildings, bars, stage-adjacent storefronts, alleys, and lived-in street details
+around the blocked crossing. The first prototype can use facades and silhouettes
+instead of enterable buildings; later passes may add interiors, extra residents,
+and hangout spaces to make the block feel more alive.
+
 A crowd, traffic line, or gathering blocks the route while everyone waits for
-the concert to start. The player asks what is taking so long, finds the local
-guitarist away from the crowd, and learns that the guitarist cannot play because
-of a clumsy show-off mishap: after a kid teased that he was old, he tried to
-prove he was still young by doing an absurd concert stunt, such as playing
-guitar while riding a skateboard on one leg, and hurt his hand or wrist. The
-player learns one **Forgiving Practice Riff** and takes over the concert. In
-v0, the concert performance can be auto-success or highly forgiving so the main
-route is not blocked by rhythm-game production. After the first playable route
-lands, a Guitar-Hero-like or Baka Mitai-style button-rhythm guitar mini-game can
-become the richer expression, potentially using Danilo's real guitar/song
-material and generated button prompts from authored song data. Once the
-performance begins, the crowd/traffic clears. After the concert, the musician
-or band waits near the opened exit for a short goodbye/reward beat where the
-guitarist entrusts the guitar to the player. This is the same physical guitar
-the player carries for the rest of the game and uses at Relay for the
-**Guitar Farewell**.
+the concert to start. The player can learn that the concert is late from
+annoyed crowd chatter, but the area should stay compact enough that simply
+wandering and talking with people can reveal the musician-side space. There the
+player finds the local guitarist and learns that he cannot play because of a
+clumsy show-off mishap: after a kid teased that he was old, he tried to prove
+he was still young by doing an absurd concert stunt, such as playing guitar
+while riding a skateboard on one leg, and hurt his hand or wrist. The player
+learns one **Forgiving Practice Riff** and takes over the concert. In v0, the
+concert performance can be auto-success or highly forgiving so the main route is
+not blocked by rhythm-game production. After the first playable route lands, a
+Guitar-Hero-like or Baka Mitai-style button-rhythm guitar mini-game can become
+the richer expression, potentially using Danilo's real guitar/song material and
+generated button prompts from authored song data. Once the performance begins,
+the crowd/traffic clears. After the concert, the musician or band waits near
+the opened exit for a short goodbye/reward beat where the guitarist entrusts
+the guitar to the player. This is the same physical guitar the player carries
+for the rest of the game and uses at Relay for the **Guitar Farewell**.
 
 The ideal later version can include a small Guitar-Hero-like performance
 mini-game. The required v0 route should use forgiving practice or auto-success
 performance first.
+
+The first blockout floor is: blocked crowd/traffic crossing, 2-3 annoyed crowd
+NPCs, hidden musician-side nook, injured guitarist, one forgiving practice
+interaction, auto-success concert start, crowd clears, goodbye/reward at the
+opened exit, guitar received, and Cicka hidden before/chilling with the band
+after.
 
 Avoid making the guitarist a joke-only drunk if it undercuts the later tribute.
 Gentle comedy, clumsiness, and foolishness are welcome; the guitar's emotional

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -171,6 +171,10 @@ pickup.
 After the player receives it, the guitar should feel present as a carried
 comfort item, but v0 does not need repeatable guitar prompts at every resting
 spot. The required playable comfort moment is the Relay **Guitar Farewell**.
+The only required guitar uses in the first-ending route are the Concert
+performance and the Relay **Sit and Play** interaction. Optional later polish can
+let the player sit at Cicka Resting Spots and play a tiny phrase there, but
+these should stay optional comfort interactions rather than route gates.
 
 Petting, lap resting, and similar affection interactions are later polish
 passes. A hug is optional and should wait until character art can support it
@@ -228,17 +232,31 @@ then echo in the Guitar Farewell montage.
 Detailed local contract:
 [`Concert Area`](./areas/02-concert/README.md).
 
-A blocked concert/traffic crossing halts the route because the local guitarist
-cannot play, the paper-stage setup is tangled, or the guitar needs a small
-repair. The player helps the resident, learns the guitar, and receives or is
-entrusted with the guitar afterward.
+A crowd, traffic line, or gathering blocks the route while everyone waits for
+the concert to start. The player asks what is taking so long, finds the local
+guitarist away from the crowd, and learns that the guitarist cannot play because
+of a clumsy show-off mishap: after a kid teased that he was old, he tried to
+prove he was still young by doing an absurd concert stunt, such as playing
+guitar while riding a skateboard on one leg, and hurt his hand or wrist. The
+player learns one **Forgiving Practice Riff** and takes over the concert. In
+v0, the concert performance can be auto-success or highly forgiving so the main
+route is not blocked by rhythm-game production. After the first playable route
+lands, a Guitar-Hero-like or Baka Mitai-style button-rhythm guitar mini-game can
+become the richer expression, potentially using Danilo's real guitar/song
+material and generated button prompts from authored song data. Once the
+performance begins, the crowd/traffic clears. After the concert, the musician
+or band waits near the opened exit for a short goodbye/reward beat where the
+guitarist entrusts the guitar to the player. This is the same physical guitar
+the player carries for the rest of the game and uses at Relay for the
+**Guitar Farewell**.
 
-The ideal version can include a small Guitar-Hero-like performance mini-game.
-The required route must also have a non-arcade fallback through conversation,
-collection, practice together, or forgiving auto-play.
+The ideal later version can include a small Guitar-Hero-like performance
+mini-game. The required v0 route should use forgiving practice or auto-success
+performance first.
 
 Avoid making the guitarist a joke-only drunk if it undercuts the later tribute.
-Gentle comedy is welcome; the guitar's emotional role needs room to breathe.
+Gentle comedy, clumsiness, and foolishness are welcome; the guitar's emotional
+role needs room to breathe.
 
 ## Blueprint Bridge
 

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -118,19 +118,27 @@ implying progress toward the final ridge.
 
 Current time-of-day arc: Bridge begins during the day at a nature/hill edge;
 Concert moves into evening/night small-town festival energy; a short sleep/rest
-interlude carries the player from Concert night to Dance Festival morning/day
-arrival; Dance Festival plays from morning/day setup into later afternoon; Relay
+interlude carries the player from Concert night to Dance Festival daytime
+arrival; Dance Festival plays from daytime setup into later afternoon; Relay
 uses sunset for Sit and Play, then the Relay Holding State for Send the
 Sketchbook.
 
 Current Concert-to-Dance transition direction: after the night concert, the
 route should rest instead of sending the player walking through the night. The
-leading flavor is a small post-concert campfire/tent sleepover, followed by
-morning travel toward Dance Festival through a grounded **Band Roadie Van
-Ride**. The transport role is a band roadie / van driver from the Concert area,
-not the injured guitarist. The roadie is a practical helpful character who
-offers the ride because the player saved the concert and the band is already
-packing up gear; he should not own the sleep-through-festival joke.
+rest can be implied or skipped in v0; a small post-concert campfire/tent hangout
+can become later liveliness scope for talking with characters, playing with
+Cicka, or adding a tiny optional toy. Morning travel toward Dance Festival uses
+a grounded **Band Roadie Van Ride**. The transport role is a band roadie / van
+driver from the Concert area, not the injured guitarist. The roadie is a
+practical helpful character who offers the ride because the player saved the
+concert and the band is already packing up gear; he should not own the
+sleep-through-festival joke. The roadie/band do not need to attend the Dance
+Festival. They are headed somewhere else nearby, such as a local hospital or
+clinic for the guitarist's wrist, another gig route, band storage, or an
+unexplained practical destination, and Dance Festival road is on the way.
+Cicka can be present if the later campfire/tent rest is shown, and she may
+arrive near Dance Festival by sneaking into or around the van. V0 does not need
+to explain her travel; she can simply appear nearby as authored field presence.
 
 A separate recurring **Festival Superfan** is desired for the game, but can wait
 until the immediate post-v0 liveliness pass if the first route prototype is
@@ -245,7 +253,7 @@ Relay Spire / Guitar Farewell -> I am ready for Cicka's threshold farewell.
 | --- | --- | --- | --- | --- | --- |
 | [Bridge Area](./areas/01-bridge/README.md) | Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
 | [Concert Area](./areas/02-concert/README.md) | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Crowd-shy observer near hidden musician-side space, then relaxed with the band after the crossing opens | Concert continues; crossing opens; guitar entrusted to player |
-| [Dance Festival Area](./areas/03-dance-festival/README.md) | Opening Dance Shuttle Beat | Accepted final beat direction; Last-Stop Operations Helper locked as romantic partner role | Creates the last emotional readiness before Relay through afternoon setup for a night dance festival at the foot of the Relay hill | Quiet threshold observer near the lantern crates, operations table, shuttle step, or service gate; may loaf with the Unnamed Counterpart Cat | Festival setup clears enough for one last daylight shuttle to Relay before the night road closure |
+| [Dance Festival Area](./areas/03-dance-festival/README.md) | Opening Dance Shuttle Beat | Accepted final beat direction; Last-Stop Operations Helper locked as romantic partner role | Creates the last emotional readiness before Relay through daytime setup that progresses toward late afternoon for a night dance festival at the foot of the Relay hill | Quiet threshold observer near the lantern crates, operations table, shuttle step, or service gate; may loaf with the Unnamed Counterpart Cat | Festival setup clears enough for one last daylight shuttle to Relay before the night road closure |
 | [Relay Ending Area](./areas/04-relay-ending/README.md) | Guitar Farewell / Cicka Threshold Farewell | Active ending direction | Final threshold after the Dance Festival barricade is cleared | Final field-presence spot and threshold departure | Open Ridge Return State preserves the final Relay mark and one quiet Concert echo |
 
 ## Opening Dance Shuttle Beat
@@ -254,8 +262,9 @@ Detailed local contract:
 [`Dance Festival Area`](./areas/03-dance-festival/README.md).
 
 Accepted route summary: the player reaches **Last-Stop Plaza** at the foot of
-the Relay hill during afternoon setup for a night dance festival. Festival
-setup blocks the service road with barriers, lantern lines, chair stacks,
+the Relay hill during daytime setup for a night dance festival, then the beat
+progresses toward the late-afternoon last daylight shuttle. Festival setup
+blocks the service road with barriers, lantern lines, chair stacks,
 stage/speaker cables, and a locked gate. The last daylight hill shuttle can
 leave only after the setup lane is safe.
 
@@ -275,13 +284,12 @@ then echo in the Guitar Farewell montage.
 Detailed local contract:
 [`Concert Area`](./areas/02-concert/README.md).
 
-Concert Area should read as a compact small-town / varos-like concert block with
-small buildings, bars, stage-adjacent storefronts, alleys, and lived-in street
-details around the blocked crossing. The concert can be a daytime or afternoon
-local festival-style event rather than a night-club gig. The first prototype can
-use facades and silhouettes instead of enterable buildings; later passes may add
-interiors, extra residents, and hangout spaces to make the block feel more
-alive.
+Concert Area should read as a compact small-town / varos-like concert block at
+evening or night, with small buildings, bars, stage-adjacent storefronts,
+alleys, street lights, and lived-in festival details around the blocked
+crossing. The first prototype can use facades and silhouettes instead of
+enterable buildings; later passes may add interiors, extra residents, and
+hangout spaces to make the block feel more alive.
 
 A crowd, traffic line, or gathering blocks the route while everyone waits for
 the concert to start. The player can learn that the concert is late from

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -125,7 +125,7 @@ can become later liveliness scope for talking with characters, playing with
 Cicka, or adding a tiny optional toy. Morning travel toward Dance Festival uses
 a grounded **Band Roadie Van Ride**. The transport role is a band roadie / van
 driver from the Concert area, not the injured guitarist. The roadie is a
-practical helpful character who offers the ride because the player saved the
+practical, helpful character who offers the ride because the player saved the
 concert and the band is already packing up gear; he should not own the
 sleep-through-festival joke. The roadie/band do not need to attend the Dance
 Festival. They are headed somewhere else nearby, such as a local hospital or
@@ -291,7 +291,7 @@ the concert to start. The player can learn that the concert is late from
 annoyed crowd chatter, but the area should stay compact enough that simply
 wandering and talking with people can reveal the musician-side space. There the
 player finds the local guitarist and learns that he cannot play because of a
-clumsy show-off mishap: after a kid teased that he was old, he tried to prove
+clumsy show-off mishap: after a kid teased him about being old, he tried to prove
 he was still young by doing an absurd concert stunt, such as playing guitar
 while riding a skateboard on one leg, and hurt his hand or wrist. The player
 learns one **Forgiving Practice Riff** and takes over the concert. In v0, the

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -124,6 +124,12 @@ but her role should evolve:
 - middle: observer of a changed object or resident moment
 - late: quiet trust marker near the threshold
 
+Bridge Area can serve as the first Cicka encounter. In the current accepted
+opening, Cicka steals the Bridge Draftsperson's tiny toy car / weight-test prop,
+pulling the player toward the unsafe crossing and unfinished blueprint. After
+this first meeting, she should not become a continuous follower; she becomes a
+recurring authored field presence across meaningful route beats.
+
 Each required Ridge Area should include one local **Cicka Resting
 Spot**: a small perch, loafing place, or quiet seat where Cicka can be present
 without making the player return to a central hub. This replaces **Cicka Home**
@@ -283,16 +289,17 @@ The **Bridge Area** should contain the first required Resident Beat,
 Cicka noticed something -> a resident needs local help -> the route visibly changes
 ```
 
-Current recommended solution: help the **Bridge Draftsperson**, a tiny nervous
-or blocked planner responsible for the crossing blueprint, finish a bridge
-drawing/blueprint by drawing or visually completing the bridge. The
+Current recommended solution: Cicka first appears by stealing the **Bridge
+Draftsperson**'s tiny toy car / weight-test prop, pulling the player toward the
+unsafe crossing and unfinished blueprint. The Draftsperson is a tiny nervous or
+blocked planner responsible for the crossing blueprint. The player helps finish
+the bridge drawing/blueprint by drawing or visually completing the bridge. The
 Draftsperson's specific problem is a missing middle span: they keep erasing and
 redrawing it because they are overthinking whether the structure will hold.
-Failed doodles, eraser marks, or a tiny toy car/weight-test prop can make this
+Failed doodles, eraser marks, and the toy car/weight-test prop make this
 readable and support a future bridge-physics toy. The finished sketch becomes
 the crossing. For v0, this can be a basic authored drawing/completion visual
-rather than a full freeform drawing system. Cicka can sit on or near the
-blank/missing part of the plan.
+rather than a full freeform drawing system.
 
 Future optional upgrade: let the player draw directly on the bridge, either as
 a visual customization or a small physics/bridge-building toy, potentially

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -283,13 +283,21 @@ The **Bridge Area** should contain the first required Resident Beat,
 Cicka noticed something -> a resident needs local help -> the route visibly changes
 ```
 
-Current recommended solution: help a resident finish a tiny bridge
-drawing/blueprint, then the finished sketch becomes the crossing. Cicka can sit
-on or near the blank/missing part of the plan.
+Current recommended solution: help the **Bridge Draftsperson**, a tiny nervous
+or blocked planner responsible for the crossing blueprint, finish a bridge
+drawing/blueprint by drawing or visually completing the bridge. The
+Draftsperson's specific problem is a missing middle span: they keep erasing and
+redrawing it because they are overthinking whether the structure will hold.
+Failed doodles, eraser marks, or a tiny toy car/weight-test prop can make this
+readable and support a future bridge-physics toy. The finished sketch becomes
+the crossing. For v0, this can be a basic authored drawing/completion visual
+rather than a full freeform drawing system. Cicka can sit on or near the
+blank/missing part of the plan.
 
 Future optional upgrade: let the player draw directly on the bridge, either as
-a visual customization or a small physics/bridge-building toy. Do not make that
-the required v0 solution.
+a visual customization or a small physics/bridge-building toy, potentially
+testing whether the drawn bridge can carry a car or similar weight. Do not make
+that the required v0 solution.
 
 Keep it tiny, obvious, and local. It should not feel like a fetch quest or a
 test of platforming skill.
@@ -305,6 +313,8 @@ Current candidates:
 - Telegraph / Clair-Obscur-style timing: optional timing/parry future alternate-path candidate.
 - Concert guitar performance: small teaching toy for the guitar, with required
   non-arcade fallback.
+- Bridge drawing/physics: future bridge-building toy after the route MVP is
+  proven; v0 should use an authored drawing/completion visual.
 
 Mini-games may unlock alternate paths, shortcuts, rewards, or just exist for
 fun. In the current first-ending route they are not required proof. Future

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -125,9 +125,16 @@ but her role should evolve:
 - late: quiet trust marker near the threshold
 
 Bridge Area can serve as the first Cicka encounter. In the current accepted
-opening, Cicka steals the Bridge Draftsperson's tiny toy car / weight-test prop,
-pulling the player toward the unsafe crossing and unfinished blueprint. After
-this first meeting, she should not become a continuous follower; she becomes a
+opening, the game begins with a simple walk-right control introduction from a
+hill or nature edge before the bridge problem is visible. Cicka first appears
+peacefully playing with the Bridge Draftsperson's tiny toy car / weight-test
+prop, and the player can meet her through a tiny pet/play interaction before
+knowing the toy matters. After the player reaches the blocked bridge and learns
+the test car is missing, they can infer that Cicka has it and return to retrieve
+it through **Cicka Parallel Play**: the player sits or relaxes near Cicka long
+enough that she treats the toy as shared play, bats or rolls it toward the
+player, and eventually lets it become usable for the bridge test. After this
+first meeting, she should not become a continuous follower; she becomes a
 recurring authored field presence across meaningful route beats.
 
 Each required Ridge Area should include one local **Cicka Resting
@@ -289,17 +296,22 @@ The **Bridge Area** should contain the first required Resident Beat,
 Cicka noticed something -> a resident needs local help -> the route visibly changes
 ```
 
-Current recommended solution: Cicka first appears by stealing the **Bridge
-Draftsperson**'s tiny toy car / weight-test prop, pulling the player toward the
-unsafe crossing and unfinished blueprint. The Draftsperson is a tiny nervous or
-blocked planner responsible for the crossing blueprint. The player helps finish
-the bridge drawing/blueprint by drawing or visually completing the bridge. The
+Current recommended solution: the player first meets Cicka peacefully playing
+with the **Bridge Draftsperson**'s tiny toy car / weight-test prop, then later
+recontextualizes that toy as the missing bridge test car after reaching the
+blocked crossing. The Draftsperson is a tiny nervous or blocked planner
+responsible for the crossing blueprint. The player retrieves the toy car from
+Cicka through **Cicka Parallel Play**, then helps finish the bridge
+drawing/blueprint by drawing or visually completing the bridge. The
 Draftsperson's specific problem is a missing middle span: they keep erasing and
 redrawing it because they are overthinking whether the structure will hold.
 Failed doodles, eraser marks, and the toy car/weight-test prop make this
 readable and support a future bridge-physics toy. The finished sketch becomes
 the crossing. For v0, this can be a basic authored drawing/completion visual
-rather than a full freeform drawing system.
+rather than a full freeform drawing system, and the toy car test should be
+auto-success presentation: place or bring the toy car to the completed
+blueprint, roll it across the drawn bridge, then let the sketch become the real
+crossing.
 
 Future optional upgrade: let the player draw directly on the bridge, either as
 a visual customization or a small physics/bridge-building toy, potentially
@@ -308,6 +320,13 @@ that the required v0 solution.
 
 Keep it tiny, obvious, and local. It should not feel like a fetch quest or a
 test of platforming skill.
+
+The first blockout floor is: walk-right nature/hill intro, peaceful Cicka + toy
+car first encounter, basic sit/play interaction, blocked bridge, Bridge
+Draftsperson + missing middle span blueprint, return to Cicka for Cicka
+Parallel Play, toy car bridge test, simple bridge drawing completion visual,
+bridge becomes crossing, and Cicka settles near the completed crossing. Cabin,
+food, physics simulation, and toy-car ping-pong are later optional layers.
 
 ## Mini-Game Entrances
 
@@ -322,6 +341,12 @@ Current candidates:
   non-arcade fallback.
 - Bridge drawing/physics: future bridge-building toy after the route MVP is
   proven; v0 should use an authored drawing/completion visual.
+- Toy-car parallel play: future tiny back-and-forth Cicka game after the route
+  MVP is proven; v0 should be a short sit/play/share interaction.
+- Cabin/treat shortcut: future optional Bridge interaction where the player can
+  bring food to Cicka as an alternate way to retrieve the toy car, such as a
+  shortcut around the toy-car parallel-play mini-game rather than required v0
+  route logic.
 
 Mini-games may unlock alternate paths, shortcuts, rewards, or just exist for
 fun. In the current first-ending route they are not required proof. Future

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -109,6 +109,36 @@ Each required Ridge Area has a concrete local barricade. Clearing that
 barricade opens the next area. Relay does not currently need a separate
 "collect enough proof" or optional-area readiness system.
 
+For the first playable route, treat the areas as separate compact maps connected
+by short transitions rather than one continuous walkable geography. This gives
+each area freedom to have its own time of day, environment, and staging while
+still reading as a linear route. Distance between areas can stay ambiguous, with
+background composition, distant Relay silhouettes, signage, or skyline changes
+implying progress toward the final ridge.
+
+Current time-of-day arc: Bridge begins during the day at a nature/hill edge;
+Concert moves into evening/night small-town festival energy; a short sleep/rest
+interlude carries the player from Concert night to Dance Festival morning/day
+arrival; Dance Festival plays from morning/day setup into later afternoon; Relay
+uses sunset for Sit and Play, then the Relay Holding State for Send the
+Sketchbook.
+
+Current Concert-to-Dance transition direction: after the night concert, the
+route should rest instead of sending the player walking through the night. The
+leading flavor is a small post-concert campfire/tent sleepover, followed by
+morning travel toward Dance Festival through a grounded **Band Roadie Van
+Ride**. The transport role is a band roadie / van driver from the Concert area,
+not the injured guitarist. The roadie is a practical helpful character who
+offers the ride because the player saved the concert and the band is already
+packing up gear; he should not own the sleep-through-festival joke.
+
+A separate recurring **Festival Superfan** is desired for the game, but can wait
+until the immediate post-v0 liveliness pass if the first route prototype is
+already cast-heavy. His running joke: he mentions at Bridge that he is excited
+for the Dance Festival, talks about it again at Concert, then sleeps through it.
+Keep this role separate from the driver unless a later staging pass finds a
+clean vehicle reason.
+
 Earlier "Living Proof" language should be treated as poetic shorthand for the
 meaning of completed area changes, not as a required mechanic, resource, or
 checklist. If a later version restores optional ordering or alternate endings,
@@ -245,11 +275,13 @@ then echo in the Guitar Farewell montage.
 Detailed local contract:
 [`Concert Area`](./areas/02-concert/README.md).
 
-Concert Area should read as a compact city-like concert block with small
-buildings, bars, stage-adjacent storefronts, alleys, and lived-in street details
-around the blocked crossing. The first prototype can use facades and silhouettes
-instead of enterable buildings; later passes may add interiors, extra residents,
-and hangout spaces to make the block feel more alive.
+Concert Area should read as a compact small-town / varos-like concert block with
+small buildings, bars, stage-adjacent storefronts, alleys, and lived-in street
+details around the blocked crossing. The concert can be a daytime or afternoon
+local festival-style event rather than a night-club gig. The first prototype can
+use facades and silhouettes instead of enterable buildings; later passes may add
+interiors, extra residents, and hangout spaces to make the block feel more
+alive.
 
 A crowd, traffic line, or gathering blocks the route while everyone waits for
 the concert to start. The player can learn that the concert is late from

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -13,14 +13,14 @@
 This bible is in-progress. It records resolved story, level-design, character,
 and progression decisions for the core Exploration Map route.
 
-Current design focus: work backward from the ending by detailing **Dance
-Festival Area / Opening Dance Shuttle Beat** before Concert Area / Concert
-Crossing Beat and Bridge Area / Blueprint Bridge.
+Current design focus: work backward from the ending while preserving the
+fixed first-ending route order: Bridge Area, Concert Area, Dance Festival Area,
+then Relay Ending.
 
 Design order:
 
 1. canonical first ending
-2. Living Proof Gate readiness
+2. fixed Area Barricade Chain
 3. Dance Festival Area / Opening Dance Shuttle Beat
 4. Concert Area / Concert Crossing Beat
 5. Bridge Area / Blueprint Bridge
@@ -41,9 +41,8 @@ The first ending path should be completable through conversations, collection,
 authored traversal interactions, Ridge Areas, Resident Beats, and visible world
 changes.
 Mini-games attach to the world as optional fun, rewards, shortcuts, or future
-alternate ways to finish a level. They should not become required Living Proof
-or the default solution for main route blockers in the current first-ending
-route.
+alternate ways to finish a level. They should not become required first-ending
+proof or the default solution for main route blockers.
 
 ## Canonical Ending
 
@@ -53,22 +52,32 @@ they add meaningful replay value without weakening Cicka's farewell.
 
 Accepted ending outline:
 
-1. The player reaches Relay Spire and can stand there before it is ready.
-2. Once Living Proof is enough, the Relay sign becomes readable.
+1. The fixed main route carries the player through Bridge Area, Concert Area,
+   and Dance Festival Area before Relay.
+2. Clearing the Dance Festival barricade grants the last daylight ride to Relay.
 3. Cicka appears in her final field-presence spot, calm and familiar.
 4. The player uses a **Sit and Play Prompt** near Cicka to share a quiet
    **Guitar Farewell**, ideally under a warm sunset or other cozy threshold
    light.
-5. A brief **Living Proof Montage** can appear during the guitar: Blueprint
+5. A brief **Route Memory Montage** can appear during the guitar: Blueprint
    Bridge being used, Concert Crossing continuing, Opening Dance beginning at
    night as an emotional echo under the player's guitar, and earlier Cicka
    Resting Spots carrying accumulated marks.
-6. Control returns in **Relay Blue Hour** at the Relay sign/spire for a **Send
+6. Control returns in a small **Relay Holding State** for a **Send
    the Sketchbook Prompt**.
-7. Cicka walks with the player to the threshold, pauses, looks back once, leaves
+7. While in the Relay Holding State, the player can remain present with Cicka
+   near the threshold, such as by walking around the small Relay clearing,
+   sitting again, replaying a quiet guitar phrase, or using an optional comfort
+   interaction if supported. The player cannot return to the wider Ridge route
+   until the sketchbook is sent.
+8. **Send the Sketchbook Prompt** is the final completion trigger. It is
+   currently provisional in exact staging, but it should mean the player is
+   ready to let the sketchbook carry the completed farewell forward.
+9. Cicka walks with the player to the threshold, pauses, looks back once, leaves
    one final paw/page mark, then slips into a page fold or light beyond the
-   player's path. The initial version uses no translated farewell line.
-8. The player returns to the **Open Ridge Return State** after the ending, with
+   player's path. The player does not force Cicka away. The initial version uses
+   no translated farewell line.
+10. The player returns to the **Open Ridge Return State** after the ending, with
    the canonical final mark preserved at the Relay threshold, one quieter echo
    at the Concert Resting Spot, and the world still open. The echo is the
    empty usual spot plus one small paw/page mark, not the player's guitar left
@@ -88,20 +97,22 @@ Tone boundaries:
 - no scattering sad marks everywhere in the initial return state; use the Relay
   threshold mark plus one quiet Concert Resting Spot echo first
 
-## Living Proof Gate
+## Area Barricade Chain
 
-The Relay Spire can be physically reachable before it can send. The blocker is
-that the sketchbook is not ready yet: the path has not created enough visible
-world changes, proofs, and Cicka familiarity.
+The first-ending route is currently a fixed linear chain:
 
-The gate should feel like emotional and semantic readiness, not an exact visible
-checklist. The route to Relay should naturally provide enough resident help and
-cat familiarity for the first ending.
+```text
+Bridge Area -> Concert Area -> Dance Festival Area -> Relay Ending
+```
 
-Living Proof should come from the three required Ridge Areas and their
-Resident/world changes, not from optional mini-games or noticing changed Cicka
-Resting Spots. A resting spot is the emotional echo or memory of proof already
-earned elsewhere, not a separate proof token.
+Each required Ridge Area has a concrete local barricade. Clearing that
+barricade opens the next area. Relay does not currently need a separate
+"collect enough proof" or optional-area readiness system.
+
+Earlier "Living Proof" language should be treated as poetic shorthand for the
+meaning of completed area changes, not as a required mechanic, resource, or
+checklist. If a later version restores optional ordering or alternate endings,
+the gate can be reconsidered.
 
 ## Cicka
 
@@ -188,7 +199,7 @@ Relay Spire / Guitar Farewell -> I am ready for Cicka's threshold farewell.
 | [Bridge Area](./areas/01-bridge/README.md) | Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
 | [Concert Area](./areas/02-concert/README.md) | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Points attention to guitar case, string, stage, or crossing | Concert continues; crossing opens; guitar entrusted to player |
 | [Dance Festival Area](./areas/03-dance-festival/README.md) | Opening Dance Shuttle Beat | Accepted final beat direction; Last-Stop Operations Helper locked as romantic partner role | Creates the last emotional readiness before Relay through afternoon setup for a night dance festival at the foot of the Relay hill | Quiet threshold observer near the lantern crates, operations table, shuttle step, or service gate; may loaf with the Unnamed Counterpart Cat | Festival setup clears enough for one last daylight shuttle to Relay before the night road closure |
-| [Relay Ending Area](./areas/04-relay-ending/README.md) | Guitar Farewell / Cicka Threshold Farewell | Active ending direction | Final threshold after Living Proof is enough | Final field-presence spot and threshold departure | Open Ridge Return State preserves the final Relay mark and one quiet Concert echo |
+| [Relay Ending Area](./areas/04-relay-ending/README.md) | Guitar Farewell / Cicka Threshold Farewell | Active ending direction | Final threshold after the Dance Festival barricade is cleared | Final field-presence spot and threshold departure | Open Ridge Return State preserves the final Relay mark and one quiet Concert echo |
 
 ## Opening Dance Shuttle Beat
 
@@ -278,5 +289,5 @@ Current cross-area hot spots:
 - Required resident cast names and silhouettes.
 - Optional resident cast and hangout spaces.
 - Concert guitar acquisition as an ending dependency.
-- Living Proof feedback at Relay when it is reachable but not ready.
+- Exact Send the Sketchbook staging after the Guitar Farewell.
 - Return-to-Ridge state after the Cicka Threshold Farewell.

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -56,32 +56,28 @@ Accepted ending outline:
    and Dance Festival Area before Relay.
 2. Clearing the Dance Festival barricade grants the last daylight ride to Relay.
 3. Cicka appears in her final field-presence spot, calm and familiar.
-4. The player uses a **Sit and Play Prompt** near Cicka to share a quiet
-   **Guitar Farewell**, ideally under a warm sunset or other cozy threshold
-   light.
-5. A brief **Route Memory Montage** can appear during the guitar: Blueprint
-   Bridge being used, Concert Crossing continuing, Opening Dance beginning at
-   night as an emotional echo under the player's guitar, and earlier Cicka
-   Resting Spots carrying accumulated marks.
-6. Control returns in a small **Relay Holding State** for a **Send
-   the Sketchbook Prompt**.
-7. While in the Relay Holding State, the player can remain present with Cicka
-   near the threshold, such as by walking around the small Relay clearing,
-   sitting again, replaying a quiet guitar phrase, or using an optional comfort
-   interaction if supported. The player cannot return to the wider Ridge route
-   until the sketchbook is sent.
-8. **Send the Sketchbook Prompt** is the final completion trigger. It is
-   currently provisional in exact staging, but it should mean the player is
-   ready to let the sketchbook carry the completed farewell forward.
-9. Cicka walks with the player to the threshold, pauses, looks back once, leaves
-   one final paw/page mark, then slips into a page fold or light beyond the
-   player's path. The player does not force Cicka away. The initial version uses
-   no translated farewell line.
-10. The player returns to the **Open Ridge Return State** after the ending, with
-   the canonical final mark preserved at the Relay threshold, one quieter echo
-   at the Concert Resting Spot, and the world still open. The echo is the
-   empty usual spot plus one small paw/page mark, not the player's guitar left
-   behind.
+4. The player uses a **Sit and Play Prompt** near Cicka to share a quiet,
+   player-triggered **Guitar Farewell**, ideally under a warm sunset or other
+   cozy threshold light. The first playable version should stay short and quiet:
+   sit beside Cicka, play the familiar Concert guitar phrase, and let the moment
+   breathe without a pass/fail challenge.
+5. A brief **Route Memory Montage** can appear during the guitar with 2-3
+   flashes, such as Blueprint Bridge being used, Concert Crossing continuing,
+   Opening Dance beginning at night as an emotional echo under the player's
+   guitar, or earlier Cicka Resting Spots carrying changed visual states.
+6. **Sit and Play Prompt** is the final completion trigger for the first
+   ending. Do not add **Send the Sketchbook Prompt** in v0 unless the sketchbook
+   becomes a seeded object or interaction across the route first.
+7. After the final guitar phrase, Cicka walks with the player to the threshold,
+   pauses, looks back once, then slips into a page fold, light, or other
+   threshold beyond the player's path. The player does not force Cicka away.
+   The initial version uses no translated farewell line.
+8. A final trace at Relay or a quiet Concert Resting Spot echo can exist only as
+   visual staging if earlier route art has taught that language. Do not present
+   paw/page marks as a mechanic or required symbol in v0.
+9. The player returns to the **Open Ridge Return State** after the ending, with
+   the world still open and the guitar still with the player. The exact
+   post-ending interactability and any minimal visual absence echo remain open.
 
 Tone boundaries:
 
@@ -94,8 +90,8 @@ Tone boundaries:
   silence
 - no immediate replacement reveal; Micka remains delayed until the later
   post-ending trigger
-- no scattering sad marks everywhere in the initial return state; use the Relay
-  threshold mark plus one quiet Concert Resting Spot echo first
+- no scattering sad marks everywhere in the initial return state; use at most a
+  minimal visual absence echo if the route has already taught that language
 
 ## Area Barricade Chain
 
@@ -120,8 +116,7 @@ Current time-of-day arc: Bridge begins during the day at a nature/hill edge;
 Concert moves into evening/night small-town festival energy; a short sleep/rest
 interlude carries the player from Concert night to Dance Festival daytime
 arrival; Dance Festival plays from daytime setup into later afternoon; Relay
-uses sunset for Sit and Play, then the Relay Holding State for Send the
-Sketchbook.
+uses sunset for Sit and Play and the Cicka Threshold Farewell.
 
 Current Concert-to-Dance transition direction: after the night concert, the
 route should rest instead of sending the player walking through the night. The
@@ -254,7 +249,7 @@ Relay Spire / Guitar Farewell -> I am ready for Cicka's threshold farewell.
 | [Bridge Area](./areas/01-bridge/README.md) | Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
 | [Concert Area](./areas/02-concert/README.md) | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Crowd-shy observer near hidden musician-side space, then relaxed with the band after the crossing opens | Concert continues; crossing opens; guitar entrusted to player |
 | [Dance Festival Area](./areas/03-dance-festival/README.md) | Opening Dance Shuttle Beat | Accepted final beat direction; Last-Stop Operations Helper locked as romantic partner role | Creates the last emotional readiness before Relay through daytime setup that progresses toward late afternoon for a night dance festival at the foot of the Relay hill | Quiet threshold observer near the lantern crates, operations table, shuttle step, or service gate; may loaf with the Unnamed Counterpart Cat | Festival setup clears enough for one last daylight shuttle to Relay before the night road closure |
-| [Relay Ending Area](./areas/04-relay-ending/README.md) | Guitar Farewell / Cicka Threshold Farewell | Active ending direction | Final threshold after the Dance Festival barricade is cleared | Final field-presence spot and threshold departure | Open Ridge Return State preserves the final Relay mark and one quiet Concert echo |
+| [Relay Ending Area](./areas/04-relay-ending/README.md) | Guitar Farewell / Cicka Threshold Farewell | Active ending direction | Final threshold after the Dance Festival barricade is cleared | Final field-presence spot and threshold departure | Open Ridge Return State keeps the world open after the farewell, with any absence echo treated as visual staging rather than a required mark mechanic |
 
 ## Opening Dance Shuttle Beat
 
@@ -402,5 +397,4 @@ Current cross-area hot spots:
 - Required resident cast names and silhouettes.
 - Optional resident cast and hangout spaces.
 - Concert guitar acquisition as an ending dependency.
-- Exact Send the Sketchbook staging after the Guitar Farewell.
 - Return-to-Ridge state after the Cicka Threshold Farewell.

--- a/docs/game-design/ridge/summit.md
+++ b/docs/game-design/ridge/summit.md
@@ -67,13 +67,14 @@ The ending order is protected:
 
 1. Fixed area barricade chain reaches Relay
 2. Cicka appears at the Relay threshold
-3. Guitar Farewell at sunset
-4. Relay Holding State with Send the Sketchbook Prompt
-5. Cicka Threshold Farewell
-6. Open Ridge Return State
+3. Sit and Play starts the Guitar Farewell at sunset as the final trigger
+4. Cicka Threshold Farewell follows the final guitar phrase
+5. Open Ridge Return State
 
 The farewell is a tribute beat, not a literal-heavy explanation. Use presence,
-absence, paw marks, silence, guitar, and the return-state Ridge to carry it.
+absence, silence, guitar, and the return-state Ridge to carry it. Paw/page marks
+should stay optional visual language only if seeded earlier, not an unintroduced
+ending mechanic.
 
 Micka appears after the player returns to normal Ridge and completes or replays
 one post-ending mini-game. She is continuity, not replacement, and should not

--- a/docs/game-design/ridge/summit.md
+++ b/docs/game-design/ridge/summit.md
@@ -65,10 +65,10 @@ does not dictate the desired route shape.
 
 The ending order is protected:
 
-1. Living Proof readiness
+1. Fixed area barricade chain reaches Relay
 2. Cicka appears at the Relay threshold
 3. Guitar Farewell at sunset
-4. Send the Sketchbook Prompt in blue hour
+4. Relay Holding State with Send the Sketchbook Prompt
 5. Cicka Threshold Farewell
 6. Open Ridge Return State
 
@@ -87,8 +87,8 @@ Desk, Neutral Notebook, and similar ideas are candidates, not required proof for
 the first ending unless route canon explicitly reopens that.
 
 Before adding or prioritizing another mini-game, ask whether Bridge, Concert,
-Dance Festival, Relay, Living Proof feedback, and the Cicka farewell are clearer
-than they were before.
+Dance Festival, Relay, route readiness feedback, and the Cicka farewell are
+clearer than they were before.
 
 ## Scope Cuts
 


### PR DESCRIPTION
## Summary
- Tighten the active Ridge pre-production docs around the fixed area chain, pacing, and route transitions.
- Record the latest decisions for Bridge, Concert, Dance Festival, and Relay Ending in the canonical design docs.
- Clarify the final `Sit and Play` ending flow, Cicka’s threshold departure, and the retired `Send the Sketchbook` concept for v0.
- Update open questions, milestone framing, and the domain context so the current route logic stays consistent across docs.

## Testing
- Not run (not requested)