### PR TITLE
Clarify Ridge v0 farewell ending and reset flow

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -249,8 +249,8 @@ _Avoid_: tutorial UI marker, required backtracking perch
 **Concert Resting Spot**:
 The Cicka Resting Spot in the Concert Area: first a hidden musician-side place
 where crowd-shy Cicka watches the delay, then a relaxed band-side spot near the
-opened exit where the Open Ridge Return State can show one quiet empty-spot echo
-after the farewell.
+opened exit where the long-term Open Ridge Return State can show one quiet
+empty-spot echo after the farewell.
 _Avoid_: abandoned guitar, shrine, required sad objective
 
 **Dance Festival Resting Spot**:
@@ -272,11 +272,17 @@ translated farewell text in the initial version.
 _Avoid_: literal death scene, grief monologue, Cicka leaving with the player, written goodbye, player escort
 
 **Open Ridge Return State**:
-The immediate post-ending Ridge state where the world remains playable with the
-farewell complete, the guitar still with the player, and any minimal absence
-echo treated as visual staging rather than a required mark mechanic before any
-later Micka trigger.
-_Avoid_: closed ending, sad objective, immediate replacement reveal, scattered sadness marks, abandoned inventory
+The long-term post-game Ridge state where the world remains playable after the
+farewell, with free travel between areas and any minimal absence echo treated as
+visual staging rather than a required mark mechanic before any later Micka
+trigger.
+_Avoid_: first-playable reset, closed ending, sad objective, immediate replacement reveal, scattered sadness marks, abandoned inventory
+
+**First Playable Reset Return**:
+The v0 post-dedication behavior where the game returns the player to the
+beginning of Bridge Area with clean route progress instead of opening a
+post-game free-travel Ridge.
+_Avoid_: post-game world, immediate Micka reveal, new objective, credits lockout, partial completed-world return, visible ending-seen marker
 
 **Guitar Farewell**:
 The final shared Cicka moment where the player chooses Sit and Play at the Relay
@@ -318,8 +324,9 @@ _Avoid_: ordinary doorway, page-edge-only fold, portal the player can enter
 
 **Dedication Card**:
 A restrained non-diegetic card after Cicka's departure and the empty-sunset hold
-that says "For Cicka." and "Thank you for playing."
-_Avoid_: message from Cicka, written goodbye, explanation of where she went
+that says "For Cicka." and "Thank you for playing.", then auto-fades without a
+button prompt.
+_Avoid_: message from Cicka, written goodbye, explanation of where she went, menu prompt, separate credits card, "The End" card
 
 **Area Barricade Chain**:
 The fixed first-ending route structure where Bridge, Concert, and Dance
@@ -567,19 +574,20 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   making the player or one NPC magically know private feelings.
 - A **Readiness Favor** can bridge the gap between knowing what a resident wants
   and helping them act without making the player directly manage their feelings.
-- The **Cicka Threshold Farewell** resolves Cicka's recurring field guidance
-  without closing the **Sketchbook Neighborhood**; the Ridge remains replayable
-  after the farewell.
+- The **Cicka Threshold Farewell** resolves Cicka's recurring field guidance.
+  V0 uses the **First Playable Reset Return** after the **Dedication Card**;
+  long-term post-game scope may replace that with the **Open Ridge Return
+  State**.
 - The **Cicka Threshold Farewell** departure should be physical and mostly
-  silent: walk together, pause, look back, then page-fold/light departure. The
-  initial version should use no translated farewell line; a tiny raw meow/chirp
-  sound can remain optional if it supports the staging. Do not rely on
-  paw/page marks as a required symbol unless the route has seeded that visual
-  language first.
-- The immediate return after the **Cicka Threshold Farewell** should be the
-  **Open Ridge Return State**: replayable, quiet, and minimally absence-marked
-  only if that visual language has been seeded, with Micka still delayed until
-  the later post-ending trigger. The guitar stays with the player.
+  silent: Cicka moves toward the threshold alone, turns back toward the seated
+  player, gives one small raw meow, then slips into the **Warm Sketchbook
+  Threshold**. Do not rely on paw/page marks as a required symbol unless the
+  route has seeded that visual language first.
+- The long-term **Open Ridge Return State** should be replayable, quiet, and
+  minimally absence-marked only if that visual language has been seeded, with
+  Micka still delayed until the later post-ending trigger. It becomes valuable
+  once optional mini-games, return content, or completed-area revisits exist;
+  v0 should use the clean **First Playable Reset Return** instead.
 - The **Guitar Farewell** should be established before the ending through the
   guitar's story role and visual Cicka Resting Spot presence. The initial route
   does not need repeatable resting-spot interactions; sitting together, petting,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -266,12 +266,10 @@ subtle posture, placement, and tiny reactions instead of explicit instructions.
 _Avoid_: companion AI, quest marker, follower pet, objective dispenser
 
 **Cicka Threshold Farewell**:
-The first ending beat where Cicka accompanies the player to the Relay Spire
-threshold, looks back, then slips into a page fold, light, or other threshold
-beyond the player's path without translated farewell text in the initial
-version. Any final trace should be treated as optional visual staging only if
-the route has already taught that language.
-_Avoid_: literal death scene, grief monologue, Cicka leaving with the player, written goodbye
+The first ending beat where Cicka leaves the seated player through a warm
+sketchbook threshold beyond the player's path after one small raw meow, without
+translated farewell text in the initial version.
+_Avoid_: literal death scene, grief monologue, Cicka leaving with the player, written goodbye, player escort
 
 **Open Ridge Return State**:
 The immediate post-ending Ridge state where the world remains playable with the
@@ -308,9 +306,20 @@ Memory Montage** unless a later design restores a separate proof system.
 _Avoid_: full recap, credits roll, visible checklist, objective summary
 
 **Route Memory Montage**:
-A brief Guitar Farewell montage that wordlessly shows the fixed route's resident
-help, world changes, and Cicka Resting Spot echoes during the final song.
+A brief three-flash Guitar Farewell montage that wordlessly shows the fixed
+route's changed world states during the final song.
 _Avoid_: full recap, credits roll, visible checklist, objective summary
+
+**Warm Sketchbook Threshold**:
+The small Relay threshold artifact that opens for Cicka beyond the player's
+path, readable as warm light, a scratch-like seam, a paper hole, or a gentle
+glitch-portal-like artifact rather than a literal page-edge fold.
+_Avoid_: ordinary doorway, page-edge-only fold, portal the player can enter
+
+**Dedication Card**:
+A restrained non-diegetic card after Cicka's departure and the empty-sunset hold
+that says "For Cicka." and "Thank you for playing."
+_Avoid_: message from Cicka, written goodbye, explanation of where she went
 
 **Area Barricade Chain**:
 The fixed first-ending route structure where Bridge, Concert, and Dance
@@ -659,10 +668,10 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 > **Domain expert:** "No — call the place a **Ridge Area** and the problem sequence a **Resident Beat**. Use **Phaser Scene** only for runtime implementation."
 
 > **Dev:** "Does Cicka leave with the player at the ending?"
-> **Domain expert:** "No — the **Cicka Threshold Farewell** means she walks with the player to the threshold, then departs somewhere the player cannot follow."
+> **Domain expert:** "No — during the **Cicka Threshold Farewell**, the player remains seated while Cicka leaves through the **Warm Sketchbook Threshold** somewhere the player cannot follow."
 
 > **Dev:** "Should Cicka's final departure include translated text?"
-> **Domain expert:** "No — the initial **Cicka Threshold Farewell** should be fully nonverbal. Use staging, silence, and optionally a tiny raw sound instead of a written goodbye."
+> **Domain expert:** "No translated line or written goodbye — Cicka gives one tiny raw meow, and the later **Dedication Card** stays non-diegetic."
 
 > **Dev:** "Should the ending rely on paw/page marks?"
 > **Domain expert:** "No — only use a final trace or absence echo as visual staging if the route has already taught that language. Do not make paw/page marks a surprise mechanic or required symbol in v0."

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -777,9 +777,9 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   and soft drops. `ramp` may remain an internal connector label where needed.
 - "Cicka follows the player" means authored **Cicka Field Presence** at route
   beats, not continuous companion following or autonomous navigation.
-- "Cicka departs with us" means **Cicka Threshold Farewell**, where she
-  accompanies the player to the Relay Spire threshold and then leaves from the
-  player, not with the player.
+- "Cicka departs with us" is imprecise; use **Cicka Threshold Farewell**, where
+  the player remains seated while Cicka leaves through the **Warm Sketchbook
+  Threshold** somewhere the player cannot follow.
 - "hint" from Cicka means subtle attention guidance through staging or reaction,
   not explicit objective text like "go fix the bridge."
 - "last dance" previously meant an after-festival closure gate; resolved: use

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,6 +11,12 @@ override legacy prototype plans, but it does not describe shipped behavior until
 implemented and reflected in the player manual.
 _Avoid_: current runtime, shipped game, legacy prototype
 
+**First Playable Route**:
+The smallest complete Bridge Area -> Concert Area -> Dance Festival Area ->
+Relay Spire path that proves the emotional arc without required mini-games,
+optional interiors, campfire hangouts, or extra resident liveliness.
+_Avoid_: v0, route MVP, prototype floor, first route prototype
+
 **Typed Ridge Blockout Source**:
 A human- and agent-editable TypeScript source notation that describes Ridge
 topology, room blockouts, traversal primitives, shortcuts, anchors, tile

--- a/docs/game-design/ridge/README.md
+++ b/docs/game-design/ridge/README.md
@@ -28,7 +28,7 @@ Use each file for exactly one concern:
 | Current Ridge route canon | [`story-level-bible.md`](./story-level-bible.md) | Route spine, area barricade chain, cross-area Cicka/guitar logic, ending order. |
 | Area-specific design canon | [`areas/`](./areas/README.md) | Local geography, blockers, residents, prompts, staging, Cicka Resting Spots, visual/audio notes. |
 | Current runtime/prototype truth | [`ridge-snapshot.md`](./ridge-snapshot.md) | What exists now in the Phaser prototype, what can be reused, and what is disposable. |
-| Active open questions | [`open-questions.md`](./open-questions.md) | Unresolved ending, Dance Festival, dependency, and scope gaps. |
+| Active open questions | [`open-questions.md`](./open-questions.md) | True design unknowns and blockout-detail TBD. Area premises may already be accepted even when prompt/topology details remain open. |
 | Product vision | [`summit.md`](./summit.md) | Durable fantasy and pillars, not detailed route implementation. |
 | Implementation sequencing | [`milestone-plan.md`](./milestone-plan.md) | Current route-reset milestones, source stack, prototype reuse rules, and agent checklist. Not live backlog. |
 | Runtime blockout contract | [`map-language.md`](./map-language.md) | Source format and generated facts for the current/prototype blockout. |

--- a/docs/game-design/ridge/areas/01-bridge/README.md
+++ b/docs/game-design/ridge/areas/01-bridge/README.md
@@ -106,6 +106,8 @@ layers.
 
 - Bridge Draftsperson silhouette, personality, and eventual name
 - exact bridge topology and camera framing
+- blockout validation for the accepted route grammar: Cicka noticed something,
+  a resident needs local help, and the route visibly changes
 - prop kit for the unfinished sketch/blueprint
 - failed doodles, eraser marks, or toy car/weight-test prop staging
 - Toy Car Play first Cicka encounter and gentle retrieval staging

--- a/docs/game-design/ridge/areas/03-dance-festival/README.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/README.md
@@ -80,4 +80,4 @@ a route gate.
   eventual names for local residents.
 - [`interaction-flow.md`](./interaction-flow.md): concrete prompts, object
   interactions, recovery paths, readiness order flexibility, and the smallest
-  playable version that still lands final readiness before Relay.
+  prompt set that proves the accepted Opening Dance Shuttle beat.

--- a/docs/game-design/ridge/areas/03-dance-festival/interaction-flow.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/interaction-flow.md
@@ -192,5 +192,4 @@ loss without replacing what was lost.
   paths
 - whether the player can help the driver or Last-Stop Operations Helper first
 - final 2-3 authored snaps for Setup Clearance Walkthrough
-- smallest playable version that still lands final emotional readiness before
-  Relay
+- smallest prompt set that proves the accepted Opening Dance Shuttle beat

--- a/docs/game-design/ridge/areas/04-relay-ending/README.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/README.md
@@ -25,17 +25,57 @@ The emotional idea is: **I am ready for Cicka's threshold farewell.**
   The first playable version should be mostly quiet, player-triggered, and
   short: sit beside Cicka, play the familiar Concert guitar phrase, and avoid
   any pass/fail challenge.
-- A brief **Route Memory Montage** may appear during the guitar with 2-3 memory
-  flashes from the route.
+- For the **First Playable Route**, lock the Relay ending as one short
+  player-triggered sequence: Dance Festival transition into Relay, brief
+  playable linger, **Sit and Play**, **Guitar Farewell**, **Cicka Threshold
+  Farewell**, then **Open Ridge Return State**.
+- Do not add a separate "send Cicka" prompt, final choice, or Relay readiness
+  gate in the first playable version.
+- Keep the first-playable Relay linger minimal: a tiny overlook space where the
+  player can take a few steps, read the Relay/threshold framing, optionally
+  inspect one quiet overlook detail, and then use **Sit and Play** near Cicka.
+- Do not add NPCs, collectibles, extra comfort menus, or a separate Cicka pet
+  prompt to the first-playable Relay linger. Later polish may add a few quiet
+  texture details if they preserve the simple final-scene shape.
+- After the player chooses **Sit and Play**, hand off fully into a short
+  authored sequence until **Open Ridge Return State**. Remove movement and
+  route input during the farewell. The one allowed agency beat is musical
+  pacing: after the montage and a short delay, reveal a soft prompt such as
+  **Let the song end**. If the player does not press it, the guitar phrase
+  resolves on its own.
+- The authored sequence should hold the moment in order: sit, camera settles,
+  guitar phrase begins, the three montage flashes play, return to Relay at
+  sunset while Danilo keeps playing as the sun lowers, the delayed soft prompt
+  appears, the player either lets the song end or the phrase resolves naturally,
+  a small silence lands, Cicka moves to the threshold, turns back toward the
+  seated player, gives one small raw meow, departs beyond the player's path,
+  the scene holds on the empty sunset spot, a restrained non-diegetic dedication
+  card appears, then the game returns to the open Ridge.
+- Include a tiny first-playable **Route Memory Montage** during the guitar:
+  exactly three soft flashes, no interaction, and no captions. Use the changed
+  world states that prove the route: completed Bridge crossing, opened Concert
+  crossing / guitar handoff echo, and Dance Festival night beginning after the
+  player leaves.
+- Cicka Resting Spot echoes are later polish unless one is visually cheap and
+  already established before the ending.
 - **Sit and Play** is the final completion trigger for v0. Do not add **Send the
   Sketchbook Prompt** unless the sketchbook becomes a seeded object or
   interaction across the route first.
-- After the final guitar phrase, Cicka walks with the player to the threshold,
-  pauses, looks back once, then slips into a page fold, light, or other
-  threshold beyond the player's path.
+- After the final guitar phrase, Cicka moves toward the threshold, pauses,
+  turns back toward the seated player, gives one small raw meow, then slips into
+  a warm sketchbook-threshold artifact beyond the player's path. It should read
+  like a small place in the page that opens for Cicka, not necessarily a literal
+  fold at a paper edge: possible reads include warm light, a scratch-like seam,
+  a paper hole, or a gentle glitch-portal-like artifact. The player cannot
+  follow into that threshold. Art direction should refine the exact threshold
+  presentation while preserving this v0 read.
 - Any final Relay trace or Concert Resting Spot echo should read as optional
   visual staging only if earlier route art has taught that language; do not make
   paw/page marks a mechanic or required symbol in v0.
+- After Cicka disappears, hold on the empty sunset spot for a short silent beat,
+  then fade to a restrained non-diegetic dedication card:
+  **For Cicka.** / **Thank you for playing.** Do not present this card as Cicka
+  writing, speaking, or explaining the farewell.
 - The player returns to the **Open Ridge Return State** with the canonical final
   farewell complete and the guitar still with the player.
 
@@ -46,15 +86,20 @@ The emotional idea is: **I am ready for Cicka's threshold farewell.**
 - no credits-only ending
 - no arcade pass/fail challenge during the Guitar Farewell
 - no explanatory departure speech and no written goodbye in the initial version
+- no translated farewell line; Cicka's only farewell sound is one tiny raw meow
+  before she crosses the threshold
+- dedication card must be non-diegetic, not a message from Cicka
 - no immediate replacement reveal; Micka remains delayed
 - no scattering sad traces everywhere in the initial return state
 
 ## Route Readiness Feedback
 
-Provisional. The current first-ending route does not require a separate Living
-Proof checklist, optional-area readiness system, or post-song send prompt. The
-main feedback need is the transition from Dance Festival clearance to Relay
-arrival, then from sunset Guitar Farewell into Cicka's threshold departure.
+The current first-ending route does not require a separate Living Proof
+checklist, optional-area readiness system, final choice, post-song send prompt,
+NPC, collectible, comfort menu, or Cicka pet prompt. The main feedback need is
+the transition from Dance Festival clearance to Relay arrival, the brief
+playable linger before **Sit and Play**, then the handoff from sunset **Guitar
+Farewell** into Cicka's threshold departure and open return.
 
 ## Cicka Threshold Staging
 
@@ -64,11 +109,15 @@ threshold geometry, and post-ending interactability.
 
 ## Open Local Slots
 
-- physical Relay topology and threshold geometry
+- physical Relay topology and warm sketchbook-threshold geometry
 - final Cicka field-presence spot
-- exact camera and input handoff for Sit and Play
-- exact guitar audio texture and silence timing
-- exact Route Memory Montage image order
-- threshold departure presentation after Sit and Play
+- exact camera framing for the authored Sit and Play handoff
+- exact guitar audio texture, delayed soft prompt timing/wording, and silence
+  timing
+- exact framing and timing for each Route Memory Montage flash
+- exact warm threshold artifact presentation after Sit and Play
+- exact empty-sunset hold duration and dedication-card fade timing
 - Open Ridge Return State interactions
 - delayed Micka trigger
+- later optional Relay texture details after the minimal first-playable linger
+  works

--- a/docs/game-design/ridge/areas/04-relay-ending/README.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/README.md
@@ -119,18 +119,20 @@ reset.
 
 Unresolved. This area still needs exact decisions for camera behavior, input
 handoff, animation beats, silence, audio, visual trace placement if any,
-threshold geometry, and post-ending interactability.
+threshold geometry, and post-ending interactability. Exact timing values for
+holds, fades, prompt delay, montage flashes, and silence are prototype-tuned
+rather than pre-production canon; implementation agents should choose tasteful
+recommended defaults and validate them through playtesting.
 
 ## Open Local Slots
 
 - physical Relay topology and warm sketchbook-threshold geometry
 - final Cicka field-presence spot
 - exact camera framing for the authored Sit and Play handoff
-- exact guitar audio texture, delayed soft prompt timing/wording, and silence
-  timing
-- exact framing and timing for each Route Memory Montage flash
+- exact guitar audio texture and delayed soft prompt wording
+- prototype-tuned timing defaults for the delayed soft prompt, silence, Route
+  Memory Montage flashes, empty-sunset hold, dedication-card hold, and auto-fade
 - exact warm threshold artifact presentation after Sit and Play
-- exact empty-sunset hold duration and dedication-card auto-fade timing
 - First Playable Reset Return Bridge-start reset behavior
 - whether any invisible ending-seen flag is needed for future unlocks
 - long-term Open Ridge Return State interactions

--- a/docs/game-design/ridge/areas/04-relay-ending/README.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/README.md
@@ -28,7 +28,7 @@ The emotional idea is: **I am ready for Cicka's threshold farewell.**
 - For the **First Playable Route**, lock the Relay ending as one short
   player-triggered sequence: Dance Festival transition into Relay, brief
   playable linger, **Sit and Play**, **Guitar Farewell**, **Cicka Threshold
-  Farewell**, then **Open Ridge Return State**.
+  Farewell**, **Dedication Card**, then **First Playable Reset Return**.
 - Do not add a separate "send Cicka" prompt, final choice, or Relay readiness
   gate in the first playable version.
 - Keep the first-playable Relay linger minimal: a tiny overlook space where the
@@ -38,7 +38,7 @@ The emotional idea is: **I am ready for Cicka's threshold farewell.**
   prompt to the first-playable Relay linger. Later polish may add a few quiet
   texture details if they preserve the simple final-scene shape.
 - After the player chooses **Sit and Play**, hand off fully into a short
-  authored sequence until **Open Ridge Return State**. Remove movement and
+  authored sequence until **First Playable Reset Return**. Remove movement and
   route input during the farewell. The one allowed agency beat is musical
   pacing: after the montage and a short delay, reveal a soft prompt such as
   **Let the song end**. If the player does not press it, the guitar phrase
@@ -50,7 +50,8 @@ The emotional idea is: **I am ready for Cicka's threshold farewell.**
   a small silence lands, Cicka moves to the threshold, turns back toward the
   seated player, gives one small raw meow, departs beyond the player's path,
   the scene holds on the empty sunset spot, a restrained non-diegetic dedication
-  card appears, then the game returns to the open Ridge.
+  card appears, the card holds briefly without a button prompt, then auto-fades
+  into the clean Bridge Area reset.
 - Include a tiny first-playable **Route Memory Montage** during the guitar:
   exactly three soft flashes, no interaction, and no captions. Use the changed
   world states that prove the route: completed Bridge crossing, opened Concert
@@ -75,15 +76,27 @@ The emotional idea is: **I am ready for Cicka's threshold farewell.**
 - After Cicka disappears, hold on the empty sunset spot for a short silent beat,
   then fade to a restrained non-diegetic dedication card:
   **For Cicka.** / **Thank you for playing.** Do not present this card as Cicka
-  writing, speaking, or explaining the farewell.
-- The player returns to the **Open Ridge Return State** with the canonical final
-  farewell complete and the guitar still with the player.
+  writing, speaking, or explaining the farewell. The card should hold briefly,
+  then auto-fade into the clean Bridge Area reset without a button prompt. Do
+  not add a separate credits card or "The End" card in v0.
+- For v0, the player enters **First Playable Reset Return** after the
+  **Dedication Card**: cleanly reset route progress and return directly to the
+  beginning of Bridge Area instead of opening a post-game free-travel Ridge or
+  title/menu return. Long-term, this can become an **Open Ridge Return State**
+  where the completed areas remain freely revisitable after the farewell, once
+  optional mini-games, return content, and completed-area revisits exist.
+- Keep the v0 reset clean: do not show Micka, a changed post-ending world, a
+  special ending-seen marker, or a new objective after reset. If an internal
+  ending-seen flag is ever needed, keep it invisible until the long-term
+  post-game design exists.
 
 ## Tone Boundaries
 
 - no literal death scene
 - no grief monologue
 - no credits-only ending
+- no separate credits card or "The End" card in v0; the **Dedication Card** is
+  the full end card
 - no arcade pass/fail challenge during the Guitar Farewell
 - no explanatory departure speech and no written goodbye in the initial version
 - no translated farewell line; Cicka's only farewell sound is one tiny raw meow
@@ -99,7 +112,8 @@ checklist, optional-area readiness system, final choice, post-song send prompt,
 NPC, collectible, comfort menu, or Cicka pet prompt. The main feedback need is
 the transition from Dance Festival clearance to Relay arrival, the brief
 playable linger before **Sit and Play**, then the handoff from sunset **Guitar
-Farewell** into Cicka's threshold departure and open return.
+Farewell** into Cicka's threshold departure, **Dedication Card**, and route
+reset.
 
 ## Cicka Threshold Staging
 
@@ -116,8 +130,10 @@ threshold geometry, and post-ending interactability.
   timing
 - exact framing and timing for each Route Memory Montage flash
 - exact warm threshold artifact presentation after Sit and Play
-- exact empty-sunset hold duration and dedication-card fade timing
-- Open Ridge Return State interactions
+- exact empty-sunset hold duration and dedication-card auto-fade timing
+- First Playable Reset Return Bridge-start reset behavior
+- whether any invisible ending-seen flag is needed for future unlocks
+- long-term Open Ridge Return State interactions
 - delayed Micka trigger
 - later optional Relay texture details after the minimal first-playable linger
   works

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -15,6 +15,11 @@ area files for local geography, blockers, residents, prompts, traversal,
 staging, Cicka Resting Spot details, visual/audio notes, and area-specific open
 questions.
 
+Ownership rule: root [`../open-questions.md`](../open-questions.md) is for
+route-level or taste-sensitive decisions. Area docs own local **Open Local
+Slots** such as topology, prompt wording, prop placement, resident silhouettes,
+camera framing, and local art/audio choices.
+
 ## Area Docs
 
 | Route order | Area doc | Owns |

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -22,8 +22,9 @@ The first complete route should prove:
 2. Relay Spire is visible early
 3. required Resident Help Beats visibly change the Ridge
 4. Cicka feels present through field appearances and resting spots
-5. Guitar Farewell, Cicka Threshold Farewell, and Open Ridge Return State land
-   without arcade gating or an unseeded extra final prompt
+5. Guitar Farewell, Cicka Threshold Farewell, Dedication Card, and First
+   Playable Reset Return land without arcade gating or an unseeded extra final
+   prompt
 6. optional mini-games remain side fun, rewards, shortcuts, or future
    alternate-path candidates rather than required first-ending proof
 
@@ -50,7 +51,8 @@ doc instead.
 - **P3 Route Readiness Feedback**: make area barricades, resident help, world
   changes, and Relay arrival readable without a visible chore checklist.
 - **P4 Ending Pass**: land Guitar Farewell as the final trigger, Cicka Threshold
-  Farewell, Open Ridge Return State, and later Micka timing.
+  Farewell, Dedication Card, First Playable Reset Return, and later long-term
+  Open Ridge Return State / Micka timing.
 
 Optional mini-games, old Cicka Home mutation work, and folded-desk topology
 enter these milestones only when an active route doc or issue pulls a specific

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -1,22 +1,54 @@
 # Ridge Open Questions
 
 > Status: needs-HITL / active brainstorming.
-> This file tracks unresolved design gaps for the active Ridge route. It is not
-> implementation scope and not a backlog. When a question resolves, move the
-> accepted decision to the correct canon file and remove or rewrite the question.
+> This file tracks route-level unresolved design gaps for the active Ridge
+> route. It is not implementation scope and not a backlog. When a question
+> resolves, move the accepted decision to the correct canon file and remove or
+> rewrite the question.
 
 Read [`README.md`](./README.md) first for source-of-truth routing. Resolved
 area-local detail belongs in the matching [`areas/`](./areas/README.md) file or
 the narrowest subdoc inside that area folder.
 
+## How To Read This File
+
+The main route shape is already accepted:
+
+```text
+Bridge Area -> Concert Area -> Dance Festival Area -> Relay Ending
+```
+
+Bridge, Concert, and Dance Festival each have accepted local contracts in
+[`areas/`](./areas/README.md). Local questions about topology, prompts, prop
+placement, character silhouettes, or exact room staging belong in the matching
+area doc's **Open Local Slots**, not here.
+
+Use these labels:
+
+- **True design unknown:** taste-sensitive or product-shaping decision still
+  needs Danilo.
+- **Route blockout TBD:** accepted route needs cross-area room checklist,
+  transition triggers, or recurring Cicka/state language.
+- **Future/post-v0:** valid idea, but not required for the **First Playable
+  Route**.
+
+Area-local detail lives here:
+
+- [`01-bridge/README.md`](./areas/01-bridge/README.md#open-local-slots)
+- [`02-concert/README.md`](./areas/02-concert/README.md#open-local-slots)
+- [`03-dance-festival/README.md`](./areas/03-dance-festival/README.md#open-local-slots)
+- [`03-dance-festival/layout.md`](./areas/03-dance-festival/layout.md#open-spatial-slots)
+- [`03-dance-festival/characters.md`](./areas/03-dance-festival/characters.md#open-character-slots)
+- [`03-dance-festival/interaction-flow.md`](./areas/03-dance-festival/interaction-flow.md#open-prompt-slots)
+- [`04-relay-ending/README.md`](./areas/04-relay-ending/README.md#open-local-slots)
+
 ## Ending
+
+True design unknowns:
 
 - **Guitar Farewell micro-staging:** Given the accepted quiet, short Sit and
   Play shape, what are the exact camera, input handoff, animation, silence, and
   audio beats from guitar phrase through Cicka's threshold departure?
-- **Pre-ending Relay linger:** What small movement, sitting, or comfort
-  interactions are available before the player chooses Sit and Play, and how is
-  the wider Ridge route blocked without feeling gamey?
 - **Cicka Threshold Farewell staging:** What exact physical sequence carries
   Cicka's final walk, look back, and page-fold/light departure without relying
   on unseeded paw/page marks as a mechanic?
@@ -26,7 +58,16 @@ the narrowest subdoc inside that area folder.
 - **Micka timing:** What post-ending action eventually introduces Micka, and
   what must stay hidden until then?
 
+Route blockout TBD:
+
+- **Relay arrival linger:** What small movement, sitting, looking, or comfort
+  interactions are available after the Dance-to-Relay transition but before the
+  player chooses Sit and Play, without adding a separate pre-ready Relay access
+  state?
+
 ## Route Transitions
+
+Route blockout TBD:
 
 - **Concert-to-Dance travel staging:** What exact beats show the accepted
   implied post-concert rest and post-rest Band Roadie Van Ride without becoming
@@ -37,43 +78,25 @@ the narrowest subdoc inside that area folder.
   near Dance Festival because it is on the way?
 - **Recurring festival superfan placement:** Where should the desired comic
   resident be seeded at Bridge and Concert, where he sleeps through Dance,
-  and is he cheap enough for v0 or better saved for the immediate post-v0
-  liveliness pass?
+  and is he cheap enough for the First Playable Route or better saved for the
+  immediate post-v0 liveliness pass?
 
-## Dance Festival Area
+## First Playable Route Blockout
 
-- **Spatial layout:** What is the room topology for Last-Stop Plaza, service
-  road gate, shuttle, operations table, dance floor, lantern lines, and exits?
-- **Moment-to-moment prompts:** What concrete prompts, object interactions,
-  conversation branches, and recovery paths express the beat without turning it
-  into chores or a cutscene?
-- **Readiness Favor order:** Can the player help the driver or Last-Stop
-  Operations Helper first, and what changes if they approach in either order?
-- **Setup Clearance Walkthrough:** Which 2-3 authored snaps are enough to show
-  the service lane becoming safe?
-- **Resident identity pass:** What silhouettes, movement, dialogue style, and
-  eventual names fit the hill-shuttle driver, Last-Stop Operations Helper, Dance
-  Teacher, steward, traveler, and Unnamed Counterpart Cat?
-- **Festival art/audio language:** What palette, signage, music texture, crowd
-  ambience, and prop kit makes this area warm and romantic without colliding
-  with Concert or the later Guitar Farewell?
-- **Scope floor:** What is the smallest playable version that still lands the
-  final emotional readiness before Relay?
+The **First Playable Route** scope floor is already accepted in
+[`../../../CONTEXT.md`](../../../CONTEXT.md): the smallest complete Bridge Area
+through Relay Spire path that proves the emotional arc without required
+mini-games, optional interiors, campfire hangouts, or extra resident liveliness.
+Do not re-grill that scope unless Danilo changes the product target.
 
-## Dependencies
+Route blockout TBD:
 
-- **Concert guitarist stunt staging:** How much of the guitarist's absurd
-  skateboard stunt needs to be shown, implied, or reconstructed through props
-  so the joke lands without becoming expensive animation scope?
-- **Bridge blockout validation:** What must be visible in the Bridge blockout
-  to prove the accepted tutorial chain is readable: Cicka noticed something,
-  resident needs local help, route visibly changes?
-- **Cicka Resting Spots v0 states:** Which exact before/after prop, posture, or
-  visual trace is the smallest readable version for each required Ridge Area,
-  and which of those states should echo in the Route Memory Montage?
-- **Whole-route v0 scope floor:** What is the smallest playable route from
-  Bridge through Relay that preserves the emotional arc without waiting for
-  later mini-games, interiors, campfire, or extra resident liveliness?
+- **Route blockout checklist:** What exact rooms, prompts, blockers, route
+  changes, Cicka before/after states, and transition triggers must exist for a
+  complete Bridge -> Concert -> Dance -> Relay blockout pass?
+- **Cicka Resting Spots first-pass states:** Which exact before/after prop,
+  posture, or visual trace is the smallest readable version for each required
+  Ridge Area, and which of those states should echo in the Route Memory Montage?
 
 ## Resolution Rule
 

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -55,10 +55,10 @@ True design unknowns:
   Cicka's final threshold movement, turn-back, tiny raw meow, and warm
   sketchbook-threshold departure without relying on unseeded paw/page marks as a
   mechanic?
-- **Open Ridge Return State:** What interactions remain available immediately
-  after the empty-sunset hold and non-diegetic dedication card, and what minimal
-  visual absence echo, if any, is preserved at Relay or the Concert Resting
-  Spot?
+- **Long-term Open Ridge Return State:** After optional mini-games, return
+  content, or completed-area revisits exist, what interactions remain available
+  in a post-game free-travel Ridge, and what minimal visual absence echo, if
+  any, is preserved at Relay or the Concert Resting Spot?
 - **Micka timing:** What post-ending action eventually introduces Micka, and
   what must stay hidden until then?
 

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -47,23 +47,27 @@ Area-local detail lives here:
 True design unknowns:
 
 - **Guitar Farewell micro-staging:** Given the accepted quiet, short Sit and
-  Play shape, what are the exact camera, input handoff, animation, silence, and
-  audio beats from guitar phrase through Cicka's threshold departure?
+  Play shape and authored post-prompt handoff, what are the exact camera,
+  animation, three-flash montage timing, post-montage sunset playing beat,
+  delayed soft prompt timing/wording, silence, and audio beats from guitar
+  phrase through Cicka's threshold departure?
 - **Cicka Threshold Farewell staging:** What exact physical sequence carries
-  Cicka's final walk, look back, and page-fold/light departure without relying
-  on unseeded paw/page marks as a mechanic?
+  Cicka's final threshold movement, turn-back, tiny raw meow, and warm
+  sketchbook-threshold departure without relying on unseeded paw/page marks as a
+  mechanic?
 - **Open Ridge Return State:** What interactions remain available immediately
-  after the ending, and what minimal visual absence echo, if any, is preserved
-  at Relay or the Concert Resting Spot?
+  after the empty-sunset hold and non-diegetic dedication card, and what minimal
+  visual absence echo, if any, is preserved at Relay or the Concert Resting
+  Spot?
 - **Micka timing:** What post-ending action eventually introduces Micka, and
   what must stay hidden until then?
 
 Route blockout TBD:
 
-- **Relay arrival linger:** What small movement, sitting, looking, or comfort
-  interactions are available after the Dance-to-Relay transition but before the
-  player chooses Sit and Play, without adding a separate pre-ready Relay access
-  state?
+- **Relay arrival linger micro-beats:** Given the accepted minimal one-sequence
+  ending shape, what exact overlook framing, optional single inspect detail, and
+  Sit and Play prompt placement are available after the Dance-to-Relay
+  transition?
 
 ## Route Transitions
 

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -48,9 +48,10 @@ True design unknowns:
 
 - **Guitar Farewell micro-staging:** Given the accepted quiet, short Sit and
   Play shape and authored post-prompt handoff, what are the exact camera,
-  animation, three-flash montage timing, post-montage sunset playing beat,
-  delayed soft prompt timing/wording, silence, and audio beats from guitar
-  phrase through Cicka's threshold departure?
+  animation, post-montage sunset playing beat, delayed soft prompt wording, and
+  audio beats from guitar phrase through Cicka's threshold departure? Exact
+  timing values should be delegated to prototype/playtest with tasteful
+  recommended defaults rather than locked in pre-production.
 - **Cicka Threshold Farewell staging:** What exact physical sequence carries
   Cicka's final threshold movement, turn-back, tiny raw meow, and warm
   sketchbook-threshold departure without relying on unseeded paw/page marks as a

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -194,12 +194,21 @@ Accepted first ending outline:
 6. After Cicka disappears, hold on the empty sunset spot for a short silent beat,
    then fade to a restrained non-diegetic dedication card:
    **For Cicka.** / **Thank you for playing.** Do not present this card as Cicka
-   writing, speaking, or explaining the farewell.
+   writing, speaking, or explaining the farewell. The card should hold briefly,
+   then auto-fade into the clean Bridge Area reset without a button prompt. Do
+   not add a separate credits card or "The End" card in v0.
 7. A final Relay trace or Concert Resting Spot echo can exist only as visual
    staging if earlier route art has taught that language. Do not present
    paw/page marks as a mechanic or required symbol in v0.
-8. The player returns to the **Open Ridge Return State** after the ending, with
-   the world still open and the guitar still with the player.
+8. For the first playable version, use **First Playable Reset Return** after the
+   **Dedication Card**: cleanly reset route progress and return the player
+   directly to the beginning of Bridge Area rather than opening a post-game
+   free-travel Ridge or title/menu return. Long-term, this can become an **Open
+   Ridge Return State** where completed areas remain freely revisitable after
+   the farewell, once optional mini-games, return content, and completed-area
+   revisits exist.
+   Do not surface any visible ending-seen memory in v0: no Micka, no changed
+   post-ending world, no special marker, and no new objective after reset.
 
 The guitar should be established earlier as a meaningful comfort item:
 something the player can pick up and carry before the Relay **Guitar Farewell**.
@@ -334,10 +343,15 @@ The target asks for:
   gentle glitch-portal-like artifact rather than a literal page-edge fold. The
   player cannot follow into that threshold. The initial version should use no
   translated farewell line.
-- Immediate post-ending play should use the **Open Ridge Return State**:
-  replayable, quiet, and minimally absence-marked only if the route has seeded
-  that visual language. Micka remains delayed until the later post-ending
-  trigger rather than appearing immediately. The guitar stays with the player.
+- Immediate v0 post-ending behavior should use **First Playable Reset Return**:
+  after the **Dedication Card**, cleanly reset route progress and return the
+  player directly to the beginning of Bridge Area instead of opening a
+  post-game free-travel Ridge. Long-term, an **Open Ridge Return State** can
+  make completed areas freely revisitable, quiet, and minimally absence-marked
+  once optional mini-games, return content, or completed-area revisits make that
+  return valuable. Do not surface visible ending-seen memory in v0; Micka
+  remains delayed until a later post-ending trigger rather than appearing
+  immediately.
 - Cicka field presence in every required Resident Help Beat, with one local
   **Cicka Resting Spot** per required Ridge Area: Bridge Resting Spot, Concert
   Resting Spot, and Dance Festival Resting Spot. Her role can vary from subtle

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -163,10 +163,9 @@ this prose pass, but the core overworld/Ridge route blockers should be legible
 in words first.
 
 The accepted ending anchor is the **Cicka Threshold Farewell**: Cicka recurs
-through the Ridge as field presence, accompanies the player to the Relay Spire
-threshold, and then departs somewhere the player cannot follow. The ending
-should stay replayable, tender, and non-literal rather than becoming a death
-scene or grief speech.
+through the Ridge as field presence, then leaves the seated player through a
+warm sketchbook threshold somewhere the player cannot follow. The ending should
+stay tender and non-literal rather than becoming a death scene or grief speech.
 Design the canonical first ending before designing optional endings. Multiple
 endings are not required for the Ridge; add alternate endings only if a later
 story/level pass proves they create meaningful replay value without weakening
@@ -197,6 +196,9 @@ Accepted first ending outline:
    writing, speaking, or explaining the farewell. The card should hold briefly,
    then auto-fade into the clean Bridge Area reset without a button prompt. Do
    not add a separate credits card or "The End" card in v0.
+   Exact hold, fade, montage, prompt-delay, and silence timings should be tuned
+   in prototype/playtest with tasteful recommended defaults rather than fixed in
+   pre-production.
 7. A final Relay trace or Concert Resting Spot echo can exist only as visual
    staging if earlier route art has taught that language. Do not present
    paw/page marks as a mechanic or required symbol in v0.

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -185,13 +185,20 @@ Accepted first ending outline:
 4. The player uses **Sit and Play** to share a quiet Guitar Farewell with Cicka,
    ideally under a warm sunset or other cozy threshold light. This is the v0
    final trigger, not setup for a separate post-song send prompt.
-5. Cicka walks with the player to the threshold, pauses, looks back once, then
-   slips into a page fold, light, or other threshold beyond the player's path.
-   The initial version uses no translated farewell line.
-6. A final Relay trace or Concert Resting Spot echo can exist only as visual
+5. Cicka moves toward the threshold, pauses, turns back toward the seated
+   player, gives one small raw meow, then slips into a warm
+   sketchbook-threshold artifact beyond the player's path. It can read as warm
+   light, a scratch-like seam, a paper hole, or a gentle glitch-portal-like
+   artifact rather than a literal page-edge fold. The player cannot follow into
+   that threshold. The initial version uses no translated farewell line.
+6. After Cicka disappears, hold on the empty sunset spot for a short silent beat,
+   then fade to a restrained non-diegetic dedication card:
+   **For Cicka.** / **Thank you for playing.** Do not present this card as Cicka
+   writing, speaking, or explaining the farewell.
+7. A final Relay trace or Concert Resting Spot echo can exist only as visual
    staging if earlier route art has taught that language. Do not present
    paw/page marks as a mechanic or required symbol in v0.
-7. The player returns to the **Open Ridge Return State** after the ending, with
+8. The player returns to the **Open Ridge Return State** after the ending, with
    the world still open and the guitar still with the player.
 
 The guitar should be established earlier as a meaningful comfort item:
@@ -320,10 +327,13 @@ The target asks for:
 - The final Relay Spire interaction should be a **Sit and Play Prompt** near
   Cicka. It starts the Guitar Farewell and commits to the ending without rhythm
   UI, fail state, final skill check, or separate post-song send prompt.
-- Cicka's departure should be physical and mostly silent: walk together, pause,
-  look back, then page-fold/light departure. The initial version should use no
-  translated farewell line; a tiny raw meow/chirp sound can remain optional if
-  it supports the staging.
+- Cicka's departure should be physical and mostly silent: Cicka moves toward
+  the threshold alone, turns back toward the seated player, gives one small raw
+  meow, then slips into a warm sketchbook-threshold artifact beyond the player's
+  path. It can read as warm light, a scratch-like seam, a paper hole, or a
+  gentle glitch-portal-like artifact rather than a literal page-edge fold. The
+  player cannot follow into that threshold. The initial version should use no
+  translated farewell line.
 - Immediate post-ending play should use the **Open Ridge Return State**:
   replayable, quiet, and minimally absence-marked only if the route has seeded
   that visual language. Micka remains delayed until the later post-ending

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -91,6 +91,9 @@ Accepted ending outline:
    as Cicka writing, speaking, or explaining the farewell. The card should hold
    briefly, then auto-fade into the clean Bridge Area reset without a button
    prompt. Do not add a separate credits card or "The End" card in v0.
+   Exact hold, fade, montage, prompt-delay, and silence timings should be tuned
+   in prototype/playtest with tasteful recommended defaults rather than fixed in
+   pre-production.
 10. A final trace at Relay or a quiet Concert Resting Spot echo can exist only as
    visual staging if earlier route art has taught that language. Do not present
    paw/page marks as a mechanic or required symbol in v0.

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -61,21 +61,38 @@ Accepted ending outline:
    cozy threshold light. The first playable version should stay short and quiet:
    sit beside Cicka, play the familiar Concert guitar phrase, and let the moment
    breathe without a pass/fail challenge.
-5. A brief **Route Memory Montage** can appear during the guitar with 2-3
-   flashes, such as Blueprint Bridge being used, Concert Crossing continuing,
-   Opening Dance beginning at night as an emotional echo under the player's
-   guitar, or earlier Cicka Resting Spots carrying changed visual states.
-6. **Sit and Play Prompt** is the final completion trigger for the first
+5. The first playable ending includes a brief **Route Memory Montage** during
+   the guitar with exactly three soft flashes, no interaction, and no captions:
+   the completed Bridge crossing, the opened Concert crossing / guitar handoff
+   echo, and Dance Festival night beginning after the player leaves. Cicka
+   Resting Spot echoes are later polish unless one is visually cheap and already
+   established.
+6. After the montage, return to Relay at sunset while Danilo keeps playing as
+   the sun lowers. Do not show the stop-playing option immediately; after a
+   short delay, reveal a soft prompt such as **Let the song end**. If the player
+   does not press it, the guitar phrase resolves on its own. Only after that
+   small musical ending and silence should Cicka move toward the threshold.
+7. **Sit and Play Prompt** is the final completion trigger for the first
    ending. Do not add **Send the Sketchbook Prompt** in v0 unless the sketchbook
    becomes a seeded object or interaction across the route first.
-7. After the final guitar phrase, Cicka walks with the player to the threshold,
-   pauses, looks back once, then slips into a page fold, light, or other
-   threshold beyond the player's path. The player does not force Cicka away.
-   The initial version uses no translated farewell line.
-8. A final trace at Relay or a quiet Concert Resting Spot echo can exist only as
+8. After the final guitar phrase, Cicka moves toward the threshold, pauses,
+   turns back toward the seated player, gives one small raw meow, then slips
+   into a warm sketchbook-threshold artifact beyond the player's path. It
+   should read like a small place in the page that opens for Cicka, not
+   necessarily a literal fold at a paper edge: possible reads include warm
+   light, a scratch-like seam, a paper hole, or a gentle glitch-portal-like
+   artifact. The player cannot follow into that threshold and does not force
+   Cicka away. The initial version uses no translated farewell line. Art
+   direction should refine the exact threshold presentation while preserving
+   this v0 read.
+9. After Cicka disappears, hold on the empty sunset spot for a short silent
+   beat, then fade to a restrained non-diegetic dedication card:
+   **For Cicka.** / **Thank you for playing.** This card should not be presented
+   as Cicka writing, speaking, or explaining the farewell.
+10. A final trace at Relay or a quiet Concert Resting Spot echo can exist only as
    visual staging if earlier route art has taught that language. Do not present
    paw/page marks as a mechanic or required symbol in v0.
-9. The player returns to the **Open Ridge Return State** after the ending, with
+11. The player returns to the **Open Ridge Return State** after the ending, with
    the world still open and the guitar still with the player. The exact
    post-ending interactability and any minimal visual absence echo remain open.
 
@@ -86,8 +103,10 @@ Tone boundaries:
 - no credits-only ending
 - no arcade pass/fail challenge during the Guitar Farewell
 - no explanatory departure speech and no written goodbye in the initial version;
-  a tiny raw meow/chirp sound is optional only if it stays smaller than the
-  silence
+  Cicka's only farewell sound is one tiny raw meow before she crosses the
+  threshold, and it should stay smaller than the silence
+- the dedication card is non-diegetic; do not present it as a message from
+  Cicka or as an explanation of where she went
 - no immediate replacement reveal; Micka remains delayed until the later
   post-ending trigger
 - no scattering sad marks everywhere in the initial return state; use at most a

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -88,19 +88,29 @@ Accepted ending outline:
 9. After Cicka disappears, hold on the empty sunset spot for a short silent
    beat, then fade to a restrained non-diegetic dedication card:
    **For Cicka.** / **Thank you for playing.** This card should not be presented
-   as Cicka writing, speaking, or explaining the farewell.
+   as Cicka writing, speaking, or explaining the farewell. The card should hold
+   briefly, then auto-fade into the clean Bridge Area reset without a button
+   prompt. Do not add a separate credits card or "The End" card in v0.
 10. A final trace at Relay or a quiet Concert Resting Spot echo can exist only as
    visual staging if earlier route art has taught that language. Do not present
    paw/page marks as a mechanic or required symbol in v0.
-11. The player returns to the **Open Ridge Return State** after the ending, with
-   the world still open and the guitar still with the player. The exact
-   post-ending interactability and any minimal visual absence echo remain open.
+11. For the first playable version, use **First Playable Reset Return** after
+   the **Dedication Card**: cleanly reset route progress and return the player
+   directly to the beginning of Bridge Area rather than opening a post-game
+   free-travel Ridge or title/menu return. Long-term, this can become an
+   **Open Ridge Return State** where the player can freely move between
+   completed areas after the farewell, but that pays off only once optional
+   mini-games, return content, and completed-area revisits exist.
+   Do not surface any visible ending-seen memory in v0: no Micka, no changed
+   post-ending world, no special marker, and no new objective after reset.
 
 Tone boundaries:
 
 - no literal death scene
 - no grief monologue
 - no credits-only ending
+- no separate credits card or "The End" card in v0; the **Dedication Card** is
+  the full end card
 - no arcade pass/fail challenge during the Guitar Farewell
 - no explanatory departure speech and no written goodbye in the initial version;
   Cicka's only farewell sound is one tiny raw meow before she crosses the
@@ -268,7 +278,7 @@ Relay Spire / Guitar Farewell -> I am ready for Cicka's threshold farewell.
 | [Bridge Area](./areas/01-bridge/README.md) | Blueprint Bridge | Accepted first art/drawing beat | Required soft gate tutorial for resident help | Obvious subtle attention cue at unsafe edge or blank plan | Finished bridge sketch becomes the crossing |
 | [Concert Area](./areas/02-concert/README.md) | Concert Crossing Beat | Accepted middle beat | Blocks a concert/traffic crossing and earns the guitar | Crowd-shy observer near hidden musician-side space, then relaxed with the band after the crossing opens | Concert continues; crossing opens; guitar entrusted to player |
 | [Dance Festival Area](./areas/03-dance-festival/README.md) | Opening Dance Shuttle Beat | Accepted final beat direction; Last-Stop Operations Helper locked as romantic partner role | Creates the last emotional readiness before Relay through daytime setup that progresses toward late afternoon for a night dance festival at the foot of the Relay hill | Quiet threshold observer near the lantern crates, operations table, shuttle step, or service gate; may loaf with the Unnamed Counterpart Cat | Festival setup clears enough for one last daylight shuttle to Relay before the night road closure |
-| [Relay Ending Area](./areas/04-relay-ending/README.md) | Guitar Farewell / Cicka Threshold Farewell | Active ending direction | Final threshold after the Dance Festival barricade is cleared | Final field-presence spot and threshold departure | Open Ridge Return State keeps the world open after the farewell, with any absence echo treated as visual staging rather than a required mark mechanic |
+| [Relay Ending Area](./areas/04-relay-ending/README.md) | Guitar Farewell / Cicka Threshold Farewell | Active ending direction | Final threshold after the Dance Festival barricade is cleared | Final field-presence spot and threshold departure | First playable cleanly resets to Bridge Area after the Dedication Card; long-term Open Ridge Return State can keep the completed world open after the farewell |
 
 ## Opening Dance Shuttle Beat
 

--- a/docs/game-design/ridge/summit.md
+++ b/docs/game-design/ridge/summit.md
@@ -69,16 +69,20 @@ The ending order is protected:
 2. Cicka appears at the Relay threshold
 3. Sit and Play starts the Guitar Farewell at sunset as the final trigger
 4. Cicka Threshold Farewell follows the final guitar phrase
-5. Open Ridge Return State
+5. First Playable Reset Return for v0; long-term Open Ridge Return State
 
 The farewell is a tribute beat, not a literal-heavy explanation. Use presence,
-absence, silence, guitar, and the return-state Ridge to carry it. Paw/page marks
-should stay optional visual language only if seeded earlier, not an unintroduced
-ending mechanic.
+absence, silence, guitar, and a restrained non-diegetic dedication to carry it.
+For v0, the ending can cleanly reset the player to Bridge Area after the
+Dedication Card instead of opening post-game free travel. Long-term, the
+return-state Ridge can carry absence and free movement between completed areas
+once optional mini-games, return content, and completed-area revisits make that
+valuable. Paw/page marks should stay optional visual language only if seeded
+earlier, not an unintroduced ending mechanic.
 
-Micka appears after the player returns to normal Ridge and completes or replays
-one post-ending mini-game. She is continuity, not replacement, and should not
-enter the ending sequence itself.
+Micka appears only after a later post-ending trigger such as returning to a
+post-game Ridge and completing or replaying one mini-game. She is continuity,
+not replacement, and should not enter the ending sequence itself.
 
 ## Optional Toy Stance
 


### PR DESCRIPTION
## Summary
- Refine the Ridge pre-production docs around the v0 farewell sequence and its supporting beat structure.
- Lock the ending into a minimal sequence: guitar farewell, Cicka’s threshold departure, dedication card, then a clean reset to the start of Bridge Area.
- Distinguish v0 behavior from the long-term post-game / open return world so the current scope stays intentionally simple.
- Update canonical Ridge docs, glossary terms, milestone plan, and open questions to match the current ending decisions.

## Testing
- Not run (not requested).
- Reviewed the active Ridge documentation set for consistency after the terminology and scope updates.