### PR TITLE
Document Ridge pre-production decisions and tracer slice readiness

### DIFF
--- a/.agents/skills/git-guardrails-claude-code/SKILL.md
+++ b/.agents/skills/git-guardrails-claude-code/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: git-guardrails-claude-code
+description: Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, branch -D, etc.) before they execute. Use when user wants to prevent destructive git operations, add git safety hooks, or block git push/reset in Claude Code.
+---
+
+# Setup Git Guardrails
+
+Sets up a PreToolUse hook that intercepts and blocks dangerous git commands before Claude executes them.
+
+## What Gets Blocked
+
+- `git push` (all variants including `--force`)
+- `git reset --hard`
+- `git clean -f` / `git clean -fd`
+- `git branch -D`
+- `git checkout .` / `git restore .`
+
+When blocked, Claude sees a message telling it that it does not have authority to access these commands.
+
+## Steps
+
+### 1. Ask scope
+
+Ask the user: install for **this project only** (`.claude/settings.json`) or **all projects** (`~/.claude/settings.json`)?
+
+### 2. Copy the hook script
+
+The bundled script is at: [scripts/block-dangerous-git.sh](scripts/block-dangerous-git.sh)
+
+Copy it to the target location based on scope:
+
+- **Project**: `.claude/hooks/block-dangerous-git.sh`
+- **Global**: `~/.claude/hooks/block-dangerous-git.sh`
+
+Make it executable with `chmod +x`.
+
+### 3. Add hook to settings
+
+Add to the appropriate settings file:
+
+**Project** (`.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-dangerous-git.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Global** (`~/.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/block-dangerous-git.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+If the settings file already exists, merge the hook into existing `hooks.PreToolUse` array — don't overwrite other settings.
+
+### 4. Ask about customization
+
+Ask if user wants to add or remove any patterns from the blocked list. Edit the copied script accordingly.
+
+### 5. Verify
+
+Run a quick test:
+
+```bash
+echo '{"tool_input":{"command":"git push origin main"}}' | <path-to-script>
+```
+
+Should exit with code 2 and print a BLOCKED message to stderr.

--- a/.agents/skills/git-guardrails-claude-code/SKILL.md
+++ b/.agents/skills/git-guardrails-claude-code/SKILL.md
@@ -5,7 +5,7 @@ description: Set up Claude Code hooks to block dangerous git commands (push, res
 
 # Setup Git Guardrails
 
-Sets up a PreToolUse hook that intercepts and blocks dangerous git commands before Claude executes them.
+Sets up a best-effort PreToolUse hook that intercepts and blocks common dangerous git commands before Claude executes them. This hook is a safety net, not a complete shell sandbox: it can miss aliases, wrappers, unusual quoting, or commands hidden behind another executable.
 
 ## What Gets Blocked
 
@@ -15,7 +15,7 @@ Sets up a PreToolUse hook that intercepts and blocks dangerous git commands befo
 - `git branch -D`
 - `git checkout .` / `git restore .`
 
-When blocked, Claude sees a message telling it that it does not have authority to access these commands.
+When blocked, Claude sees a message telling it that it does not have authority to access these commands. Keep normal review and permission habits in place even after installing the hook.
 
 ## Steps
 
@@ -93,3 +93,11 @@ echo '{"tool_input":{"command":"git push origin main"}}' | <path-to-script>
 ```
 
 Should exit with code 2 and print a BLOCKED message to stderr.
+
+Also test common variants:
+
+```bash
+echo '{"tool_input":{"command":"git -C repo push"}}' | <path-to-script>
+echo '{"tool_input":{"command":"git clean -xdf"}}' | <path-to-script>
+echo '{"tool_input":{"command":"git restore -- ."}}' | <path-to-script>
+```

--- a/.agents/skills/git-guardrails-claude-code/SKILL.md
+++ b/.agents/skills/git-guardrails-claude-code/SKILL.md
@@ -5,7 +5,7 @@ description: Set up Claude Code hooks to block dangerous git commands (push, res
 
 # Setup Git Guardrails
 
-Sets up a best-effort PreToolUse hook that intercepts and blocks common dangerous git commands before Claude executes them. This hook is a safety net, not a complete shell sandbox: it can miss aliases, wrappers, unusual quoting, or commands hidden behind another executable.
+Sets up a best-effort PreToolUse hook that intercepts and blocks common dangerous git commands before Claude executes them. This hook requires `jq` and fails closed if it cannot parse Claude's hook input. It is a safety net, not a complete shell sandbox: it can miss aliases, wrappers, unusual quoting, or commands hidden behind another executable.
 
 ## What Gets Blocked
 
@@ -33,6 +33,10 @@ Copy it to the target location based on scope:
 - **Global**: `~/.claude/hooks/block-dangerous-git.sh`
 
 Make it executable with `chmod +x`.
+
+Make sure `jq` is installed on the machine where the hook will run. The script
+exits with code 2 if `jq` is missing or if Claude's hook payload cannot be
+parsed.
 
 ### 3. Add hook to settings
 

--- a/.agents/skills/git-guardrails-claude-code/scripts/block-dangerous-git.sh
+++ b/.agents/skills/git-guardrails-claude-code/scripts/block-dangerous-git.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+
+DANGEROUS_PATTERNS=(
+  "git push"
+  "git reset --hard"
+  "git clean -fd"
+  "git clean -f"
+  "git branch -D"
+  "git checkout \."
+  "git restore \."
+  "push --force"
+  "reset --hard"
+)
+
+for pattern in "${DANGEROUS_PATTERNS[@]}"; do
+  if echo "$COMMAND" | grep -qE "$pattern"; then
+    echo "BLOCKED: '$COMMAND' matches dangerous pattern '$pattern'. The user has prevented you from doing this." >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/.agents/skills/git-guardrails-claude-code/scripts/block-dangerous-git.sh
+++ b/.agents/skills/git-guardrails-claude-code/scripts/block-dangerous-git.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
-INPUT=$(cat)
-
-if command -v jq >/dev/null 2>&1; then
-  COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
-else
-  COMMAND=$(printf '%s' "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: 'jq' is required but not installed. Cannot verify git guardrails." >&2
+  exit 2
 fi
 
-if [ -z "${COMMAND:-}" ]; then
-  exit 0
+INPUT=$(cat)
+
+if ! COMMAND=$(printf '%s' "$INPUT" | jq -er '.tool_input.command | strings' 2>/dev/null); then
+  echo "ERROR: Failed to parse tool input command. Cannot verify git guardrails." >&2
+  exit 2
 fi
 
 NORMALIZED_COMMAND=$(printf '%s' "$COMMAND" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
@@ -28,7 +28,7 @@ DANGEROUS_PATTERNS=(
 
 for pattern in "${DANGEROUS_PATTERNS[@]}"; do
   if printf '%s\n' "$NORMALIZED_COMMAND" | grep -qE "$pattern"; then
-    echo "BLOCKED: '$COMMAND' matches dangerous git pattern. The user has prevented you from doing this." >&2
+    printf "BLOCKED: '%s' matches dangerous git pattern. The user has prevented you from doing this.\n" "$COMMAND" >&2
     exit 2
   fi
 done

--- a/.agents/skills/git-guardrails-claude-code/scripts/block-dangerous-git.sh
+++ b/.agents/skills/git-guardrails-claude-code/scripts/block-dangerous-git.sh
@@ -1,23 +1,34 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+
+if command -v jq >/dev/null 2>&1; then
+  COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+else
+  COMMAND=$(printf '%s' "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+fi
+
+if [ -z "${COMMAND:-}" ]; then
+  exit 0
+fi
+
+NORMALIZED_COMMAND=$(printf '%s' "$COMMAND" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
+
+GIT_PREFIX='(^|[;&|[:space:]])git([[:space:]]+(-C|-c|--git-dir|--work-tree)[[:space:]]+[^[:space:]]+|[[:space:]]+-[A-Za-z][^[:space:]]*)*'
 
 DANGEROUS_PATTERNS=(
-  "git push"
-  "git reset --hard"
-  "git clean -fd"
-  "git clean -f"
-  "git branch -D"
-  "git checkout \."
-  "git restore \."
-  "push --force"
-  "reset --hard"
+  "$GIT_PREFIX[[:space:]]+push([[:space:]]|$)"
+  "$GIT_PREFIX[[:space:]]+reset([^;&|]*)[[:space:]]+--hard([[:space:]]|$)"
+  "$GIT_PREFIX[[:space:]]+clean([^;&|]*)(-[^[:space:]]*f|--force)([^;&|]*)"
+  "$GIT_PREFIX[[:space:]]+branch([^;&|]*)[[:space:]]+-D([[:space:]]|$)"
+  "$GIT_PREFIX[[:space:]]+(checkout|restore)([^;&|]*)[[:space:]]+--?[[:space:]]+\\.([[:space:]]|$)"
+  "$GIT_PREFIX[[:space:]]+(checkout|restore)([^;&|]*)[[:space:]]+\\.([[:space:]]|$)"
+  '(^|[;&|[:space:]])git([^;&|]*)[[:space:]]+push([^;&|]*)--force([[:space:]]|$)'
 )
 
 for pattern in "${DANGEROUS_PATTERNS[@]}"; do
-  if echo "$COMMAND" | grep -qE "$pattern"; then
-    echo "BLOCKED: '$COMMAND' matches dangerous pattern '$pattern'. The user has prevented you from doing this." >&2
+  if printf '%s\n' "$NORMALIZED_COMMAND" | grep -qE "$pattern"; then
+    echo "BLOCKED: '$COMMAND' matches dangerous git pattern. The user has prevented you from doing this." >&2
     exit 2
   fi
 done

--- a/.agents/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/.agents/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -10,7 +10,7 @@
 ## Language
 
 **Order**:
-{A concise description of the term}
+{A one or two sentence description of the term}
 _Avoid_: Purchase, transaction
 
 **Invoice**:
@@ -20,31 +20,14 @@ _Avoid_: Bill, payment request
 **Customer**:
 A person or organization that places orders.
 _Avoid_: Client, buyer, account
-
-## Relationships
-
-- An **Order** produces one or more **Invoices**
-- An **Invoice** belongs to exactly one **Customer**
-
-## Example dialogue
-
-> **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
-> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed."
-
-## Flagged ambiguities
-
-- "account" was used to mean both **Customer** and **User** — resolved: these are distinct concepts.
 ```
 
 ## Rules
 
-- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
-- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
-- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
-- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
 - **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
 - **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
-- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
 
 ## Single vs multi-context repos
 

--- a/.agents/skills/grill-with-docs/SKILL.md
+++ b/.agents/skills/grill-with-docs/SKILL.md
@@ -73,7 +73,7 @@ When the user states how something works, check whether the code agrees. If you 
 
 When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
 
-Don't couple `CONTEXT.md` to implementation details. Only include terms that are meaningful to domain experts.
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
 
 ### Offer ADRs sparingly
 

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: "What will the next session be used for?"
+---
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save to the temporary directory of the user's OS - not the current workspace.
+
+Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+Redact any sensitive information, such as API keys, passwords, or personally identifiable information.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.

--- a/.agents/skills/improve-codebase-architecture/HTML-REPORT.md
+++ b/.agents/skills/improve-codebase-architecture/HTML-REPORT.md
@@ -1,0 +1,123 @@
+# HTML Report Format
+
+The architectural review is rendered as a single self-contained HTML file in the OS temp directory. Tailwind and Mermaid both come from CDNs. Mermaid handles graph-shaped diagrams reliably; hand-built divs and inline SVG handle the more editorial visuals (mass diagrams, cross-sections). Mix the two — don't lean on Mermaid for everything, it'll start to look generic.
+
+## Scaffold
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Architecture review — {{repo name}}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      /* small custom layer for things Tailwind doesn't cover cleanly:
+         dashed seam lines, hand-drawn-feeling arrow heads, etc. */
+      .seam { stroke-dasharray: 4 4; }
+      .leak { stroke: #dc2626; }
+      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="max-w-5xl mx-auto px-6 py-12 space-y-12">
+      <header>...</header>
+      <section id="candidates" class="space-y-10">...</section>
+      <section id="top-recommendation">...</section>
+    </main>
+  </body>
+</html>
+```
+
+## Header
+
+Repo name, date, and a compact legend: solid box = module, dashed line = seam, red arrow = leakage, thick dark box = deep module. No introduction paragraph — straight into the candidates.
+
+## Candidate card
+
+The diagrams carry the weight. Prose is sparse, plain, and uses the glossary terms ([LANGUAGE.md](LANGUAGE.md)) without ceremony.
+
+Each candidate is one `<article>`:
+
+- **Title** — short, names the deepening (e.g. "Collapse the Order intake pipeline").
+- **Badge row** — recommendation strength (`Strong` = emerald, `Worth exploring` = amber, `Speculative` = slate), plus a tag for the dependency category (`in-process`, `local-substitutable`, `ports & adapters`, `mock`).
+- **Files** — monospaced list, `font-mono text-sm`.
+- **Before / After diagram** — the centrepiece. Two columns, side by side. See patterns below.
+- **Problem** — one sentence. What hurts.
+- **Solution** — one sentence. What changes.
+- **Wins** — bullets, ≤6 words each. e.g. "Tests hit one interface", "Pricing logic stops leaking", "Delete 4 shallow wrappers".
+- **ADR callout** (if applicable) — one line in an amber-tinted box.
+
+No paragraphs of explanation. If the diagram needs a paragraph to be understood, redraw the diagram.
+
+## Diagram patterns
+
+Pick the pattern that fits the candidate. Mix them. Don't make every diagram look the same — variety is part of the point.
+
+### Mermaid graph (the workhorse for dependencies / call flow)
+
+Use a Mermaid `flowchart` or `graph` when the point is "X calls Y calls Z, and look at the mess." Wrap it in a Tailwind-styled card so it doesn't feel parachuted in. Style with classDef to colour leakage edges red and the deep module dark. Sequence diagrams work well for "before: 6 round-trips; after: 1."
+
+```html
+<div class="rounded-lg border border-slate-200 bg-white p-4">
+  <pre class="mermaid">
+    flowchart LR
+      A[OrderHandler] --> B[OrderValidator]
+      B --> C[OrderRepo]
+      C -.leak.-> D[PricingClient]
+      classDef leak stroke:#dc2626,stroke-width:2px;
+      class C,D leak
+  </pre>
+</div>
+```
+
+### Hand-built boxes-and-arrows (when Mermaid's layout fights you)
+
+Modules as `<div>`s with borders and labels. Arrows as inline SVG `<line>` or `<path>` elements positioned absolutely over a relative container. Reach for this when you want the "after" diagram to feel like one thick-bordered deep module with greyed-out internals — Mermaid won't render that with the right weight.
+
+### Cross-section (good for layered shallowness)
+
+Stack horizontal bands (`h-12 border-l-4`) to show layers a call passes through. Before: 6 thin layers each doing nothing. After: 1 thick band labelled with the consolidated responsibility.
+
+### Mass diagram (good for "interface as wide as implementation")
+
+Two rectangles per module — one for interface surface area, one for implementation. Before: interface rectangle is nearly as tall as the implementation rectangle (shallow). After: interface rectangle is short, implementation rectangle is tall (deep).
+
+### Call-graph collapse
+
+Before: a tree of function calls rendered as nested boxes. After: the same tree collapsed into one box, with the now-internal calls shown faded inside it.
+
+## Style guidance
+
+- Lean editorial, not corporate-dashboard. Generous whitespace. Serif optional for headings (`font-serif` works well with stone/slate).
+- Colour sparingly: one accent (emerald or indigo) plus red for leakage and amber for warnings.
+- Keep diagrams ~320px tall so before/after sits comfortably side by side without scrolling.
+- Use `text-xs uppercase tracking-wider` for module labels inside diagrams — they should read as schematic, not as UI.
+- The only scripts are the Tailwind CDN and the Mermaid ESM import. The report is otherwise static — no app code, no interactivity beyond Mermaid's own rendering.
+
+## Top recommendation section
+
+One larger card. Candidate name, one sentence on why, anchor link to its card. That's it.
+
+## Tone
+
+Plain English, concise — but the architectural nouns and verbs come straight from [LANGUAGE.md](LANGUAGE.md). Concision is not an excuse to drift.
+
+**Use exactly:** module, interface, implementation, depth, deep, shallow, seam, adapter, leverage, locality.
+
+**Never substitute:** component, service, unit (for module) · API, signature (for interface) · boundary (for seam) · layer, wrapper (for module, when you mean module).
+
+**Phrasings that fit the style:**
+
+- "Order intake module is shallow — interface nearly matches the implementation."
+- "Pricing leaks across the seam."
+- "Deepen: one interface, one place to test."
+- "Two adapters justify the seam: HTTP in prod, in-memory in tests."
+
+**Wins bullets** name the gain in glossary terms: *"locality: bugs concentrate in one module"*, *"leverage: one interface, N call sites"*, *"interface shrinks; implementation absorbs the wrappers"*. Don't write *"easier to maintain"* or *"cleaner code"* — those terms aren't in the glossary and don't earn their place.
+
+No hedging, no throat-clearing, no "it's worth noting that…". If a sentence could be a bullet, make it a bullet. If a bullet could be cut, cut it. If a term isn't in [LANGUAGE.md](LANGUAGE.md), reach for one that is before inventing a new one.

--- a/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -44,20 +44,30 @@ Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't
 
 Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
 
-### 2. Present candidates
+### 2. Present candidates as an HTML report
 
-Present a numbered list of deepening opportunities. For each candidate:
+Write a self-contained HTML file to the OS temp directory so nothing lands in the repo. Resolve the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows), and write to `<tmpdir>/architecture-review-<timestamp>.html` so each run gets a fresh file. Open it for the user — `xdg-open <path>` on Linux, `open <path>` on macOS, `start <path>` on Windows — and tell them the absolute path.
+
+The report uses **Tailwind via CDN** for layout and styling, and **Mermaid via CDN** for diagrams where a graph/flow/sequence reliably communicates the structure. Mix Mermaid with hand-crafted CSS/SVG visuals — use Mermaid when relationships are graph-shaped (call graphs, dependencies, sequences), and hand-built divs/SVG when you want something more editorial (mass diagrams, cross-sections, collapse animations). Each candidate gets a **before/after visualisation**. Be visual.
+
+For each candidate, the same template as before, but rendered as a card:
 
 - **Files** — which files/modules are involved
 - **Problem** — why the current architecture is causing friction
 - **Solution** — plain English description of what would change
-- **Benefits** — explained in terms of locality and leverage, and also in how tests would improve
+- **Benefits** — explained in terms of locality and leverage, and how tests would improve
+- **Before / After diagram** — side-by-side, custom-drawn, illustrating the shallowness and the deepening
+- **Recommendation strength** — one of `Strong`, `Worth exploring`, `Speculative`, rendered as a badge
+
+End the report with a **Top recommendation** section: which candidate you'd tackle first and why.
 
 **Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
 
-**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly (e.g. _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly in the card (e.g. a warning callout: _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
 
-Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
+See [HTML-REPORT.md](HTML-REPORT.md) for the full HTML scaffold, diagram patterns, and styling guidance.
+
+Do NOT propose interfaces yet. After the file is written, ask the user: "Which of these would you like to explore?"
 
 ### 3. Grilling loop
 

--- a/.agents/skills/prototype/LOGIC.md
+++ b/.agents/skills/prototype/LOGIC.md
@@ -1,0 +1,79 @@
+# Logic Prototype
+
+A tiny interactive terminal app that lets the user drive a state model by hand. Use this when the question is about **business logic, state transitions, or data shape** — the kind of thing that looks reasonable on paper but only feels wrong once you push it through real cases.
+
+## When this is the right shape
+
+- "I'm not sure if this state machine handles the edge case where X then Y."
+- "Does this data model actually let me represent the case where..."
+- "I want to feel out what the API should look like before writing it."
+- Anything where the user wants to **press buttons and watch state change**.
+
+If the question is "what should this look like" — wrong branch. Use [UI.md](UI.md).
+
+## Process
+
+### 1. State the question
+
+Before writing code, write down what state model and what question you're prototyping. One paragraph, in the prototype's README or a comment at the top of the file. A logic prototype that answers the wrong question is pure waste — make the question explicit so it can be checked later, whether the user is watching now or returning to it AFK.
+
+### 2. Pick the language
+
+Use whatever the host project uses. If the project has no obvious runtime (e.g. a docs repo), ask.
+
+Match the project's existing conventions for tooling — don't add a new package manager or runtime just for the prototype.
+
+### 3. Isolate the logic in a portable module
+
+Put the actual logic — the bit that's answering the question — behind a small, pure interface that could be lifted out and dropped into the real codebase later. The TUI around it is throwaway; the logic module shouldn't be.
+
+The right shape depends on the question:
+
+- **A pure reducer** — `(state, action) => state`. Good when actions are discrete events and state is a single value.
+- **A state machine** — explicit states and transitions. Good when "which actions are even legal right now" is part of the question.
+- **A small set of pure functions** over a plain data type. Good when there's no implicit current state — just transformations.
+- **A class or module with a clear method surface** when the logic genuinely owns ongoing internal state.
+
+Pick whichever shape best fits the question being asked, *not* whichever is easiest to wire to a TUI. Keep it pure: no I/O, no terminal code, no `console.log` for control flow. The TUI imports it and calls into it; nothing flows the other direction.
+
+This is what makes the prototype useful past its own lifetime. When the question's been answered, the validated reducer / machine / function set can be lifted into the real module — the TUI shell gets deleted.
+
+### 4. Build the smallest TUI that exposes the state
+
+Build it as a **lightweight TUI** — on every tick, clear the screen (`console.clear()` / `print("\033[2J\033[H")` / equivalent) and re-render the whole frame. The user should always see one stable view, not an ever-growing scrollback.
+
+Each frame has two parts, in this order:
+
+1. **Current state**, pretty-printed and diff-friendly (one field per line, or formatted JSON). Use **bold** for field names or section headers and **dim** for less important context (timestamps, IDs, derived values). Native ANSI escape codes are fine — `\x1b[1m` bold, `\x1b[2m` dim, `\x1b[0m` reset. No need to pull in a styling library unless one is already in the project.
+2. **Keyboard shortcuts**, listed at the bottom: `[a] add user  [d] delete user  [t] tick clock  [q] quit`. Bold the key, dim the description, or vice-versa — whatever reads cleanly.
+
+Behaviour:
+
+1. **Initialise state** — a single in-memory object/struct. Render the first frame on start.
+2. **Read one keystroke (or one line)** at a time, dispatch to a handler that mutates state.
+3. **Re-render** the full frame after every action — don't append, replace.
+4. **Loop until quit.**
+
+The whole frame should fit on one screen.
+
+### 5. Make it runnable in one command
+
+Add a script to the project's existing task runner (`package.json` scripts, `Makefile`, `justfile`, `pyproject.toml`). The user should run `pnpm run <prototype-name>` or equivalent — never need to remember a path.
+
+If the host project has no task runner, just put the command at the top of the prototype's README.
+
+### 6. Hand it over
+
+Give the user the run command. They'll drive it themselves; the interesting moments are when they say "wait, that shouldn't be possible" or "huh, I assumed X would be different" — those are the bugs in the _idea_, which is the whole point. If they want new actions added, add them. Prototypes evolve.
+
+### 7. Capture the answer
+
+When the prototype has done its job, the answer to the question is the only thing worth keeping. If the user is around, ask what it taught them. If not, leave a `NOTES.md` next to the prototype so the answer can be filled in (or filled in by you, if you've watched the session) before the prototype gets deleted.
+
+## Anti-patterns
+
+- **Don't add tests.** A prototype that needs tests is no longer a prototype.
+- **Don't wire it to the real database.** Use an in-memory store unless the question is specifically about persistence.
+- **Don't generalise.** No "what if we wanted to support X later." The prototype answers one question.
+- **Don't blur the logic and the TUI together.** If the reducer / state machine references `console.log`, prompts, or terminal escape codes, it's no longer portable. Keep the TUI as a thin shell over a pure module.
+- **Don't ship the TUI shell into production.** The shell is optimised for being driven by hand from a terminal. The logic module behind it is the bit worth keeping.

--- a/.agents/skills/prototype/SKILL.md
+++ b/.agents/skills/prototype/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: prototype
+description: Build a throwaway prototype to flesh out a design before committing to it. Routes between two branches — a runnable terminal app for state/business-logic questions, or several radically different UI variations toggleable from one route. Use when the user wants to prototype, sanity-check a data model or state machine, mock up a UI, explore design options, or says "prototype this", "let me play with it", "try a few designs".
+---
+
+# Prototype
+
+A prototype is **throwaway code that answers a question**. The question decides the shape.
+
+## Pick a branch
+
+Identify which question is being answered — from the user's prompt, the surrounding code, or by asking if the user is around:
+
+- **"Does this logic / state model feel right?"** → [LOGIC.md](LOGIC.md). Build a tiny interactive terminal app that pushes the state machine through cases that are hard to reason about on paper.
+- **"What should this look like?"** → [UI.md](UI.md). Generate several radically different UI variations on a single route, switchable via a URL search param and a floating bottom bar.
+
+The two branches produce very different artifacts — getting this wrong wastes the whole prototype. If the question is genuinely ambiguous and the user isn't reachable, default to whichever branch better matches the surrounding code (a backend module → logic; a page or component → UI) and state the assumption at the top of the prototype.
+
+## Rules that apply to both
+
+1. **Throwaway from day one, and clearly marked as such.** Locate the prototype code close to where it will actually be used (next to the module or page it's prototyping for) so context is obvious — but name it so a casual reader can see it's a prototype, not production. For throwaway UI routes, obey whatever routing convention the project already uses; don't invent a new top-level structure.
+2. **One command to run.** Whatever the project's existing task runner supports — `pnpm <name>`, `python <path>`, `bun <path>`, etc. The user must be able to start it without thinking.
+3. **No persistence by default.** State lives in memory. Persistence is the thing the prototype is _checking_, not something it should depend on. If the question explicitly involves a database, hit a scratch DB or a local file with a clear "PROTOTYPE — wipe me" name.
+4. **Skip the polish.** No tests, no error handling beyond what makes the prototype _runnable_, no abstractions. The point is to learn something fast and then delete it.
+5. **Surface the state.** After every action (logic) or on every variant switch (UI), print or render the full relevant state so the user can see what changed.
+6. **Delete or absorb when done.** When the prototype has answered its question, either delete it or fold the validated decision into the real code — don't leave it rotting in the repo.
+
+## When done
+
+The _answer_ is the only thing worth keeping from a prototype. Capture it somewhere durable (commit message, ADR, issue, or a `NOTES.md` next to the prototype) along with the question it was answering. If the user is around, that capture is a quick conversation; if not, leave the placeholder so they (or you, on the next pass) can fill in the verdict before deleting the prototype.

--- a/.agents/skills/prototype/UI.md
+++ b/.agents/skills/prototype/UI.md
@@ -1,0 +1,112 @@
+# UI Prototype
+
+Generate **several radically different UI variations** on a single route, switchable from a floating bottom bar. The user flips between variants in the browser, picks one (or steals bits from each), then throws the rest away.
+
+If the question is about logic/state rather than what something looks like — wrong branch. Use [LOGIC.md](LOGIC.md).
+
+## When this is the right shape
+
+- "What should this page look like?"
+- "I want to see a few options for this dashboard before committing."
+- "Try a different layout for the settings screen."
+- Any time the user would otherwise spend a day picking between three vague mockups in their head.
+
+## Two sub-shapes — strongly prefer sub-shape A
+
+A UI prototype is much easier to judge when it's **butting up against the rest of the app** — real header, real sidebar, real data, real density. A throwaway route on its own is a vacuum: every variant looks fine in isolation. Default to sub-shape A whenever there's a plausible existing page to host the variants. Only reach for sub-shape B if the prototype genuinely has no nearby home.
+
+### Sub-shape A — adjustment to an existing page (preferred)
+
+The route already exists. Variants are rendered **on the same route**, gated by a `?variant=` URL search param. The existing data fetching, params, and auth all stay — only the rendering swaps. This is the default; pick it unless there's a specific reason not to.
+
+If the prototype is for something that doesn't yet have a page but *would naturally live inside one* (a new section of the dashboard, a new card on the settings screen, a new step in an existing flow) — that's still sub-shape A. Mount the variants inside the host page.
+
+### Sub-shape B — a new page (last resort)
+
+Only use this when the thing being prototyped genuinely has no existing page to live inside — e.g. an entirely new top-level surface, or a flow that can't be embedded anywhere sensible.
+
+Create a **throwaway route** following whatever routing convention the project already uses — don't invent a new top-level structure. Name it so it's obviously a prototype (e.g. include the word `prototype` in the path or filename). Same `?variant=` pattern.
+
+Before committing to sub-shape B, sanity-check: is there really no existing page this could be embedded in? An empty route hides design problems that a populated one would expose.
+
+In both sub-shapes the floating bottom bar is identical.
+
+## Process
+
+### 1. State the question and pick N
+
+Default to **3 variants**. More than 5 stops being radically different and starts being noise — cap there.
+
+Write down the plan in one line, in the prototype's location or a top-of-file comment:
+
+> "Three variants of the settings page, switchable via `?variant=`, on the existing `/settings` route."
+
+This works whether the user is here to push back or not.
+
+### 2. Generate radically different variants
+
+Draft each variant. Hold each one to:
+
+- The page's purpose and the data it has access to.
+- The project's component library / styling system (TailwindCSS, shadcn, MUI, plain CSS, whatever).
+- A clear exported component name, e.g. `VariantA`, `VariantB`, `VariantC`.
+
+Variants must be **structurally different** — different layout, different information hierarchy, different primary affordance, not just different colours. Three slightly-tweaked card grids isn't a UI prototype, it's wallpaper. If two drafts come out too similar, redo one with explicit "do not use a card grid" guidance.
+
+### 3. Wire them together
+
+Create a single switcher component on the route:
+
+```tsx
+// pseudo-code — adapt to the project's framework
+const variant = searchParams.get('variant') ?? 'A';
+return (
+  <>
+    {variant === 'A' && <VariantA {...data} />}
+    {variant === 'B' && <VariantB {...data} />}
+    {variant === 'C' && <VariantC {...data} />}
+    <PrototypeSwitcher variants={['A','B','C']} current={variant} />
+  </>
+);
+```
+
+For sub-shape A (existing page): keep all the existing data fetching above the switcher; only the rendered subtree changes per variant.
+
+For sub-shape B (new page): the throwaway route under `/prototype/<name>` mounts the same switcher.
+
+### 4. Build the floating switcher
+
+A small fixed-position bar at the bottom-centre of the screen with three pieces:
+
+- **Left arrow** — cycles to the previous variant (wraps around).
+- **Variant label** — shows the current variant key and, if the variant exports a name, that name too. e.g. `B — Sidebar layout`.
+- **Right arrow** — cycles forward (wraps around).
+
+Behaviour:
+
+- Clicking an arrow updates the URL search param (use the framework's router — `router.replace` on Next, `navigate` on React Router, etc) so the variant is shareable and reload-stable.
+- Keyboard: `←` and `→` arrow keys also cycle. Don't intercept arrow keys when an `<input>`, `<textarea>`, or `[contenteditable]` is focused.
+- Visually distinct from the page (e.g. high-contrast pill, subtle shadow) so it's obviously not part of the design being evaluated.
+- Hidden in production builds — gate on `process.env.NODE_ENV !== 'production'` or an equivalent check, so a stray prototype merge can't ship the bar to users.
+
+Put the switcher in a single shared component so both sub-shapes can reuse it. Locate it wherever shared UI lives in the project.
+
+### 5. Hand it over
+
+Surface the URL (and the `?variant=` keys). The user will flip through whenever they get to it. The interesting feedback is usually **"I want the header from B with the sidebar from C"** — that's the actual design they want.
+
+### 6. Capture the answer and clean up
+
+Once a variant has won, write down which one and why (commit message, ADR, issue, or a `NOTES.md` next to the prototype if running AFK and the user hasn't responded yet). Then:
+
+- **Sub-shape A** — delete the losing variants and the switcher; fold the winner into the existing page.
+- **Sub-shape B** — promote the winning variant to a real route, delete the throwaway route and the switcher.
+
+Don't leave variant components or the switcher lying around. They rot fast and confuse the next reader.
+
+## Anti-patterns
+
+- **Variants that differ only in colour or copy.** That's a tweak, not a prototype. Real variants disagree about structure.
+- **Sharing too much code between variants.** A shared `<Header>` is fine; a shared `<Layout>` defeats the point. Each variant should be free to throw out the layout.
+- **Wiring variants to real mutations.** Read-only prototypes are fine. If a variant needs to mutate, point it at a stub — the question is "what should this look like", not "does the backend work".
+- **Promoting the prototype directly to production.** The variant code was written under prototype constraints (no tests, minimal error handling). Rewrite it properly when you fold it in.

--- a/.agents/skills/setup-matt-pocock-skills/issue-tracker-gitlab.md
+++ b/.agents/skills/setup-matt-pocock-skills/issue-tracker-gitlab.md
@@ -6,7 +6,7 @@ Issues and PRDs for this repo live as GitLab issues. Use the [`glab`](https://gi
 
 - **Create an issue**: `glab issue create --title "..." --description "..."`. Use a heredoc for multi-line descriptions. Pass `--description -` to open an editor.
 - **Read an issue**: `glab issue view <number> --comments`. Use `-F json` for machine-readable output.
-- **List issues**: `glab issue list --state opened -F json` with appropriate `--label` filters. Note that GitLab uses `opened` (not `open`) for the state value.
+- **List issues**: `glab issue list -F json` with appropriate `--label` filters.
 - **Comment on an issue**: `glab issue note <number> --message "..."`. GitLab calls comments "notes".
 - **Apply / remove labels**: `glab issue update <number> --label "..."` / `--unlabel "..."`. Multiple labels can be comma-separated or by repeating the flag.
 - **Close**: `glab issue close <number>`. `glab issue close` does not accept a closing comment, so post the explanation first with `glab issue note <number> --message "..."`, then close.

--- a/.agents/skills/setup-pre-commit/SKILL.md
+++ b/.agents/skills/setup-pre-commit/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: setup-pre-commit
+description: Set up Husky pre-commit hooks with lint-staged (Prettier), type checking, and tests in the current repo. Use when user wants to add pre-commit hooks, set up Husky, configure lint-staged, or add commit-time formatting/typechecking/testing.
+---
+
+# Setup Pre-Commit Hooks
+
+## What This Sets Up
+
+- **Husky** pre-commit hook
+- **lint-staged** running Prettier on all staged files
+- **Prettier** config (if missing)
+- **typecheck** and **test** scripts in the pre-commit hook
+
+## Steps
+
+### 1. Detect package manager
+
+Check for `package-lock.json` (npm), `pnpm-lock.yaml` (pnpm), `yarn.lock` (yarn), `bun.lockb` (bun). Use whichever is present. Default to npm if unclear.
+
+### 2. Install dependencies
+
+Install as devDependencies:
+
+```
+husky lint-staged prettier
+```
+
+### 3. Initialize Husky
+
+```bash
+npx husky init
+```
+
+This creates `.husky/` dir and adds `prepare: "husky"` to package.json.
+
+### 4. Create `.husky/pre-commit`
+
+Write this file (no shebang needed for Husky v9+):
+
+```
+npx lint-staged
+npm run typecheck
+npm run test
+```
+
+**Adapt**: Replace `npm` with detected package manager. If repo has no `typecheck` or `test` script in package.json, omit those lines and tell the user.
+
+### 5. Create `.lintstagedrc`
+
+```json
+{
+  "*": "prettier --ignore-unknown --write"
+}
+```
+
+### 6. Create `.prettierrc` (if missing)
+
+Only create if no Prettier config exists. Use these defaults:
+
+```json
+{
+  "useTabs": false,
+  "tabWidth": 2,
+  "printWidth": 80,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "semi": true,
+  "arrowParens": "always"
+}
+```
+
+### 7. Verify
+
+- [ ] `.husky/pre-commit` exists and is executable
+- [ ] `.lintstagedrc` exists
+- [ ] `prepare` script in package.json is `"husky"`
+- [ ] `prettier` config exists
+- [ ] Run `npx lint-staged` to verify it works
+
+### 8. Commit
+
+Stage all changed/created files and commit with message: `Add pre-commit hooks (husky + lint-staged + prettier)`
+
+This will run through the new pre-commit hooks — a good smoke test that everything works.
+
+## Notes
+
+- Husky v9+ doesn't need shebangs in hook files
+- `prettier --ignore-unknown` skips files Prettier can't parse (images, etc.)
+- The pre-commit runs lint-staged first (fast, staged-only), then full typecheck and tests

--- a/.agents/skills/thermo-nuclear-code-quality-review/SKILL.md
+++ b/.agents/skills/thermo-nuclear-code-quality-review/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: thermo-nuclear-code-quality-review
+description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for a thermo-nuclear code quality review, thermonuclear review, deep code quality audit, or especially harsh maintainability review.
+disable-model-invocation: true
+---
+
+# Thermo-Nuclear Code Quality Review
+
+Use this skill for an unusually strict review focused on implementation quality, maintainability, abstraction quality, and codebase health.
+
+Above all, this skill should push the reviewer to be **ambitious** about code structure. Do not merely identify local cleanup opportunities. Actively search for "code judo" moves: restructurings that preserve behavior while making the implementation dramatically simpler, smaller, more direct, and more elegant.
+
+## Core Prompt
+
+Start from this baseline:
+
+> Perform a deep code quality audit of the current branch's changes.
+> Rethink how to structure / implement the changes to meaningfully improve code quality without impacting behavior.
+> Work to improve abstractions, modularity, reduce Spaghetti code, improve succinctness and legibility.
+> Be ambitious, if there is a clear path to improving the implementation that involves restructuring some of the codebase, go for it.
+> Be extremely thorough and rigorous. Measure twice, cut once.
+
+## Non-Negotiable Additional Standards
+
+Apply the baseline prompt above, plus these explicit review rules:
+
+0. **Be ambitious about structural simplification.**
+   - Do not stop at "this could be a bit cleaner."
+   - Look for opportunities to reframe the change so that whole branches, helpers, modes, conditionals, or layers disappear entirely.
+   - Prefer the solution that makes the code feel inevitable in hindsight.
+   - Assume there is often a "code judo" move available: a re-organization that uses the existing architecture more effectively and makes the change dramatically simpler and more elegant.
+   - If you see a path to delete complexity rather than rearrange it, push hard for that path.
+
+1. **Do not let a PR push a file from under 1k lines to over 1k lines without a very strong reason.**
+   - Treat this as a strong code-quality smell by default.
+   - Prefer extracting helpers, subcomponents, modules, or local abstractions instead of letting a file sprawl past 1000 lines.
+   - If the diff crosses that threshold, explicitly ask whether the code should be decomposed first.
+   - Only waive this if there is a compelling structural reason and the resulting file is still clearly organized.
+
+2. **Do not allow random spaghetti growth in existing code.**
+   - Be highly suspicious of new ad-hoc conditionals, scattered special cases, or one-off branches inserted into unrelated flows.
+   - If a change adds "weird if statements in random places", treat that as a design problem, not a stylistic nit.
+   - Prefer pushing the logic into a dedicated abstraction, helper, state machine, policy object, or separate module instead of tangling an existing path.
+   - Call out changes that make the surrounding code harder to reason about, even if they technically work.
+
+3. **Bias toward cleaning the design, not just accepting working code.**
+   - If behavior can stay the same while the structure becomes meaningfully cleaner, push for the cleaner version.
+   - Do not rubber-stamp "it works" implementations that leave the codebase messier.
+   - Strongly prefer simplifications that remove moving pieces altogether over refactors that merely spread the same complexity around.
+
+4. **Prefer direct, boring, maintainable code over hacky or magical code.**
+   - Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem.
+   - Be skeptical of generic mechanisms that hide simple data-shape assumptions.
+   - Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+
+5. **Push hard on type and boundary cleanliness when they affect maintainability.**
+   - Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist.
+   - Prefer explicit typed models or shared contracts over loosely-shaped ad-hoc objects.
+   - If a branch relies on silent fallback to paper over an unclear invariant, ask whether the boundary should be made explicit instead.
+
+6. **Keep logic in the canonical layer and reuse existing helpers.**
+   - Call out feature logic leaking into shared paths or implementation details leaking through APIs.
+   - Prefer existing canonical utilities/helpers over bespoke one-offs.
+   - Push code toward the right package, service, or module instead of normalizing architectural drift.
+
+7. **Treat unnecessary sequential orchestration and non-atomic updates as design smells when the cleaner structure is obvious.**
+   - If independent work is serialized for no good reason, ask whether the flow should run in parallel instead.
+   - If related updates can leave state half-applied, push for a more atomic structure.
+   - Do not over-index on micro-optimizations, but do flag avoidable orchestration complexity that makes the implementation more brittle.
+
+## Primary Review Questions
+
+For every meaningful change, ask:
+
+- Is there a "code judo" move that would make this dramatically simpler?
+- Can this change be reframed so fewer concepts, branches, or helper layers are needed?
+- Does this improve or worsen the local architecture?
+- Did the diff add branching complexity where a better abstraction should exist?
+- Did a previously cohesive module become more coupled, more stateful, or harder to scan?
+- Is this logic living in the right file and layer?
+- Did this change enlarge a file or component past a healthy size boundary?
+- Are there repeated conditionals that signal a missing model or missing helper?
+- Is the implementation direct and legible, or does it rely on special cases and incidental control flow?
+- Is this abstraction actually earning its keep, or is it just a wrapper?
+- Did the diff introduce casts, optionality, or ad-hoc object shapes that obscure the real invariant?
+- Is this logic living in the canonical layer, or did the diff leak details across a boundary?
+- Is this orchestration more sequential or less atomic than it needs to be?
+
+## What to Flag Aggressively
+
+Escalate findings when you see:
+
+- A complicated implementation where a cleaner reframing could delete whole categories of complexity.
+- Refactors that move code around but fail to reduce the number of concepts a reader must hold in their head.
+- A file crossing 1000 lines due to the PR, especially if the new code could be split out.
+- New conditionals bolted onto unrelated code paths.
+- One-off booleans, nullable modes, or flags that complicate existing control flow.
+- Feature-specific logic leaking into general-purpose modules.
+- Generic "magic" handling that hides simple structure and makes the code harder to reason about.
+- Thin wrappers or identity abstractions that add indirection without simplifying anything.
+- Unnecessary casts, `any`, `unknown`, or optional params that muddy the real contract.
+- Copy-pasted logic instead of extracted helpers.
+- Narrow edge-case handling implemented in the middle of an already busy function.
+- Refactors that technically pass tests but make the code less modular or less readable.
+- "Temporary" branching that is likely to become permanent debt.
+- Bespoke helpers where the codebase already has a canonical utility for the job.
+- Logic added in the wrong layer/package when it should live somewhere more central.
+- Sequential async flow where obviously independent work could stay simpler and clearer with parallel execution.
+- Partial-update logic that leaves state less atomic than necessary.
+
+## Preferred Remedies
+
+When you identify a code-quality problem, prefer suggestions like:
+
+- Delete a whole layer of indirection rather than polishing it.
+- Reframe the state model so conditionals disappear instead of getting centralized.
+- Change the ownership boundary so the feature becomes a natural extension of an existing abstraction.
+- Turn special-case logic into a simpler default flow with fewer exceptions.
+- Extract a helper or pure function.
+- Split a large file into smaller focused modules.
+- Move feature-specific logic behind a dedicated abstraction.
+- Replace condition chains with a typed model or explicit dispatcher.
+- Separate orchestration from business logic.
+- Collapse duplicate branches into a single clearer flow.
+- Delete wrappers that do not meaningfully clarify the API.
+- Reuse the existing canonical helper instead of introducing a near-duplicate.
+- Make type boundaries more explicit so the control flow gets simpler.
+- Move the logic to the package/module/layer that already owns the concept.
+- Parallelize independent work when that also simplifies the orchestration.
+- Restructure related updates into a more atomic flow when partial state would be harder to reason about.
+
+Do not be satisfied with "maybe rename this" feedback when the real issue is structural.
+Do not be satisfied with a merely cleaner version of the same messy idea if there is a plausible path to a much simpler idea.
+
+## Review Tone
+
+Be direct, serious, and demanding about quality.
+Do not be rude, but do not soften major maintainability issues into mild suggestions.
+If the code is making the codebase messier, say so clearly.
+If the implementation missed an opportunity for a dramatic simplification, say that clearly too.
+
+Good phrases:
+
+- `this pushes the file past 1k lines. can we decompose this first?`
+- `this adds another special-case branch into an already busy flow. can we move this behind its own abstraction?`
+- `this works, but it makes the surrounding code more spaghetti. let's keep the behavior and restructure the implementation.`
+- `this feels like feature logic leaking into a shared path. can we isolate it?`
+- `this abstraction seems unnecessary. can we just keep the direct flow?`
+- `why does this need a cast / optional here? can we make the boundary more explicit instead?`
+- `this looks like a bespoke helper for something we already have elsewhere. can we reuse the canonical one?`
+- `i think there's a code-judo move here that makes this much simpler. can we reframe this so these branches disappear?`
+- `this refactor moves complexity around, but doesn't really delete it. is there a way to make the model itself simpler?`
+
+## Output Expectations
+
+Prioritize findings in this order:
+
+1. Structural code-quality regressions
+2. Missed opportunities for dramatic simplification / code-judo restructuring
+3. Spaghetti / branching complexity increases
+4. Boundary / abstraction / type-contract problems that make the code harder to reason about
+5. File-size and decomposition concerns
+6. Modularity and abstraction issues
+7. Legibility and maintainability concerns
+
+Do not flood the review with low-value nits if there are larger structural issues.
+Prefer a smaller number of high-conviction comments over a long list of cosmetic notes.
+
+## Approval Bar
+
+Do not approve merely because behavior seems correct.
+The bar for approval is:
+
+- no clear structural regression
+- no obvious missed opportunity to make the implementation dramatically simpler when such a path is visible
+- no unjustified file-size explosion
+- no obvious spaghetti-growth from special-case branching
+- no obviously hacky or magical abstraction that makes the code harder to reason about
+- no unnecessary wrapper/cast/optionality churn obscuring the real design
+- no clear architecture-boundary leak or avoidable canonical-helper duplication
+- no missed opportunity for an obvious decomposition that would materially improve maintainability
+
+Treat these as presumptive blockers unless the author can justify them clearly:
+
+- the PR preserves a lot of incidental complexity when there is a plausible code-judo move that would delete it
+- the PR pushes a file from below 1000 lines to above 1000 lines
+- the PR adds ad-hoc branching that makes an existing flow more tangled
+- the PR solves a local problem by scattering feature checks across shared code
+- the PR adds an unnecessary abstraction, wrapper, or cast-heavy contract that makes the design more indirect
+- the PR duplicates an existing helper or puts logic in the wrong layer when there is a clear canonical home
+
+If those conditions are not met, leave explicit, actionable feedback and push for a cleaner decomposition.

--- a/.agents/skills/to-issues/SKILL.md
+++ b/.agents/skills/to-issues/SKILL.md
@@ -51,7 +51,7 @@ Iterate until the user approves the breakdown.
 
 ### 5. Publish the issues to the issue tracker
 
-For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. Apply the `needs-triage` triage label so each issue enters the normal triage flow.
+For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. These issues are considered ready for AFK agents, so publish them with the correct triage label unless instructed otherwise.
 
 Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
 
@@ -63,6 +63,8 @@ A reference to the parent issue on the issue tracker (if the source was an exist
 ## What to build
 
 A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation.
+
+Avoid specific file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it here and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
 
 ## Acceptance criteria
 

--- a/.agents/skills/to-issues/SKILL.md
+++ b/.agents/skills/to-issues/SKILL.md
@@ -51,7 +51,9 @@ Iterate until the user approves the breakdown.
 
 ### 5. Publish the issues to the issue tracker
 
-For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. These issues are considered ready for AFK agents, so publish them with the correct triage label unless instructed otherwise.
+For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. Apply the `needs-triage` triage label by default so each issue enters the normal triage flow.
+
+Only apply `ready-for-agent` during publishing when the user explicitly asks for that state and the issue body already includes the equivalent of the triage agent brief: clear source context, implementation scope, constraints, acceptance checks, and any required HITL/AFK readiness decision.
 
 Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
 

--- a/.agents/skills/to-prd/SKILL.md
+++ b/.agents/skills/to-prd/SKILL.md
@@ -17,7 +17,7 @@ A deep module (as opposed to a shallow module) is one which encapsulates a lot o
 
 Check with the user that these modules match their expectations. Check with the user which modules they want tests written for.
 
-3. Write the PRD using the template below, then publish it to the project issue tracker. Apply the `needs-triage` triage label so it enters the normal triage flow.
+3. Write the PRD using the template below, then publish it to the project issue tracker. Apply the `ready-for-agent` triage label - no need for additional triage.
 
 <prd-template>
 
@@ -54,6 +54,8 @@ A list of implementation decisions that were made. This can include:
 - Specific interactions
 
 Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+
+Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it within the relevant decision and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
 
 ## Testing Decisions
 

--- a/.agents/skills/to-prd/SKILL.md
+++ b/.agents/skills/to-prd/SKILL.md
@@ -17,7 +17,7 @@ A deep module (as opposed to a shallow module) is one which encapsulates a lot o
 
 Check with the user that these modules match their expectations. Check with the user which modules they want tests written for.
 
-3. Write the PRD using the template below, then publish it to the project issue tracker. Apply the `ready-for-agent` triage label - no need for additional triage.
+3. Write the PRD using the template below, then publish it to the project issue tracker. Apply the `needs-triage` triage label so it enters the normal triage flow.
 
 <prd-template>
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -151,6 +151,19 @@ provisional lines or prompts, clear intent, and the route or world-state outcome
 it supports.
 _Avoid_: final polish pass, generic placeholder text, deep branching tree, final proper names too early
 
+**Prompt/Dialogue ID**:
+A stable area-scoped label for a prompt, line, bark, or interaction beat before
+the final text is locked. The ID lets docs, implementation issues, runtime data,
+and tests point at the same beat while wording can still change.
+_Avoid_: final line text, final character name, throwaway TODO label, implementation-only magic string
+
+**Paper-Level Acceptance Check**:
+A pre-implementation acceptance check phrased as a player-visible outcome or
+documented slice requirement. It confirms that an area doc is ready to become an
+implementation issue, but it does not claim runtime proof, screenshots, tests,
+or playability evidence yet.
+_Avoid_: runtime test result, playtest evidence, implementation done state, vague design wish
+
 **Minimum Route Cast**:
 The smallest set of visible characters needed for the First Playable Route to
 feel alive, readable, and emotionally staged without requiring optional
@@ -294,6 +307,13 @@ without fixing pixel positions, collision geometry, parallax distances, or final
 prop placement.
 _Avoid_: exact coordinates, collision map, final prop placement, production layout pass
 
+**Stage-Order Sketch**:
+A tiny non-coordinate ASCII sketch inside an area doc that summarizes Rough
+Stage Composition for first-read planning, such as entry -> Cicka/prop ->
+blocker/resident -> changed route -> exit. It is a schematic beat order, not a
+map.
+_Avoid_: minimap, tile layout, pixel layout, final camera plan
+
 **Bridge Tracer Slice**:
 The first implementation slice after the Area Paper Pass: Bridge blocker,
 Bridge Draftsperson, Cicka toy-car play, visible bridge change, and the
@@ -302,6 +322,15 @@ data shape, camera framing, Cicka placement, transition handling, and Coherent
 Sketchbook Blockout conventions before Concert, Dance Festival, and Relay work
 fan out.
 _Avoid_: parallelizing all areas first, full Bridge polish, isolated tech spike, final art pass
+
+**Bridge Tracer Slice Done**:
+The acceptance bar for the first implementation slice: the player can start
+Bridge, encounter Cicka with the toy car, talk to the Bridge Draftsperson, use
+Cicka Parallel Play, run the toy-car bridge test, see the crossing visibly
+change, and trigger the Bridge-to-Concert transition. The slice also proves
+shared route state, Prompt/Dialogue ID lookup, camera framing, Cicka placement,
+one Compact Area Transition, and basic playability evidence.
+_Avoid_: visual-only mock, isolated dialogue demo, Bridge polish pass, unverified handoff
 
 **First Playable Audio Floor**:
 The smallest audio palette needed to test route mood, timing, and emotional

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -256,6 +256,20 @@ received, and whether the Relay ending sequence is running. Progress should be
 felt through changed world state rather than visible quest UI.
 _Avoid_: quest log, proof inventory, optional-area readiness score, complex save model, visible checklist
 
+**Minimal Route Guidance**:
+The First Playable Route's guidance style: readable staging, visible blockers,
+NPC barks, Cicka placement, camera framing, changed world state, and contextual
+prompts, with only a tiny current-area prompt on first entry if playtests prove
+it is needed.
+_Avoid_: quest log, checklist, minimap, objective tracker, "go talk to X" UI, repeated hint popup
+
+**Agent-Ready Slice Contract**:
+The minimum specification needed before assigning a Ridge implementation slice
+to an AFK agent: area, local beat state, prompt/dialogue IDs, visible blocker,
+world-change result, Cicka before/after placement, exit condition, linked source
+docs, and acceptance checks.
+_Avoid_: vague area build request, taste-sensitive unresolved premise, broad "make this level" task, hidden dependency on undocumented canon
+
 **Authored Traversal Interaction**:
 A local route action that moves the player through a designed object or route
 change instead of requiring freeform jump execution.
@@ -580,6 +594,13 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   and whether the Relay ending sequence is running. Do not add a visible quest
   log, proof inventory, optional-area readiness score, or complex save model for
   the First Playable Route.
+- Use **Minimal Route Guidance** for the First Playable Route. The route should
+  be readable through staging and prompts, not a quest log, checklist, minimap,
+  objective tracker, or "go talk to X" UI.
+- An implementation issue should satisfy the **Agent-Ready Slice Contract**
+  before it is assigned to an AFK agent. Slice boundaries should name the
+  relevant area, beat state, prompts, world change, Cicka placement, exit
+  condition, source docs, and acceptance checks.
 - The first playable route should use **Compact Area Transitions** between
   separate compact maps, allowing different time of day, environment, and
   staging per area while distant Relay cues imply route progress.
@@ -843,6 +864,11 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   Threshold** somewhere the player cannot follow.
 - "hint" from Cicka means subtle attention guidance through staging or reaction,
   not explicit objective text like "go fix the bridge."
+- "objective UI" for the First Playable Route should mean **Minimal Route
+  Guidance**, not a visible quest tracker, minimap, checklist, or repeated hint
+  popup.
+- "ready for agent" for Ridge implementation means the issue satisfies the
+  **Agent-Ready Slice Contract**, not just that the area direction is accepted.
 - "last dance" previously meant an after-festival closure gate; resolved: use
   **Opening Dance Shuttle Beat** for the final dance-festival route beat.
 - "bachata" is loose discarded inspiration, not canonical genre; use a simple,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -158,10 +158,9 @@ and tests point at the same beat while wording can still change.
 _Avoid_: final line text, final character name, throwaway TODO label, implementation-only magic string
 
 **Paper-Level Acceptance Check**:
-A pre-implementation acceptance check phrased as a player-visible outcome or
-documented slice requirement. It confirms that an area doc is ready to become an
-implementation issue, but it does not claim runtime proof, screenshots, tests,
-or playability evidence yet.
+A pre-implementation readiness phrase for an area-doc outcome that has not yet
+been proven in runtime. The detailed checklist is owned by the Ridge milestone
+plan.
 _Avoid_: runtime test result, playtest evidence, implementation done state, vague design wish
 
 **Minimum Route Cast**:
@@ -271,32 +270,26 @@ rather than inventory systems.
 _Avoid_: inventory screen, freeform item combining, required rhythm/drawing/dance skill check, fail state
 
 **First Playable Route State**:
-The tiny linear progress model for the First Playable Route. It tracks current
-area, the current local beat state, whether the Concert Guitar has been
-received, and whether the Relay ending sequence is running. Progress should be
-felt through changed world state rather than visible quest UI.
+The tiny linear progress idea for the First Playable Route: enough state to move
+through the required areas without turning progress into a quest-log system.
+The concrete contract is owned by the Ridge milestone plan.
 _Avoid_: quest log, proof inventory, optional-area readiness score, complex save model, visible checklist
 
 **Minimal Route Guidance**:
-The First Playable Route's guidance style: readable staging, visible blockers,
-NPC barks, Cicka placement, camera framing, changed world state, and contextual
-prompts, with only a tiny current-area prompt on first entry if playtests prove
-it is needed.
+The First Playable Route's guidance style: readable staging and contextual
+prompts instead of explicit objective tracking.
 _Avoid_: quest log, checklist, minimap, objective tracker, "go talk to X" UI, repeated hint popup
 
 **Agent-Ready Slice Contract**:
-The minimum specification needed before assigning a Ridge implementation slice
-to an AFK agent: area, local beat state, prompt/dialogue IDs, visible blocker,
-world-change result, Cicka before/after placement, exit condition, linked source
-docs, and acceptance checks.
+The Ridge milestone-plan checklist for deciding whether an implementation slice
+is specific enough to hand to an AFK agent without asking that agent to resolve
+product taste.
 _Avoid_: vague area build request, taste-sensitive unresolved premise, broad "make this level" task, hidden dependency on undocumented canon
 
 **Area Paper Pass**:
-The pre-implementation documentation pass that makes each required Ridge Area
-ready to slice into agent work. It defines local beat states, blocker, Cicka
-before/after placement, prompt/dialogue IDs, transition or exit condition, rough
-stage composition, and acceptance checks without producing pixel maps, final
-scripts, final art specs, or complete dialogue trees.
+The pre-implementation documentation pass that gets required Ridge Areas ready
+to slice into agent work without producing final maps, scripts, art, or runtime
+proof.
 _Avoid_: final level spec, pixel map, implementation ticket, polished script, final art brief
 
 **Rough Stage Composition**:
@@ -315,28 +308,14 @@ map.
 _Avoid_: minimap, tile layout, pixel layout, final camera plan
 
 **Bridge Tracer Slice**:
-The first implementation slice after the Area Paper Pass: Bridge blocker,
-Bridge Draftsperson, Cicka toy-car play, visible bridge change, and the
-Bridge-to-Concert transition. It proves shared route state, prompts/dialogue
-data shape, camera framing, Cicka placement, transition handling, and Coherent
-Sketchbook Blockout conventions before Concert, Dance Festival, and Relay work
-fan out.
+The first implementation slice after the Area Paper Pass. It proves the Bridge
+route seam before Concert, Dance Festival, and Relay implementation fan out; the
+done checklist is owned by the Ridge milestone plan.
 _Avoid_: parallelizing all areas first, full Bridge polish, isolated tech spike, final art pass
 
-**Bridge Tracer Slice Done**:
-The acceptance bar for the first implementation slice: the player can start
-Bridge, encounter Cicka with the toy car, talk to the Bridge Draftsperson, use
-Cicka Parallel Play, run the toy-car bridge test, see the crossing visibly
-change, and trigger the Bridge-to-Concert transition. The slice also proves
-shared route state, Prompt/Dialogue ID lookup, camera framing, Cicka placement,
-one Compact Area Transition, and basic playability evidence.
-_Avoid_: visual-only mock, isolated dialogue demo, Bridge polish pass, unverified handoff
-
 **First Playable Audio Floor**:
-The smallest audio palette needed to test route mood, timing, and emotional
-handoffs: simple handmade-feeling ambience per area, one short guitar phrase for
-Concert and Relay, tiny Cicka meow/purr/chirp cues, soft transition stingers,
-and clear blocker/world-change cues.
+The smallest placeholder audio layer needed to test route mood, timing, and
+emotional handoffs before final songs, mix, or adaptive scoring exist.
 _Avoid_: full soundtrack, final polished mix, voiced dialogue, adaptive score engine, rhythm-game-quality track, full song system
 
 **Authored Traversal Interaction**:
@@ -627,293 +606,6 @@ A retired or provisional ending-gate term. The current first-ending route uses
 the fixed **Area Barricade Chain** instead of a separate proof resource,
 checklist, or optional readiness system.
 _Avoid_: boss gate, precision climb gate, arbitrary content checklist
-
-## Relationships
-
-- A **Topology Map** defines the route logic between **Room Beats**.
-- The **Typed Ridge Blockout Source** describes **Room Beats** in a validated source file.
-- The **Ridge Blockout Source** is written as **Typed Ridge Blockout Source**.
-- The **Ridge Blockout Source** produces a **Ridge Blockout** and a compiled
-  fact layer for routes, anchors, shortcuts, and Cicka Home mutations.
-- A **Ridge Blockout Editor** reads and writes the **Ridge Blockout Source**
-  through the same validation and compilation path used by runtime.
-- The **Ridge Tile Registry** maps **Authoring Symbols** in room grids to
-  explicit **Runtime Tile IDs**.
-- Danilo and AI level-design agents edit **Authoring Symbols**; runtime systems
-  consume compiled **Runtime Tile IDs**, geometry, and facts.
-- The **Ridge Source Contract** validates the **Ridge Blockout Source** before
-  runtime/editor code imports compiled Ridge blockout data.
-- A Ridge Blockout Source format migration may use a temporary dual path inside
-  one implementation PR for parity checks, but the project does not carry two
-  permanent Ridge source formats after validation passes.
-- A **Grid Cell** gives **Room Beats** their scale in the **Ridge Blockout**.
-- A **Ridge Blockout** is replaced or enriched by final assets after traversal feels good.
-- The current **Ridge Blockout** is the prototype **Exploration Map**.
-- The **Exploration Map** should read first as a **Sketchbook Neighborhood**,
-  with shortcut relief supporting that fantasy instead of required precision
-  platforming defining it.
-- The **Ridge Pre-Production Plan** is the current target for the desired game
-  rework; the existing Phaser Ridge is a legacy prototype/reference unless a
-  task explicitly targets current runtime behavior.
-- The **Sketchbook Neighborhood** should obey **Lived-In Causality** even when
-  its art direction is sketchbook-like: a route change can be whimsical in
-  presentation, but its blocker, helper, and resolution should feel practical
-  and locally motivated.
-- The **Exploration Map** uses **Exploration Traversal**.
-- The first-ending route currently uses an **Area Barricade Chain**: Bridge
-  Area clears into Concert Area, Concert Area clears into Dance Festival Area,
-  and Dance Festival clears into Relay Ending.
-- The **First Playable Route State** should stay tiny and linear: track current
-  area, local area beat state, whether the **Concert Guitar** has been received,
-  and whether the Relay ending sequence is running. Do not add a visible quest
-  log, proof inventory, optional-area readiness score, or complex save model for
-  the First Playable Route.
-- Use **Minimal Route Guidance** for the First Playable Route. The route should
-  be readable through staging and prompts, not a quest log, checklist, minimap,
-  objective tracker, or "go talk to X" UI.
-- An implementation issue should satisfy the **Agent-Ready Slice Contract**
-  before it is assigned to an AFK agent. Slice boundaries should name the
-  relevant area, beat state, prompts, world change, Cicka placement, exit
-  condition, source docs, and acceptance checks.
-- Use the **First Playable Audio Floor** for the initial route: placeholder
-  handmade ambience, one short guitar phrase shared by Concert and Relay, tiny
-  Cicka vocals, transition stingers, and blocker/world-change cues. Defer full
-  songs, voiced dialogue, adaptive scoring, polished mix, and rhythm-game audio
-  production until the route proves itself.
-- The first playable route should use **Compact Area Transitions** between
-  separate compact maps, allowing different time of day, environment, and
-  staging per area while distant Relay cues imply route progress.
-- A mini-game may use its own **Mini-Game Movement System** instead of
-  **Exploration Traversal**.
-- The first ending path should be completable through conversation, collection,
-  authored traversal, Ridge Areas, Resident Beats, and world changes without
-  requiring full arcade mini-games.
-- **Mini-Game Entrances** can provide optional rewards, shortcuts, alternate
-  path unlocks, or pure side fun, but they should not be required first-ending
-  proof for the current first ending. Future passes may let them unlock alternate
-  ways to finish a level.
-- **Exploration Traversal** treats jump as non-core for the v0 main path;
-  vertical movement should come from **Authored Traversal Interactions** unless
-  a future mobility item deliberately changes the route grammar.
-- **Cicka Home Mutations** are current proof-of-concept data for the old
-  hub-like blockout. The newer linear story route should prefer local
-  **Cicka Resting Spots** unless a future map deliberately restores a central
-  home space.
-- **Cicka Field Presence** complements **Cicka Resting Spots** by making Cicka
-  recur across the **Sketchbook Neighborhood** without turning her into a
-  follower, solver, vendor, or quest board.
-- **Toy Car Play** can introduce Cicka in Bridge Area, but it should lead into
-  recurring **Cicka Field Presence**, not continuous follower behavior.
-- **Cicka Parallel Play** retrieves the toy car by joining Cicka's play rather
-  than commanding her, taking the toy, or adding a food-fetch gate.
-- The first Bridge prototype should use an auto-success **Toy Car Bridge Test**;
-  **Bridge Drawing Toy**, toy-car ping-pong, and **Cicka Treat Shortcut** are
-  later optional layers after the route MVP is proven.
-- A **Resident Help Beat** may use **Cicka Field Presence** to draw attention to
-  a route blocker, but the solution should come from a resident, artifact,
-  mini-game clear, or visible environment change.
-- Required **Resident Help Beats** should include **Cicka Field Presence**, but
-  Cicka's role can shift from obvious attention cue to changed-object observer
-  to quiet trust marker.
-- Each required **Ridge Area** should have one local **Cicka Resting Spot**: a
-  **Bridge Resting Spot** near the crossing, **Concert Resting Spot** as a
-  listening corner, and **Dance Festival Resting Spot** near operations or the
-  service gate. These spots are local emotional anchors, not hubs.
-- A required **Resident Help Beat** usually belongs to one **Resident Beat**
-  inside a **Ridge Area**; that area can include multiple residents, interiors,
-  optional interactions, and alternate solutions without becoming one Phaser
-  scene.
-- **Resident Beats** can use **Recoverable Conversation Choices** to make
-  resident help feel authored and personal, but the main ending path should not
-  become permanently missable because of one dialogue choice.
-- A **Practical Wayfinding Loop** should introduce route blockers before
-  emotional stakes when a beat needs to feel lived-in and grounded.
-- A **Triangulated Discovery Flow** can reveal a resident relationship without
-  making the player or one NPC magically know private feelings.
-- A **Readiness Favor** can bridge the gap between knowing what a resident wants
-  and helping them act without making the player directly manage their feelings.
-- The **Cicka Threshold Farewell** resolves Cicka's recurring field guidance.
-  V0 uses the **First Playable Reset Return** after the **Dedication Card**:
-  reset directly to Bridge with fresh route progress. If an internal
-  ending-seen flag is useful, keep it invisible. Long-term post-game scope may
-  replace the clean reset with the **Open Ridge Return State**.
-- The **Cicka Threshold Farewell** departure should be physical and mostly
-  silent: Cicka moves toward the threshold alone, turns back toward the seated
-  player, gives one small raw meow, then slips into the **Warm Sketchbook
-  Threshold**. Do not rely on paw/page marks as a required symbol unless the
-  route has seeded that visual language first.
-- The long-term **Open Ridge Return State** should be replayable, quiet, and
-  minimally absence-marked only if that visual language has been seeded, with
-  Micka still delayed until the later post-ending trigger. It becomes valuable
-  once optional mini-games, return content, or completed-area revisits exist;
-  v0 should use the clean **First Playable Reset Return** instead.
-- The **Guitar Farewell** should be established before the ending through the
-  guitar's story role and visual Cicka Resting Spot presence. The initial route
-  does not need repeatable resting-spot interactions; sitting together, petting,
-  lap loafing, or playing guitar at local spots can wait for a later affection
-  pass.
-- The **Concert Guitar** is the same physical instrument used in the **Guitar
-  Farewell**, not an abstract music unlock or a different ending-only prop.
-- The only required guitar uses in the first-ending route are the Concert
-  performance and Relay **Sit and Play Prompt**; any guitar use at local
-  **Cicka Resting Spots** should be an **Optional Guitar Comfort Interaction**.
-- The **Guitar Farewell** can include a **Route Memory Montage**, but the montage
-  should stay brief and keep Cicka as the emotional focus; the player's guitar
-  is the only music the player needs to hear during the montage.
-- The **Sit and Play Prompt** starts the **Guitar Farewell** at Relay Spire
-  without turning it into a rhythm challenge, and it is the v0 final trigger.
-- Do not use **Send the Sketchbook Prompt** in v0 unless the sketchbook becomes
-  a seeded object or interaction across the route first.
-- The Relay ending should use sunset for **Sit and Play Prompt** and the
-  **Cicka Threshold Farewell**; the **Route Memory Montage** can show the night
-  festival beginning elsewhere.
-- The **Concert Crossing Beat** can teach the guitar through a small
-  Guitar-Hero-like mini-game, but the **Guitar Farewell** itself should remain a
-  cozy remembrance interaction rather than an arcade pass/fail challenge.
-- The **Opening Dance Shuttle Beat** keeps the dance festival as a night event,
-  but the required route action starts during daytime setup, progresses toward
-  late afternoon, and gets the player to Relay Spire for the sunset **Guitar
-  Farewell**.
-- The **Opening Dance Shuttle Beat** centers the hill-shuttle driver and the
-  **Last-Stop Operations Helper** as colleagues whose practical work and private
-  nervousness both delay the last daylight ride.
-- The hill-shuttle driver, **Last-Stop Operations Helper**, and **Dance Teacher**
-  should use **Role Names** until a later character naming pass;
-  their jobs and emotional functions matter more than proper names right now.
-- The **Minimum Route Cast** should prioritize the required route residents,
-  Cicka, a few readable barks or silhouettes where needed for area liveliness,
-  and no optional resident systems until the First Playable Route works.
-- The **Operations Handoff Check** is the Last-Stop Operations Helper's current
-  **Readiness Favor**; the **Dance Teacher** covers the operations watch after
-  setup is proven safe, keeping the cast small and letting the helper enjoy the
-  dance without implying someone else planned it better.
-- **One-Step Practice** is the hill-shuttle driver's current **Readiness Favor**;
-  it gives him one private, imperfect step rather than turning dance into a
-  public skill test.
-- The **Folded Song Request** connects the two Readiness Favors by letting the
-  driver ask through a subtle operations-table object instead of direct public
-  matchmaking; the song should be simple, cute, and guitar-friendly, not locked
-  to bachata or any other specific dance genre, and it can remain unshown and
-  unheard as a specific track.
-- The **Setup Clearance Walkthrough** restores the practical route blocker after
-  the romantic connector by making the service lane visibly ready for the last
-  daylight shuttle.
-- The **Setup Clearance Walkthrough** should present as a **Prompt-Driven
-  Playable Montage**, with three default symbolic snaps: secure the lantern
-  line, clear or tape the service-lane obstruction, and flip the shuttle sign to
-  "Last daylight ride." These can collapse further if implementation needs a
-  shorter transition, but they should not become full manual chores.
-- In the **Opening Dance Shuttle Beat**, **Cicka Field Presence** should read as
-  a quiet threshold observer near the operations table or service gate; the
-  **Unnamed Counterpart Cat** can add texture and imply future continuity, but
-  it should stay visual-only and should not be named or treated as Micka.
-- The ride from Last-Stop Plaza to Relay should be a **Short Threshold
-  Transition**, not a controllable driving scene; a driver line, vehicle-start
-  sound, brief blackout, and Relay spawn are enough.
-- Required **Resident Beats** that contain arcade-like interactions should
-  also have a non-arcade fallback through conversation, collection, practice, or
-  a forgiving auto-resolve path.
-- **Living Proof Gate** language should not imply a required proof resource in
-  the current first-ending route; use **Area Barricade Chain** for progression
-  and **Route Memory Montage** for the ending echo.
-- The old Overworld and Hobbies scenes are transitional surfaces. Long-term,
-  their best content should fold into the **Exploration Map** as artifacts,
-  entrances, Cicka reactions, Basement/Potassium paths, and mini-game props.
-
-## Example Dialogue
-
-> **Dev:** "Should we change the Stampede room art now?"
-> **Domain expert:** "No, first update the **Room Beat** in the **Typed Ridge Blockout Source** so the **Ridge Blockout** proves the shortcut back to Cicka."
-
-> **Dev:** "Should the player always return to Cicka Home after a blocked bridge?"
-> **Domain expert:** "No — in the linear story route, use a local **Cicka Resting Spot** and **Cicka Field Presence** at the bridge instead of requiring hub returns."
-
-> **Dev:** "Can Cicka tell the player to fix the bridge?"
-> **Domain expert:** "No — let **Cicka Field Presence** make the bridge feel suspicious, then resolve it as a **Resident Help Beat** with a visible route change."
-
-> **Dev:** "Does every resident need to solve a barricade?"
-> **Domain expert:** "No — required **Resident Help Beats** change routes, while optional residents can offer mini-games, atmosphere, jokes, or quiet company."
-
-> **Dev:** "Should each resident scene be a Phaser scene?"
-> **Domain expert:** "No — call the place a **Ridge Area** and the problem sequence a **Resident Beat**. Use **Phaser Scene** only for runtime implementation."
-
-> **Dev:** "Does Cicka leave with the player at the ending?"
-> **Domain expert:** "No — during the **Cicka Threshold Farewell**, the player remains seated while Cicka leaves through the **Warm Sketchbook Threshold** somewhere the player cannot follow."
-
-> **Dev:** "Should Cicka's final departure include translated text?"
-> **Domain expert:** "No translated line or written goodbye — Cicka gives one tiny raw meow, and the later **Dedication Card** stays non-diegetic."
-
-> **Dev:** "Should the ending rely on paw/page marks?"
-> **Domain expert:** "No — only use a final trace or absence echo as visual staging if the route has already taught that language. Do not make paw/page marks a surprise mechanic or required symbol in v0."
-
-> **Dev:** "Should the Cicka Resting Spot echo leave the guitar there?"
-> **Domain expert:** "No — the guitar stays with the player. Any echo should be a small absence cue at the usual spot, not an abandoned inventory object."
-
-> **Dev:** "Should each bridge/concert/dance area have a small Cicka resting spot?"
-> **Domain expert:** "Yes — give each required **Ridge Area** one local **Cicka Resting Spot**. It keeps Cicka present across a linear route without turning any area into a hub."
-
-> **Dev:** "What should we call the bridge/concert/dance festival chunks?"
-> **Domain expert:** "Use **Ridge Area** for the logical place and **Resident Beat** for the authored problem inside it; reserve **Phaser Scene** for runtime units."
-
-> **Dev:** "Can the final Cicka beat be the player playing guitar for her?"
-> **Domain expert:** "Yes — make it the **Guitar Farewell**, but establish guitar as a quiet comfort interaction before Relay so it carries memory instead of exposition."
-
-> **Dev:** "Can the Guitar Farewell show what happened to the residents?"
-> **Domain expert:** "Yes — use a brief **Route Memory Montage** of resident/world changes, not a full recap."
-
-> **Dev:** "Can the guitar come from a concert problem?"
-> **Domain expert:** "Yes — use the **Concert Crossing Beat** to earn the guitar through a tiny performance/help moment, then let local **Cicka Resting Spots** turn it into comfort."
-
-> **Dev:** "Does the dance festival happen at night?"
-> **Domain expert:** "Yes — but the required route beat is the **Opening Dance Shuttle Beat**, where daytime setup progresses toward one last daylight ride to Relay before the night festival begins."
-
-> **Dev:** "Is the driver's crush the DJ?"
-> **Domain expert:** "No — she is the **Last-Stop Operations Helper**, a visible plaza worker whose setup checklist and service-road handoff make her role immediately readable."
-
-> **Dev:** "How do we help the shy operations helper without therapizing her?"
-> **Domain expert:** "Use the **Operations Handoff Check**: prove the setup is ready and let the **Dance Teacher** keep watch so she can enjoy the night."
-
-> **Dev:** "Who covers the operations watch?"
-> **Domain expert:** "Use the **Dance Teacher**. They already belong in the beat as the gentle facilitator, so they can cover the watch without adding another resident role."
-
-> **Dev:** "Do the driver and Last-Stop Operations Helper need proper names now?"
-> **Domain expert:** "No — use **Role Names** for now. Names can wait until their jobs, movement, and emotional function survive a later character pass."
-
-> **Dev:** "How do we help the driver if he cannot dance?"
-> **Domain expert:** "Use **One-Step Practice**: he learns one tiny private step, enough to ask without pretending he is suddenly good."
-
-> **Dev:** "How does he actually ask her to dance?"
-> **Domain expert:** "Use the **Folded Song Request**: a small paper invitation at the operations table, not a public confession."
-
-> **Dev:** "Does the dance need to be bachata?"
-> **Domain expert:** "No — keep bachata as loose inspiration at most. Canon should use a simple, cute, guitar-friendly requested song so the driver can plausibly dance and the Guitar Farewell montage can carry the same feeling."
-
-> **Dev:** "Is the night festival literally hearing the same guitar song as the Relay farewell?"
-> **Domain expert:** "No — treat it as an emotional echo. The requested festival song stays implied/offscreen; the only song the player needs to hear is the guitar during the **Guitar Farewell**."
-
-> **Dev:** "How does the road physically open after the cute paper moment?"
-> **Domain expert:** "Use the **Setup Clearance Walkthrough** so visible setup details clear the service lane for the last daylight shuttle."
-
-> **Dev:** "Do we make the player manually move every chair?"
-> **Domain expert:** "No — present the **Setup Clearance Walkthrough** as a **Prompt-Driven Playable Montage** with a few authored interaction snaps."
-
-> **Dev:** "Which setup snaps should the montage use?"
-> **Domain expert:** "Use three symbolic one-action snaps by default: lantern line, service-lane obstruction, and shuttle sign. They are story-readable, practical, and easy to collapse if the beat needs to be shorter."
-
-> **Dev:** "Can Cicka hang out with another cat during the dance setup?"
-> **Domain expert:** "Yes — use the **Unnamed Counterpart Cat** for implied continuity, but do not spend Micka before the post-ending return."
-
-> **Dev:** "Should we design the other cat now?"
-> **Domain expert:** "Only at silhouette/color level: a pale or light-ink contrast to Cicka, with no name, dialogue, or parentage reveal."
-
-> **Dev:** "Do we play the shuttle ride?"
-> **Domain expert:** "No — use a **Short Threshold Transition**: driver line, vehicle-start sound, brief blackout, then control resumes at Relay."
-
-> **Dev:** "Does every obstacle need a mini-game?"
-> **Domain expert:** "No — the first ending path should work through residents, conversations, collection, and world changes; **Mini-Game Entrances** can add alternate paths or side fun."
-
-> **Dev:** "Should the Relay Spire require a boss or hard climb?"
-> **Domain expert:** "No — use the **Area Barricade Chain** so the player reaches Relay after clearing the Bridge, Concert, and Dance Festival barricades."
 
 ## Flagged Ambiguities
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -136,6 +136,19 @@ _Avoid_: required food fetch, first-route errand, replacing parallel play in v0
 The nervous or blocked resident responsible for the Blueprint Bridge plan.
 _Avoid_: wizard, quest board, generic artist-god, final proper name too early
 
+**Role Name**:
+A stable pre-production label for a resident, character, or animal before a
+final proper name is accepted. Role Names are safe for docs, dialogue IDs,
+implementation references, and issue writing until a focused naming/tone pass
+chooses final names.
+_Avoid_: throwaway final name, unstable nickname, hardcoded proper name too early
+
+**Minimum Route Cast**:
+The smallest set of visible characters needed for the First Playable Route to
+feel alive, readable, and emotionally staged without requiring optional
+residents, hangouts, or rich crowd writing.
+_Avoid_: full town cast, optional resident backlog, empty gray-box route, writing every background silhouette as required content
+
 **Bridge Drawing Toy**:
 A future optional upgrade where the player draws or customizes the bridge more
 directly, potentially with simple bridge-building physics.
@@ -228,6 +241,21 @@ walking and authored traversal interactions such as climb, descend, drop, lift,
 bridge, enter, inspect, and recovery helpers.
 _Avoid_: mini-game controls, one-off arcade movement, required jump platforming
 
+**First Playable Interaction Vocabulary**:
+The small shared verb set for the First Playable Route: move left/right,
+interact or talk, inspect, enter/exit an Area Interior Pocket when present,
+sit/play for Cicka or Relay guitar moments, and confirm contextual prompts.
+Object handoffs can exist, but they should be immediate authored interactions
+rather than inventory systems.
+_Avoid_: inventory screen, freeform item combining, required rhythm/drawing/dance skill check, fail state
+
+**First Playable Route State**:
+The tiny linear progress model for the First Playable Route. It tracks current
+area, the current local beat state, whether the Concert Guitar has been
+received, and whether the Relay ending sequence is running. Progress should be
+felt through changed world state rather than visible quest UI.
+_Avoid_: quest log, proof inventory, optional-area readiness score, complex save model, visible checklist
+
 **Authored Traversal Interaction**:
 A local route action that moves the player through a designed object or route
 change instead of requiring freeform jump execution.
@@ -291,7 +319,10 @@ _Avoid_: route gate, dialogue station, confirmed parentage scene
 An authored Cicka appearance inside the Exploration Map where she observes,
 loafs, points attention, or quietly reacts at a meaningful route beat through
 subtle posture, placement, and tiny reactions instead of explicit instructions.
-_Avoid_: companion AI, quest marker, follower pet, objective dispenser
+The route should stay readable through compact layout, NPC barks, camera
+framing, prop placement, and prompt availability rather than depending on Cicka
+as a hint system.
+_Avoid_: companion AI, quest marker, follower pet, objective dispenser, hint system
 
 **Cicka Threshold Farewell**:
 The first ending beat where Cicka leaves the seated player through a warm
@@ -421,12 +452,6 @@ step and covers the operations watch so the Last-Stop Operations Helper can
 enjoy the night dance.
 _Avoid_: romance target, competition judge, extra route gate, new protagonist
 
-**Role-First Character Labels**:
-Placeholder character labels that describe the resident's job in the beat before
-a later naming pass, such as hill-shuttle driver, Last-Stop Operations Helper,
-and Dance Teacher.
-_Avoid_: premature proper names, joke aliases, final character names before role clarity
-
 **Operations Handoff Check**:
 A Readiness Favor where the player helps the Last-Stop Operations Helper prove
 the plaza setup is safe enough for the Dance Teacher to watch while she enjoys
@@ -550,6 +575,11 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - The first-ending route currently uses an **Area Barricade Chain**: Bridge
   Area clears into Concert Area, Concert Area clears into Dance Festival Area,
   and Dance Festival clears into Relay Ending.
+- The **First Playable Route State** should stay tiny and linear: track current
+  area, local area beat state, whether the **Concert Guitar** has been received,
+  and whether the Relay ending sequence is running. Do not add a visible quest
+  log, proof inventory, optional-area readiness score, or complex save model for
+  the First Playable Route.
 - The first playable route should use **Compact Area Transitions** between
   separate compact maps, allowing different time of day, environment, and
   staging per area while distant Relay cues imply route progress.
@@ -647,8 +677,11 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   **Last-Stop Operations Helper** as colleagues whose practical work and private
   nervousness both delay the last daylight ride.
 - The hill-shuttle driver, **Last-Stop Operations Helper**, and **Dance Teacher**
-  should use **Role-First Character Labels** until a later character naming pass;
+  should use **Role Names** until a later character naming pass;
   their jobs and emotional functions matter more than proper names right now.
+- The **Minimum Route Cast** should prioritize the required route residents,
+  Cicka, a few readable barks or silhouettes where needed for area liveliness,
+  and no optional resident systems until the First Playable Route works.
 - The **Operations Handoff Check** is the Last-Stop Operations Helper's current
   **Readiness Favor**; the **Dance Teacher** covers the operations watch after
   setup is proven safe, keeping the cast small and letting the helper enjoy the
@@ -743,7 +776,7 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 > **Domain expert:** "Use the **Dance Teacher**. They already belong in the beat as the gentle facilitator, so they can cover the watch without adding another resident role."
 
 > **Dev:** "Do the driver and Last-Stop Operations Helper need proper names now?"
-> **Domain expert:** "No — use **Role-First Character Labels** for now. Names can wait until their jobs, movement, and emotional function survive a later character pass."
+> **Domain expert:** "No — use **Role Names** for now. Names can wait until their jobs, movement, and emotional function survive a later character pass."
 
 > **Dev:** "How do we help the driver if he cannot dance?"
 > **Domain expert:** "Use **One-Step Practice**: he learns one tiny private step, enough to ask without pretending he is suddenly good."
@@ -818,8 +851,8 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   player's guitar.
 - "festival helper" is too generic for the driver's colleague; resolved: use
   **Last-Stop Operations Helper**.
-- "name" or "alias" for Opening Dance residents should mean a **Role-First
-  Character Label** for now, not a final proper name.
+- "name" or "alias" for Opening Dance residents should mean a **Role Name** for
+  now, not a final proper name.
 - "Cicka Home" is a current proof-of-concept/runtime blockout term; the newer
   linear story route should say **Cicka Resting Spot** unless a central home
   space is deliberately restored.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,6 +84,20 @@ residents, props, Cicka Resting Spots, mini-game entrances, and one or more
 runtime Phaser Scenes.
 _Avoid_: hub, Phaser scene, single room, isolated mini-game silo
 
+**Compact Ridge Stage**:
+The First Playable Route topology target for each required Ridge Area: one
+small, readable stage/chapter with a local entry, blocker, resident beat, Cicka
+spot, visible world change, and exit composition. It can contain small depth
+pockets, but it should not become a sprawling mini-map.
+_Avoid_: sprawling area map, free-roam zone, multi-room maze
+
+**Area Interior Pocket**:
+A small enterable building, nook, facade interior, or side space that belongs to
+the current Ridge Area. It may use a Phaser scene change if useful, but it
+shares the same area progress and exists to add staged depth, richness, or
+local context rather than becoming a separate Ridge Area.
+_Avoid_: separate chapter, required dungeon, second mini-map
+
 **Bridge Area**:
 The first required Ridge Area. It contains the Blueprint Bridge Resident Beat
 and teaches that helping a resident can visibly change the route.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -186,6 +186,12 @@ where the player moves toward the Relay Spire by helping tiny residents and
 seeing routes change.
 _Avoid_: metroidvania platforming map, portfolio theme park, static building row
 
+**Walkable Sketchbook Stage**:
+The accepted Ridge presentation direction: a Harold Halibut-like or theater-set
+2.5D area presentation that preserves side-view interaction simplicity while
+composing each area like a hand-built paper set with shallow staged depth.
+_Avoid_: isometric RPG map, true 3D navigation, flat precision-platformer camera
+
 **Lived-In Causality**:
 A design rule for the Sketchbook Neighborhood: route blockers and world changes
 should have practical in-world causes, local context, and residents with

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -192,6 +192,14 @@ The accepted Ridge presentation direction: a Harold Halibut-like or theater-set
 composing each area like a hand-built paper set with shallow staged depth.
 _Avoid_: isometric RPG map, true 3D navigation, flat precision-platformer camera
 
+**Coherent Sketchbook Blockout**:
+The First Playable Route art target: rough and cheap enough to change, but
+already art-directed enough to test Sketchbook Ridge mood, readability, Cicka
+staging, blockers, resident silhouettes, before/after world changes, and the
+Walkable Sketchbook Stage presentation. It is not gray-box art and not final
+polish.
+_Avoid_: gray-box placeholder, final art pass, polished asset set
+
 **Lived-In Causality**:
 A design rule for the Sketchbook Neighborhood: route blockers and world changes
 should have practical in-world causes, local context, and residents with

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -286,6 +286,14 @@ stage composition, and acceptance checks without producing pixel maps, final
 scripts, final art specs, or complete dialogue trees.
 _Avoid_: final level spec, pixel map, implementation ticket, polished script, final art brief
 
+**Rough Stage Composition**:
+The P1-level spatial description for a Compact Ridge Stage. It names the
+left-to-right beat order, entry and exit sides, blocker location, Cicka spot,
+resident or prop zone, optional Area Interior Pocket, and camera framing intent
+without fixing pixel positions, collision geometry, parallax distances, or final
+prop placement.
+_Avoid_: exact coordinates, collision map, final prop placement, production layout pass
+
 **Bridge Tracer Slice**:
 The first implementation slice after the Area Paper Pass: Bridge blocker,
 Bridge Draftsperson, Cicka toy-car play, visible bridge change, and the

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -270,6 +270,13 @@ world-change result, Cicka before/after placement, exit condition, linked source
 docs, and acceptance checks.
 _Avoid_: vague area build request, taste-sensitive unresolved premise, broad "make this level" task, hidden dependency on undocumented canon
 
+**First Playable Audio Floor**:
+The smallest audio palette needed to test route mood, timing, and emotional
+handoffs: simple handmade-feeling ambience per area, one short guitar phrase for
+Concert and Relay, tiny Cicka meow/purr/chirp cues, soft transition stingers,
+and clear blocker/world-change cues.
+_Avoid_: full soundtrack, final polished mix, voiced dialogue, adaptive score engine, rhythm-game-quality track, full song system
+
 **Authored Traversal Interaction**:
 A local route action that moves the player through a designed object or route
 change instead of requiring freeform jump execution.
@@ -601,6 +608,11 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
   before it is assigned to an AFK agent. Slice boundaries should name the
   relevant area, beat state, prompts, world change, Cicka placement, exit
   condition, source docs, and acceptance checks.
+- Use the **First Playable Audio Floor** for the initial route: placeholder
+  handmade ambience, one short guitar phrase shared by Concert and Relay, tiny
+  Cicka vocals, transition stingers, and blocker/world-change cues. Defer full
+  songs, voiced dialogue, adaptive scoring, polished mix, and rhythm-game audio
+  production until the route proves itself.
 - The first playable route should use **Compact Area Transitions** between
   separate compact maps, allowing different time of day, environment, and
   staging per area while distant Relay cues imply route progress.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -143,6 +143,14 @@ implementation references, and issue writing until a focused naming/tone pass
 chooses final names.
 _Avoid_: throwaway final name, unstable nickname, hardcoded proper name too early
 
+**Tone-Locked Placeholder Dialogue**:
+Pre-production route dialogue that is specific enough to test implementation,
+state changes, and emotional feel, but not treated as final writing. Each
+required beat should have stable IDs, Role Name speakers, one to three
+provisional lines or prompts, clear intent, and the route or world-state outcome
+it supports.
+_Avoid_: final polish pass, generic placeholder text, deep branching tree, final proper names too early
+
 **Minimum Route Cast**:
 The smallest set of visible characters needed for the First Playable Route to
 feel alive, readable, and emotionally staged without requiring optional
@@ -270,6 +278,23 @@ world-change result, Cicka before/after placement, exit condition, linked source
 docs, and acceptance checks.
 _Avoid_: vague area build request, taste-sensitive unresolved premise, broad "make this level" task, hidden dependency on undocumented canon
 
+**Area Paper Pass**:
+The pre-implementation documentation pass that makes each required Ridge Area
+ready to slice into agent work. It defines local beat states, blocker, Cicka
+before/after placement, prompt/dialogue IDs, transition or exit condition, rough
+stage composition, and acceptance checks without producing pixel maps, final
+scripts, final art specs, or complete dialogue trees.
+_Avoid_: final level spec, pixel map, implementation ticket, polished script, final art brief
+
+**Bridge Tracer Slice**:
+The first implementation slice after the Area Paper Pass: Bridge blocker,
+Bridge Draftsperson, Cicka toy-car play, visible bridge change, and the
+Bridge-to-Concert transition. It proves shared route state, prompts/dialogue
+data shape, camera framing, Cicka placement, transition handling, and Coherent
+Sketchbook Blockout conventions before Concert, Dance Festival, and Relay work
+fan out.
+_Avoid_: parallelizing all areas first, full Bridge polish, isolated tech spike, final art pass
+
 **First Playable Audio Floor**:
 The smallest audio palette needed to test route mood, timing, and emotional
 handoffs: simple handmade-feeling ambience per area, one short guitar phrase for
@@ -361,7 +386,9 @@ _Avoid_: first-playable reset, closed ending, sad objective, immediate replaceme
 **First Playable Reset Return**:
 The v0 post-dedication behavior where the game returns the player to the
 beginning of Bridge Area with clean route progress instead of opening a
-post-game free-travel Ridge.
+post-game free-travel Ridge. An internal ending-seen flag may exist only as
+invisible implementation or debug state; it should not create player-facing
+memory, objectives, Micka setup, or altered world state in v0.
 _Avoid_: post-game world, immediate Micka reveal, new objective, credits lockout, partial completed-world return, visible ending-seen marker
 
 **Guitar Farewell**:
@@ -416,8 +443,11 @@ _Avoid_: optional proof checklist, hub progression, abstract emotional gate
 
 **Compact Area Transition**:
 A short transition between separate compact Ridge Areas that preserves linear
-progress without requiring one continuous walkable overworld geography.
-_Avoid_: unexplained teleport, giant continuous map requirement, hard distance scale
+progress without requiring one continuous walkable overworld geography. For the
+First Playable Route, it should use a small authored handoff beat such as an
+exit prompt or resident line, a quick page/ink/blackout-style transition, one
+travel cue or stinger, and a respawn framed at the next area's local problem.
+_Avoid_: unexplained teleport, giant continuous map requirement, hard distance scale, playable commute, vehicle mini-game, long cutscene, map screen
 
 **Send the Sketchbook Prompt**:
 A retired/provisional ending prompt. Do not use it in v0 unless the sketchbook
@@ -666,9 +696,10 @@ _Avoid_: boss gate, precision climb gate, arbitrary content checklist
 - A **Readiness Favor** can bridge the gap between knowing what a resident wants
   and helping them act without making the player directly manage their feelings.
 - The **Cicka Threshold Farewell** resolves Cicka's recurring field guidance.
-  V0 uses the **First Playable Reset Return** after the **Dedication Card**;
-  long-term post-game scope may replace that with the **Open Ridge Return
-  State**.
+  V0 uses the **First Playable Reset Return** after the **Dedication Card**:
+  reset directly to Bridge with fresh route progress. If an internal
+  ending-seen flag is useful, keep it invisible. Long-term post-game scope may
+  replace the clean reset with the **Open Ridge Return State**.
 - The **Cicka Threshold Farewell** departure should be physical and mostly
   silent: Cicka moves toward the threshold alone, turns back toward the seated
   player, gives one small raw meow, then slips into the **Warm Sketchbook

--- a/docs/design/style-guide.md
+++ b/docs/design/style-guide.md
@@ -40,8 +40,10 @@ The aesthetic is a fusion of **Pablo Stanley’s Open Peeps** (modular, clean ch
 
 ### 3. Environment & World-Building
 
-- **Perspective:** 2D side-view with horizontal parallax layering unless a
-  future design spike deliberately proves another presentation.
+- **Perspective:** The active Ridge route uses a Walkable Sketchbook Stage:
+  side-view interaction composed like a shallow hand-built paper set. Use
+  foreground frames, a readable playable lane, background set dressing, and
+  authored composition rather than true 3D navigation or isometric map logic.
 - **Layout:** A continuous, readable sketchbook route. Buildings, props,
   resting spots, and landmarks should serve the active route instead of
   defaulting to a portfolio street.
@@ -66,6 +68,11 @@ The aesthetic is a fusion of **Pablo Stanley’s Open Peeps** (modular, clean ch
 - **Line-weight integrity:** Preserve thick outer contours and lighter interior marks when scaling, tweening, or reusing assets. Avoid transformations that visibly stretch ink lines.
 - **Living paper motion:** Prefer stepped motion around 10-12 FPS, subtle wobble, low-frequency line jitter, or paper-grain displacement over smooth synthetic easing.
 - **Memory language:** Denser hatching, high-contrast 1-bit/dither treatments, or harsher ink shadows are available for memories or special emotional beats only if readability stays strong.
+- **First playable art target:** Use a Coherent Sketchbook Blockout: rough,
+  replaceable art with clear paper layers, blockers, resident silhouettes,
+  Cicka spots, and before/after world changes. Avoid gray-box placeholders, but
+  do not require final animation sets, full interiors, or polished prop
+  catalogs before the route is playable.
 - **Implementation anchors:** For Phaser assets, define pivots/origins, baselines, and runtime scale before polishing. For scalable paper UI inside Phaser, consider nine-slice-style panels only when the rendering constraints fit the scene.
 - **Scope boundary:** Do not adopt new styling systems, skeletal animation tools, or 3D-to-2D asset pipelines just because the research mentions them. Promote those only after a real production need.
 

--- a/docs/game-design/ridge/README.md
+++ b/docs/game-design/ridge/README.md
@@ -31,7 +31,7 @@ Use each file for exactly one concern:
 | Current runtime/prototype truth | [`ridge-snapshot.md`](./ridge-snapshot.md) | What exists now in the Phaser prototype, what can be reused, and what is disposable. |
 | Active open questions | [`open-questions.md`](./open-questions.md) | True design unknowns and blockout-detail TBD. Area premises may already be accepted even when prompt/topology details remain open. |
 | Product vision | [`summit.md`](./summit.md) | Durable fantasy and pillars, not detailed route implementation. |
-| Implementation sequencing | [`milestone-plan.md`](./milestone-plan.md) | Current route-reset milestones, source stack, prototype reuse rules, and agent checklist. Not live backlog. |
+| Implementation sequencing | [`milestone-plan.md`](./milestone-plan.md) | Current route-reset milestones, source stack, Agent-Ready Slice Contract, prototype reuse rules, and agent checklist. Not live backlog. |
 | Runtime blockout contract | [`map-language.md`](./map-language.md) | Source format and generated facts for the current/prototype blockout. |
 | Legacy prototype history | [`legacy/`](./legacy/README.md) | Superseded folded/Cicka Home plans, old summit/milestone history, map plans, and reviews. Reference only unless an active doc links there. |
 | Art/audio/asset support | [`reference/`](./reference/README.md) | Reference packs that support active docs but do not override route canon. |

--- a/docs/game-design/ridge/README.md
+++ b/docs/game-design/ridge/README.md
@@ -27,6 +27,7 @@ Use each file for exactly one concern:
 | Shipped behavior | [`../player-manual.md`](../player-manual.md) | Update only when behavior ships. |
 | Current Ridge route canon | [`story-level-bible.md`](./story-level-bible.md) | Route spine, area barricade chain, cross-area Cicka/guitar logic, ending order. |
 | Area-specific design canon | [`areas/`](./areas/README.md) | Local geography, blockers, residents, prompts, staging, Cicka Resting Spots, visual/audio notes. |
+| Dialogue conventions | [`dialogue-conventions.md`](./dialogue-conventions.md) | Pre-production dialogue file structure, line IDs, placeholder policy, and migration rules. |
 | Current runtime/prototype truth | [`ridge-snapshot.md`](./ridge-snapshot.md) | What exists now in the Phaser prototype, what can be reused, and what is disposable. |
 | Active open questions | [`open-questions.md`](./open-questions.md) | True design unknowns and blockout-detail TBD. Area premises may already be accepted even when prompt/topology details remain open. |
 | Product vision | [`summit.md`](./summit.md) | Durable fantasy and pillars, not detailed route implementation. |

--- a/docs/game-design/ridge/README.md
+++ b/docs/game-design/ridge/README.md
@@ -31,7 +31,7 @@ Use each file for exactly one concern:
 | Current runtime/prototype truth | [`ridge-snapshot.md`](./ridge-snapshot.md) | What exists now in the Phaser prototype, what can be reused, and what is disposable. |
 | Active open questions | [`open-questions.md`](./open-questions.md) | True design unknowns and blockout-detail TBD. Area premises may already be accepted even when prompt/topology details remain open. |
 | Product vision | [`summit.md`](./summit.md) | Durable fantasy and pillars, not detailed route implementation. |
-| Implementation sequencing | [`milestone-plan.md`](./milestone-plan.md) | Current route-reset milestones, source stack, Agent-Ready Slice Contract, prototype reuse rules, and agent checklist. Not live backlog. |
+| Implementation sequencing | [`milestone-plan.md`](./milestone-plan.md) | Current route-reset milestones, Bridge Tracer Slice, source stack, Agent-Ready Slice Contract, prototype reuse rules, and agent checklist. Not live backlog. |
 | Runtime blockout contract | [`map-language.md`](./map-language.md) | Source format and generated facts for the current/prototype blockout. |
 | Legacy prototype history | [`legacy/`](./legacy/README.md) | Superseded folded/Cicka Home plans, old summit/milestone history, map plans, and reviews. Reference only unless an active doc links there. |
 | Art/audio/asset support | [`reference/`](./reference/README.md) | Reference packs that support active docs but do not override route canon. |

--- a/docs/game-design/ridge/areas/01-bridge/README.md
+++ b/docs/game-design/ridge/areas/01-bridge/README.md
@@ -67,6 +67,11 @@ The resting spot is readable flavor, not a gate.
 
 ## Prototype Floor
 
+The first Bridge implementation should serve as the **Bridge Tracer Slice** for
+the wider route. It should prove shared route state, prompts/dialogue shape,
+camera framing, Cicka placement, transition handling, and Coherent Sketchbook
+Blockout conventions before the other required areas fan out.
+
 The first blockout only needs:
 
 - walk-right nature/hill intro

--- a/docs/game-design/ridge/areas/01-bridge/README.md
+++ b/docs/game-design/ridge/areas/01-bridge/README.md
@@ -110,7 +110,10 @@ layers.
 ## Open Local Slots
 
 - Bridge Draftsperson silhouette, personality, and eventual name
-- exact bridge topology and camera framing
+- rough bridge stage order, entry/exit sides, blocker location, Cicka spot,
+  Bridge Draftsperson/prop zone, and camera framing intent
+- exact bridge topology, collision geometry, and final camera tuning during
+  blockout
 - blockout validation for the accepted route grammar: Cicka noticed something,
   a resident needs local help, and the route visibly changes
 - prop kit for the unfinished sketch/blueprint

--- a/docs/game-design/ridge/areas/01-bridge/README.md
+++ b/docs/game-design/ridge/areas/01-bridge/README.md
@@ -65,6 +65,26 @@ Use **Bridge Resting Spot** as the practical label.
 
 The resting spot is readable flavor, not a gate.
 
+## Rough Stage Composition
+
+Stage-order sketch:
+
+```text
+Nature / hill entry
+  -> Cicka + toy car play spot
+  -> blocked bridge + unfinished blueprint
+  -> Bridge Draftsperson / prop zone
+  -> Cicka Parallel Play return
+  -> toy car bridge test + completed crossing
+  -> Concert transition exit
+```
+
+Framing intent: start with a gentle walk-right introduction, then compose the
+blocked crossing and blueprint as the readable center of the stage. Foreground
+paper edges and failed sketch props can frame the playable lane; background
+layers should make the bridge feel like a small handmade crossing rather than a
+platforming gauntlet.
+
 ## Prototype Floor
 
 The first Bridge implementation should serve as the **Bridge Tracer Slice** for
@@ -84,9 +104,27 @@ The first blockout only needs:
 - simple bridge drawing completion visual
 - bridge becomes crossing
 - Cicka settles near the completed crossing
+- Bridge-to-Concert transition trigger
 
 Cabin, food, physics simulation, and toy-car ping-pong are later optional
 layers.
+
+Definition of done for the Bridge Tracer Slice:
+
+1. player can start at Bridge and move through the nature/hill entry
+2. player can encounter Cicka with the toy car
+3. player can talk to the Bridge Draftsperson at the unfinished blueprint
+4. player can use Cicka Parallel Play to receive or unlock the toy car test prop
+5. player can run the toy-car bridge test
+6. the bridge visibly changes from blocked to usable
+7. player can trigger the Bridge-to-Concert transition
+8. implementation proves shared route state, prompt/dialogue lookup by ID,
+   camera framing, Cicka placement, transition handoff, and basic playability
+   evidence
+
+First Playable Audio Floor needs for the tracer: gentle Bridge/nature ambience,
+Cicka chirp or purr cue, toy-car bridge-test cue, visible bridge-change cue, and
+a soft Bridge-to-Concert transition stinger.
 
 ## Boundaries
 
@@ -110,8 +148,6 @@ layers.
 ## Open Local Slots
 
 - Bridge Draftsperson silhouette, personality, and eventual name
-- rough bridge stage order, entry/exit sides, blocker location, Cicka spot,
-  Bridge Draftsperson/prop zone, and camera framing intent
 - exact bridge topology, collision geometry, and final camera tuning during
   blockout
 - blockout validation for the accepted route grammar: Cicka noticed something,

--- a/docs/game-design/ridge/areas/01-bridge/dialogue.md
+++ b/docs/game-design/ridge/areas/01-bridge/dialogue.md
@@ -1,6 +1,6 @@
 # Bridge Dialogue
 
-> Status: accepted pre-production home / needs line pass.
+> Status: accepted pre-production home / needs tone-locked placeholder line pass.
 > Parent: [`README.md`](./README.md). Format:
 > [`../../dialogue-conventions.md`](../../dialogue-conventions.md).
 

--- a/docs/game-design/ridge/areas/01-bridge/dialogue.md
+++ b/docs/game-design/ridge/areas/01-bridge/dialogue.md
@@ -1,0 +1,27 @@
+# Bridge Dialogue
+
+> Status: accepted pre-production home / needs line pass.
+> Parent: [`README.md`](./README.md). Format:
+> [`../../dialogue-conventions.md`](../../dialogue-conventions.md).
+
+This file owns Bridge Area conversations, prompts, barks, and placeholder lines.
+
+## Planned Conversation Sets
+
+- `bridge.cicka.first_meet`: peaceful first Cicka encounter around the toy car /
+  weight-test prop.
+- `bridge.draftsperson.missing_span`: Bridge Draftsperson introduces the
+  unfinished blueprint and missing middle span.
+- `bridge.cicka.parallel_play`: player joins Cicka's toy-car play until she
+  chooses to share the test car.
+- `bridge.draftsperson.toy_car_test`: toy car test and authored bridge-complete
+  response.
+- `bridge.exit.opened_crossing`: smallest prompt or line set after the crossing
+  opens.
+
+## Open Dialogue Slots
+
+- exact Bridge Draftsperson voice and role label
+- first Cicka prompt wording
+- Cicka Parallel Play prompts and recovery beats
+- bridge completion reaction lines

--- a/docs/game-design/ridge/areas/01-bridge/dialogue.md
+++ b/docs/game-design/ridge/areas/01-bridge/dialogue.md
@@ -1,6 +1,7 @@
 # Bridge Dialogue
 
-> Status: accepted pre-production home / needs tone-locked placeholder line pass.
+> Status: Bridge Tracer Slice placeholder IDs accepted / wording still
+> tone-locked, not final.
 > Parent: [`README.md`](./README.md). Format:
 > [`../../dialogue-conventions.md`](../../dialogue-conventions.md).
 
@@ -19,9 +20,90 @@ This file owns Bridge Area conversations, prompts, barks, and placeholder lines.
 - `bridge.exit.opened_crossing`: smallest prompt or line set after the crossing
   opens.
 
+## Tone-Locked Placeholder Lines
+
+### bridge.cicka.first_meet
+
+Purpose: Establish Cicka as a calm field presence before the toy car becomes a
+route object.
+Trigger: Player approaches Cicka at the toy car / weight-test prop.
+State: `bridge:intro`.
+
+| ID | Speaker | Line / Prompt | Notes |
+| --- | --- | --- | --- |
+| bridge.cicka.first_meet.01 | Prompt | Sit near Cicka | Gentle optional-feeling first contact. |
+| bridge.cicka.first_meet.02 | Cicka | Small chirp. | Audio/event placeholder, not written speech. |
+| bridge.cicka.first_meet.03 | Prompt | Cicka bats the tiny car back into place. | Recontextualizes the toy as shared play. |
+
+Outcome: Player has seen Cicka with the toy car before the Bridge Draftsperson
+names it as the missing bridge test prop.
+
+### bridge.draftsperson.missing_span
+
+Purpose: Introduce the blocked crossing, unfinished blueprint, and missing toy
+car test.
+Trigger: Player talks to the Bridge Draftsperson at the unfinished blueprint.
+State: `bridge:intro` or `bridge:needs_toy_car`.
+
+| ID | Speaker | Line / Prompt | Notes |
+| --- | --- | --- | --- |
+| bridge.draftsperson.missing_span.01 | Bridge Draftsperson | The middle span keeps looking brave until I imagine someone crossing it. | Nervous practical worry, not magic exposition. |
+| bridge.draftsperson.missing_span.02 | Bridge Draftsperson | I had a tiny test car for this. It was here a minute ago. | Points back to Cicka without making her a quest giver. |
+| bridge.draftsperson.missing_span.03 | Prompt | Look for the tiny test car | Updates player intent without quest-log UI. |
+
+Outcome: Route state can move to `bridge:needs_toy_car`; player understands the
+toy car matters for the bridge test.
+
+### bridge.cicka.parallel_play
+
+Purpose: Retrieve the test car through gentle parallel play rather than taking
+it from Cicka.
+Trigger: Player returns to Cicka after learning the test car matters.
+State: `bridge:needs_toy_car`.
+
+| ID | Speaker | Line / Prompt | Notes |
+| --- | --- | --- | --- |
+| bridge.cicka.parallel_play.01 | Prompt | Sit with Cicka | Uses the shared sit/play vocabulary. |
+| bridge.cicka.parallel_play.02 | Prompt | Roll the car back gently | Lets the player join the game, not snatch the prop. |
+| bridge.cicka.parallel_play.03 | Cicka | Quiet purr. | Audio/event placeholder for permission and trust. |
+| bridge.cicka.parallel_play.04 | Prompt | Cicka leaves the tiny car beside you. | Handoff result without making Cicka obedient. |
+
+Outcome: Player receives or can carry the toy car test prop; route remains kind
+and local.
+
+### bridge.draftsperson.toy_car_test
+
+Purpose: Complete the authored bridge test and make the crossing change visible.
+Trigger: Player returns to the blueprint with the toy car.
+State: `bridge:needs_toy_car`.
+
+| ID | Speaker | Line / Prompt | Notes |
+| --- | --- | --- | --- |
+| bridge.draftsperson.toy_car_test.01 | Prompt | Set the tiny car on the drawing | Starts auto-success bridge test. |
+| bridge.draftsperson.toy_car_test.02 | Bridge Draftsperson | If it can carry this much courage, maybe it can carry us. | Provisional line; keep soft, not too clever. |
+| bridge.draftsperson.toy_car_test.03 | Prompt | The toy car rolls across the new span. | Presentation beat for visible route change. |
+| bridge.draftsperson.toy_car_test.04 | Bridge Draftsperson | That line holds. The bridge knows it now. | Signals sketch becoming crossing. |
+
+Outcome: Route state can move to `bridge:bridge_complete`; bridge crossing
+becomes visible and traversable.
+
+### bridge.exit.opened_crossing
+
+Purpose: Let the player leave Bridge Area after the visible world change.
+Trigger: Player approaches the completed crossing / exit side.
+State: `bridge:bridge_complete`.
+
+| ID | Speaker | Line / Prompt | Notes |
+| --- | --- | --- | --- |
+| bridge.exit.opened_crossing.01 | Prompt | Cross the finished bridge | Exit prompt after world change. |
+| bridge.exit.opened_crossing.02 | Bridge Draftsperson | Thank you. I think I can leave this line alone now. | Short gratitude; avoids over-explaining. |
+| bridge.exit.opened_crossing.03 | Prompt | The page turns toward evening music. | Bridge-to-Concert transition cue. |
+
+Outcome: Bridge-to-Concert Compact Area Transition can fire.
+
 ## Open Dialogue Slots
 
 - exact Bridge Draftsperson voice and role label
-- first Cicka prompt wording
-- Cicka Parallel Play prompts and recovery beats
-- bridge completion reaction lines
+- final wording for Cicka prompts and nonverbal audio labels
+- Cicka Parallel Play recovery beats if the player walks away mid-interaction
+- bridge completion reaction polish after the Bridge Tracer Slice proves pacing

--- a/docs/game-design/ridge/areas/02-concert/README.md
+++ b/docs/game-design/ridge/areas/02-concert/README.md
@@ -91,6 +91,43 @@ This can later become the post-ending echo spot. If used, the echo should be a
 small visual absence cue at Cicka's usual spot, not the player's guitar left
 behind and not an unseeded paw/page mark mechanic.
 
+## Rough Stage Composition
+
+Stage-order sketch:
+
+```text
+Bridge transition entry
+  -> crowd / traffic crossing blocker
+  -> crowd barks + facade atmosphere
+  -> musician-side nook with hidden Cicka
+  -> Injured Guitarist practice riff
+  -> auto-success concert start
+  -> opened crossing + goodbye / guitar handoff
+  -> Dance transition exit
+```
+
+Framing intent: present the Concert Area as a compact night block with the
+blocked crossing readable early, then pull the player sideways into the quieter
+musician nook. Foreground crowd silhouettes and storefront facades can sell
+depth while the playable lane stays mostly left/right.
+
+## Paper-Level Acceptance Checks
+
+- The blocked crowd/traffic crossing is visible before dialogue explains the
+  concert delay.
+- Cicka has a before-resolution hiding spot near the musician-side nook and an
+  after-resolution resting spot with or near the band.
+- The Injured Guitarist role, practice-riff beat, and non-arcade fallback are
+  named.
+- Planned prompt/dialogue IDs cover crowd barks, injury setup, practice riff,
+  performance start, guitar handoff, and Cicka flavor.
+- The visible world change is that the crowd or traffic clears and the crossing
+  opens.
+- The guitar handoff is named as the reward that sets up Relay.
+- The Dance transition exit condition is named.
+- First Playable Audio Floor needs are clear: night ambience, guitar phrase,
+  crowd-clearing cue, Cicka cue if used, and transition stinger.
+
 ## Boundaries
 
 - A Guitar-Hero-like performance mini-game is allowed as an ideal or optional
@@ -105,8 +142,6 @@ behind and not an unseeded paw/page mark mechanic.
 
 ## Open Local Slots
 
-- rough concert stage order, entry/exit sides, crossing blocker location,
-  Cicka spot, Injured Guitarist/Band Roadie zone, and camera framing intent
 - exact crossing geometry, collision behavior, and why it blocks progress
 - small-city block layout, bars, building facades, and possible later Area
   Interior Pockets

--- a/docs/game-design/ridge/areas/02-concert/README.md
+++ b/docs/game-design/ridge/areas/02-concert/README.md
@@ -60,13 +60,14 @@ spaces to make the block feel more alive.
 The first blockout only needs:
 
 - blocked crowd/traffic crossing
-- 2-3 annoyed crowd NPCs
+- 2-3 annoyed crowd barks or silhouettes
 - hidden musician-side nook
 - injured guitarist
 - one forgiving practice interaction
 - auto-success concert start
 - crowd clears
-- goodbye/reward beat at the opened exit
+- goodbye/reward beat at the opened exit, with a band member only if needed for
+  staging
 - guitar received
 - Cicka hidden before resolution and chilling with the band after resolution
 

--- a/docs/game-design/ridge/areas/02-concert/README.md
+++ b/docs/game-design/ridge/areas/02-concert/README.md
@@ -105,8 +105,11 @@ behind and not an unseeded paw/page mark mechanic.
 
 ## Open Local Slots
 
-- exact crossing geometry and why it blocks progress
-- small-city block layout, bars, building facades, and possible later interiors
+- rough concert stage order, entry/exit sides, crossing blocker location,
+  Cicka spot, Injured Guitarist/Band Roadie zone, and camera framing intent
+- exact crossing geometry, collision behavior, and why it blocks progress
+- small-city block layout, bars, building facades, and possible later Area
+  Interior Pockets
 - how many annoyed crowd/band flavor lines are enough for discovery
 - exact post-concert goodbye staging near the opened exit
 - guitarist/resident role, silhouette, simplified staging for the skateboard

--- a/docs/game-design/ridge/areas/02-concert/dialogue.md
+++ b/docs/game-design/ridge/areas/02-concert/dialogue.md
@@ -1,6 +1,6 @@
 # Concert Dialogue
 
-> Status: accepted pre-production home / needs line pass.
+> Status: accepted pre-production home / needs tone-locked placeholder line pass.
 > Parent: [`README.md`](./README.md). Format:
 > [`../../dialogue-conventions.md`](../../dialogue-conventions.md).
 

--- a/docs/game-design/ridge/areas/02-concert/dialogue.md
+++ b/docs/game-design/ridge/areas/02-concert/dialogue.md
@@ -1,0 +1,28 @@
+# Concert Dialogue
+
+> Status: accepted pre-production home / needs line pass.
+> Parent: [`README.md`](./README.md). Format:
+> [`../../dialogue-conventions.md`](../../dialogue-conventions.md).
+
+This file owns Concert Area conversations, prompts, barks, and placeholder
+lines.
+
+## Planned Conversation Sets
+
+- `concert.crowd.delay_barks`: annoyed crowd or traffic chatter that makes the
+  blocked crossing and late concert readable.
+- `concert.guitarist.injury`: injured guitarist explains the failed show-off
+  stunt without becoming joke-only.
+- `concert.guitarist.practice_riff`: forgiving practice interaction that teaches
+  the player the concert phrase.
+- `concert.performance.auto_success`: minimal concert start and crowd-clearing
+  line/prompt set.
+- `concert.guitarist.guitar_handoff`: post-concert goodbye and guitar reward.
+- `concert.cicka.band_resting_spot`: Cicka before/during/after concert flavor.
+
+## Open Dialogue Slots
+
+- exact injured guitarist voice and eventual name
+- how many crowd barks are needed for discovery
+- practice riff prompt wording
+- guitar handoff line that makes the Relay use feel earned

--- a/docs/game-design/ridge/areas/02-concert/dialogue.md
+++ b/docs/game-design/ridge/areas/02-concert/dialogue.md
@@ -7,6 +7,10 @@
 This file owns Concert Area conversations, prompts, barks, and placeholder
 lines.
 
+Pre-Tracer scope: these planned conversation IDs are enough until Concert is
+packaged as its own implementation slice. Add line-level Tone-Locked Placeholder
+Dialogue after the Bridge Tracer Slice proves the dialogue data shape.
+
 ## Planned Conversation Sets
 
 - `concert.crowd.delay_barks`: annoyed crowd or traffic chatter that makes the

--- a/docs/game-design/ridge/areas/03-dance-festival/README.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/README.md
@@ -72,6 +72,44 @@ Use **Dance Festival Resting Spot** as the practical label.
 Cicka is an observer, not an explainer. The resting spot is readable flavor, not
 a route gate.
 
+## Rough Stage Composition
+
+Stage-order sketch:
+
+```text
+Concert rest / van arrival entry
+  -> Last-Stop Plaza setup
+  -> shuttle sign + operations table
+  -> service-road blocker
+  -> readiness favors + folded song request
+  -> cleared shuttle lane / Cicka settles
+  -> Relay sunset transition exit
+```
+
+Framing intent: make the shuttle, operations table, and blocked service road
+read as one practical plaza problem. Keep the promised night dance visible in
+lanterns, chair stacks, and dance-floor edges without turning the first-playable
+route into a full festival simulation.
+
+## Paper-Level Acceptance Checks
+
+- The service-road blocker is visible before the player understands the
+  romantic folded-song-request layer.
+- The shuttle, last-daylight sign, operations table, and service gate are named
+  as one readable plaza problem.
+- Cicka has before/after placement near the operations table, shuttle step,
+  lantern crates, service gate, or cleared shuttle sign.
+- Minimum Route Cast roles are named: Hill-Shuttle Driver, Last-Stop Operations
+  Helper, Dance Teacher, Festival Steward, and Unnamed Counterpart Cat.
+- Planned prompt/dialogue IDs cover wayfinding, shuttle delay, operations
+  handoff, local triangulation, one-step practice, folded song request, setup
+  clearance, and final shuttle ride.
+- The visible world change is that setup clears enough for the last daylight
+  shuttle lane.
+- The Relay sunset transition exit condition is named.
+- First Playable Audio Floor needs are clear: daytime setup ambience,
+  setup-clearance cue, Cicka cue if used, and shuttle/transition stinger.
+
 ## Open Local Slots
 
 - [`layout.md`](./layout.md): Rough Stage Composition first, then exact room

--- a/docs/game-design/ridge/areas/03-dance-festival/README.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/README.md
@@ -74,8 +74,8 @@ a route gate.
 
 ## Open Local Slots
 
-- [`layout.md`](./layout.md): exact room topology, prop placement, staging,
-  palette, signage, music texture, and crowd ambience.
+- [`layout.md`](./layout.md): Rough Stage Composition first, then exact room
+  topology, prop placement, palette, signage, music texture, and crowd ambience.
 - [`characters.md`](./characters.md): silhouettes, movement, dialogue style, and
   eventual names for local residents.
 - [`interaction-flow.md`](./interaction-flow.md): concrete prompts, object

--- a/docs/game-design/ridge/areas/03-dance-festival/characters.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/characters.md
@@ -23,15 +23,20 @@ performer; she is the trusted local who keeps the last-stop plaza from becoming
 confused. Emotionally, the operations table lets her keep being useful instead
 of becoming visible enough to be asked to dance.
 
-## Supporting Static Residents
+## Supporting Static Presence
 
-- traveler near the plaza entry: points the player toward the shuttle and
-  explains that Relay requires the last daylight hill shuttle
-- festival steward near the barrier: explains that the service road opens only
-  after setup is safe and closes again when the night festival begins
-- **Dance Teacher** near the floor: offers gentle facilitation, teaches one
-  small step, covers the operations watch once setup is proven safe, and notices
-  that two shy people are orbiting each other, but is not the romance target
+For First Playable, use only the smallest supporting presence needed for the
+route to read clearly:
+
+- optional traveler bark near the plaza entry: points the player toward the
+  shuttle if playtests need extra arrival readability
+- **Festival Steward** near the barrier or **Dance Teacher** near the floor:
+  covers the practical handoff once setup is proven safe
+
+The **Dance Teacher** can also offer gentle facilitation, teach one small step,
+and notice that two shy people are orbiting each other, but is not the romance
+target. Do not require both a fully written steward and teacher unless staging
+proves they serve different jobs.
 
 ## Locked Character Roles
 

--- a/docs/game-design/ridge/areas/03-dance-festival/dialogue.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/dialogue.md
@@ -7,6 +7,11 @@
 This file owns Dance Festival conversations, prompts, barks, and placeholder
 lines. Flow details live in [`interaction-flow.md`](./interaction-flow.md).
 
+Pre-Tracer scope: these planned conversation IDs are enough until Dance Festival
+is packaged as its own implementation slice. Add line-level Tone-Locked
+Placeholder Dialogue after the Bridge Tracer Slice proves the dialogue data
+shape.
+
 ## Planned Conversation Sets
 
 - `dance.traveler.relay_wayfinding`: practical first read that Relay requires

--- a/docs/game-design/ridge/areas/03-dance-festival/dialogue.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/dialogue.md
@@ -1,6 +1,6 @@
 # Dance Festival Dialogue
 
-> Status: accepted pre-production home / needs line pass.
+> Status: accepted pre-production home / needs tone-locked placeholder line pass.
 > Parent: [`README.md`](./README.md). Format:
 > [`../../dialogue-conventions.md`](../../dialogue-conventions.md).
 

--- a/docs/game-design/ridge/areas/03-dance-festival/dialogue.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/dialogue.md
@@ -1,0 +1,32 @@
+# Dance Festival Dialogue
+
+> Status: accepted pre-production home / needs line pass.
+> Parent: [`README.md`](./README.md). Format:
+> [`../../dialogue-conventions.md`](../../dialogue-conventions.md).
+
+This file owns Dance Festival conversations, prompts, barks, and placeholder
+lines. Flow details live in [`interaction-flow.md`](./interaction-flow.md).
+
+## Planned Conversation Sets
+
+- `dance.traveler.relay_wayfinding`: practical first read that Relay requires
+  the last daylight hill shuttle.
+- `dance.driver.shuttle_delay`: driver explains the setup/lane blocker without
+  revealing the whole romantic beat.
+- `dance.operations_helper.handoff_check`: Last-Stop Operations Helper's setup
+  concern and readiness favor.
+- `dance.locals.triangulated_read`: traveler, steward, or Dance Teacher flavor
+  that helps the player infer what is happening.
+- `dance.driver.one_step_practice`: private one-step practice with the Dance
+  Teacher.
+- `dance.driver.folded_song_request`: small folded request that preserves
+  dignity instead of forcing confession.
+- `dance.setup_clearance`: prompt-driven playable montage lines and prompts.
+- `dance.shuttle.last_daylight_ride`: short threshold transition to Relay.
+
+## Open Dialogue Slots
+
+- exact driver, operations helper, steward, and Dance Teacher voices
+- recoverable conversation choices and awkward recovery lines
+- setup clearance prompt wording
+- final shuttle departure line

--- a/docs/game-design/ridge/areas/03-dance-festival/layout.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/layout.md
@@ -75,8 +75,10 @@ Open art/audio choices:
 
 ## Open Spatial Slots
 
-- exact room topology for Last-Stop Plaza
-- camera framing for plaza entry, shuttle, operations table, service gate, and
-  dance floor
+- Rough Stage Composition for Last-Stop Plaza: entry/exit sides, blocker
+  location, Cicka spot, shuttle/operations/resident zones, and camera framing
+  intent
+- exact room topology, collision geometry, and camera tuning for plaza entry,
+  shuttle, operations table, service gate, and dance floor
 - whether the road gate is one screen or a visible edge across several screens
 - final 2-3 setup snaps that visibly clear the service lane

--- a/docs/game-design/ridge/areas/03-dance-festival/layout.md
+++ b/docs/game-design/ridge/areas/03-dance-festival/layout.md
@@ -31,6 +31,24 @@ Festival setup blocks the service road.
 Sign: "Service road closes for night dance. Last daylight shuttle after setup check."
 ```
 
+## Rough Stage Composition
+
+Stage-order sketch:
+
+```text
+Van drop-off / plaza entry
+  -> shuttle stop and last-daylight sign
+  -> operations table with helper / clipboard props
+  -> lantern crates, chairs, cables, dance-floor edge
+  -> service-road gate blocker
+  -> cleared setup snaps
+  -> shuttle departure toward Relay
+```
+
+Optional depth pocket: a community-hall doorway, equipment alcove, or
+operations-side nook can exist if it helps stage setup favors, but it should
+share the same Dance Festival progress and not become a second navigation map.
+
 ## Required Readability
 
 - The closed service-road barrier must be visible before the player understands
@@ -75,9 +93,6 @@ Open art/audio choices:
 
 ## Open Spatial Slots
 
-- Rough Stage Composition for Last-Stop Plaza: entry/exit sides, blocker
-  location, Cicka spot, shuttle/operations/resident zones, and camera framing
-  intent
 - exact room topology, collision geometry, and camera tuning for plaza entry,
   shuttle, operations table, service gate, and dance floor
 - whether the road gate is one screen or a visible edge across several screens

--- a/docs/game-design/ridge/areas/04-relay-ending/README.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/README.md
@@ -87,8 +87,8 @@ The emotional idea is: **I am ready for Cicka's threshold farewell.**
   optional mini-games, return content, and completed-area revisits exist.
 - Keep the v0 reset clean: do not show Micka, a changed post-ending world, a
   special ending-seen marker, or a new objective after reset. If an internal
-  ending-seen flag is ever needed, keep it invisible until the long-term
-  post-game design exists.
+  ending-seen flag is ever needed for implementation or debugging, keep it
+  invisible until the long-term post-game design exists.
 
 ## Tone Boundaries
 
@@ -134,7 +134,8 @@ recommended defaults and validate them through playtesting.
   Memory Montage flashes, empty-sunset hold, dedication-card hold, and auto-fade
 - exact warm threshold artifact presentation after Sit and Play
 - First Playable Reset Return Bridge-start reset behavior
-- whether any invisible ending-seen flag is needed for future unlocks
+- implementation-only: whether an invisible ending-seen flag is useful for
+  debugging or future unlock plumbing
 - long-term Open Ridge Return State interactions
 - delayed Micka trigger
 - later optional Relay texture details after the minimal first-playable linger

--- a/docs/game-design/ridge/areas/04-relay-ending/README.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/README.md
@@ -126,7 +126,10 @@ recommended defaults and validate them through playtesting.
 
 ## Open Local Slots
 
-- physical Relay topology and warm sketchbook-threshold geometry
+- Rough Stage Composition for Relay: arrival side, sit/play spot, Cicka
+  threshold spot, warm artifact zone, and camera framing intent
+- physical Relay topology, collision geometry, and warm sketchbook-threshold
+  geometry during blockout
 - final Cicka field-presence spot
 - exact camera framing for the authored Sit and Play handoff
 - exact guitar audio texture and delayed soft prompt wording

--- a/docs/game-design/ridge/areas/04-relay-ending/README.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/README.md
@@ -115,6 +115,44 @@ playable linger before **Sit and Play**, then the handoff from sunset **Guitar
 Farewell** into Cicka's threshold departure, **Dedication Card**, and route
 reset.
 
+## Rough Stage Composition
+
+Stage-order sketch:
+
+```text
+Dance shuttle / sunset arrival
+  -> tiny overlook linger
+  -> Cicka final field-presence spot
+  -> Sit and Play guitar spot
+  -> warm sketchbook-threshold artifact beyond the path
+  -> dedication card
+  -> Bridge reset
+```
+
+Framing intent: keep Relay almost still. The playable space should be a small
+sunset overlook that lets the player take a few steps before settling beside
+Cicka; the threshold belongs beyond the player's path, readable but unreachable.
+
+## Paper-Level Acceptance Checks
+
+- The Relay arrival, tiny overlook linger, Cicka final field-presence spot, and
+  Sit and Play location are named.
+- The player-facing final trigger is Sit and Play, with no separate send prompt,
+  readiness gate, final choice, NPC, collectible, or comfort menu.
+- The authored sequence order is documented from guitar phrase through Cicka
+  threshold departure, Dedication Card, and Bridge reset.
+- Planned prompt/dialogue IDs cover optional overlook inspect, Sit and Play,
+  delayed soft prompt, final raw meow, and dedication card text.
+- The Route Memory Montage uses exactly three soft flashes: completed Bridge,
+  opened Concert/guitar handoff echo, and Dance Festival night beginning.
+- The warm sketchbook-threshold artifact is beyond the player's path and cannot
+  be followed.
+- The First Playable Reset Return goes directly to fresh Bridge progress with no
+  player-facing ending-seen marker, changed post-ending world, Micka tease, or
+  new objective.
+- First Playable Audio Floor needs are clear: quiet Relay ambience, familiar
+  guitar phrase, final raw meow, silence beat, and reset/fade cue.
+
 ## Cicka Threshold Staging
 
 Unresolved. This area still needs exact decisions for camera behavior, input
@@ -126,8 +164,6 @@ recommended defaults and validate them through playtesting.
 
 ## Open Local Slots
 
-- Rough Stage Composition for Relay: arrival side, sit/play spot, Cicka
-  threshold spot, warm artifact zone, and camera framing intent
 - physical Relay topology, collision geometry, and warm sketchbook-threshold
   geometry during blockout
 - final Cicka field-presence spot

--- a/docs/game-design/ridge/areas/04-relay-ending/dialogue.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/dialogue.md
@@ -1,0 +1,33 @@
+# Relay Ending Dialogue
+
+> Status: accepted pre-production home / needs line pass.
+> Parent: [`README.md`](./README.md). Format:
+> [`../../dialogue-conventions.md`](../../dialogue-conventions.md).
+
+This file owns Relay Ending prompts, minimal inspect text, dedication-card text,
+and any placeholder lines. The first playable ending should remain mostly quiet.
+
+## Planned Conversation Sets
+
+- `relay.overlook.inspect`: optional single quiet overlook inspect detail, if
+  kept in the minimal linger.
+- `relay.sit_and_play.prompt`: final player-triggered Sit and Play prompt.
+- `relay.guitar.let_song_end`: delayed soft prompt after the montage and sunset
+  playing beat.
+- `relay.cicka.threshold_meow`: one tiny raw meow before Cicka crosses the
+  threshold.
+- `relay.dedication.card`: non-diegetic dedication card text.
+
+## Accepted Text
+
+| ID | Speaker | Line / Prompt | Notes |
+| --- | --- | --- | --- |
+| relay.dedication.card.01 | Non-diegetic card | For Cicka. | First line of dedication card. |
+| relay.dedication.card.02 | Non-diegetic card | Thank you for playing. | Second line of dedication card. |
+
+## Open Dialogue Slots
+
+- exact Sit and Play prompt wording
+- exact delayed soft prompt wording
+- whether the optional overlook inspect line is needed
+- how to represent Cicka's final raw meow in implementation data

--- a/docs/game-design/ridge/areas/04-relay-ending/dialogue.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/dialogue.md
@@ -1,6 +1,6 @@
 # Relay Ending Dialogue
 
-> Status: accepted pre-production home / needs line pass.
+> Status: accepted pre-production home / needs tone-locked placeholder line pass.
 > Parent: [`README.md`](./README.md). Format:
 > [`../../dialogue-conventions.md`](../../dialogue-conventions.md).
 

--- a/docs/game-design/ridge/areas/04-relay-ending/dialogue.md
+++ b/docs/game-design/ridge/areas/04-relay-ending/dialogue.md
@@ -7,6 +7,11 @@
 This file owns Relay Ending prompts, minimal inspect text, dedication-card text,
 and any placeholder lines. The first playable ending should remain mostly quiet.
 
+Pre-Tracer scope: keep Relay mostly at planned prompt IDs plus the already
+accepted dedication-card text until Relay is packaged as its own implementation
+slice. Add any remaining line-level Tone-Locked Placeholder Dialogue after the
+Bridge Tracer Slice proves the dialogue data shape.
+
 ## Planned Conversation Sets
 
 - `relay.overlook.inspect`: optional single quiet overlook inspect detail, if

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -57,10 +57,12 @@ placement, exit condition, and acceptance checks.
 
 Before implementation starts, use the Area Paper Pass to make each local area
 doc agent-ready rather than final: define beat states, blocker or threshold,
-Cicka before/after, required prompt/dialogue IDs, rough stage composition,
-transition or reset behavior, audio floor needs, and acceptance checks. Do not
-turn the area docs into pixel maps, final scripts, complete dialogue trees, or
-final art briefs.
+Cicka before/after, required prompt/dialogue IDs, Rough Stage Composition,
+transition or reset behavior, audio floor needs, and acceptance checks. Rough
+Stage Composition should name beat order, entry/exit sides, blocker location,
+Cicka spot, resident/prop zone, optional Area Interior Pocket, and camera
+framing intent. Do not turn the area docs into pixel maps, collision geometry,
+final scripts, complete dialogue trees, or final art briefs.
 
 For first playable audio, use the First Playable Audio Floor: placeholder
 handmade ambience, blocker/world-change cues, Cicka cue if present, and only the
@@ -69,8 +71,8 @@ pack for palette, not as a requirement to produce final songs or mixes.
 
 Ownership rule: root [`../open-questions.md`](../open-questions.md) is for
 route-level or taste-sensitive decisions. Area docs own local **Open Local
-Slots** such as topology, prompt wording, prop placement, resident silhouettes,
-camera framing, and local art/audio choices.
+Slots** such as Rough Stage Composition, prompt wording, resident silhouettes,
+camera framing intent, exact blockout geometry, and local art/audio choices.
 
 ## Area Docs
 

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -61,8 +61,15 @@ Cicka before/after, required prompt/dialogue IDs, Rough Stage Composition,
 transition or reset behavior, audio floor needs, and acceptance checks. Rough
 Stage Composition should name beat order, entry/exit sides, blocker location,
 Cicka spot, resident/prop zone, optional Area Interior Pocket, and camera
-framing intent. Do not turn the area docs into pixel maps, collision geometry,
-final scripts, complete dialogue trees, or final art briefs.
+framing intent. Each area README should include a tiny Stage-Order Sketch, using
+ASCII arrows or equivalent simple text, for the first-read route shape. Do not
+turn the area docs into pixel maps, collision geometry, final scripts, complete
+dialogue trees, or final art briefs.
+
+For Concert, Dance Festival, and Relay, P1 acceptance checks are paper-level:
+list five to eight player-visible outcomes or documented requirements in the
+area README, but do not require runtime proof until those areas become
+implementation slices after the Bridge Tracer Slice.
 
 For first playable audio, use the First Playable Audio Floor: placeholder
 handmade ambience, blocker/world-change cues, Cicka cue if present, and only the

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -13,7 +13,8 @@ Use [`../story-level-bible.md`](../story-level-bible.md) for the route spine,
 ending order, area barricade chain, and cross-area Cicka/guitar logic. Use these
 area files for local geography, blockers, residents, prompts, traversal,
 staging, Cicka Resting Spot details, visual/audio notes, and area-specific open
-questions.
+questions. Use [`../dialogue-conventions.md`](../dialogue-conventions.md) for
+dialogue file format, placeholder policy, and line ID rules.
 
 Ownership rule: root [`../open-questions.md`](../open-questions.md) is for
 route-level or taste-sensitive decisions. Area docs own local **Open Local
@@ -24,10 +25,10 @@ camera framing, and local art/audio choices.
 
 | Route order | Area doc | Owns |
 | --- | --- | --- |
-| 1 | [`01-bridge/README.md`](./01-bridge/README.md) | Blueprint Bridge, first resident-help soft gate, first Cicka attention cue |
-| 2 | [`02-concert/README.md`](./02-concert/README.md) | Concert Crossing, guitar acquisition, comfort-through-memory beat |
-| 3 | [`03-dance-festival/README.md`](./03-dance-festival/README.md) | Opening Dance Shuttle index; local detail split into [`layout.md`](./03-dance-festival/layout.md), [`characters.md`](./03-dance-festival/characters.md), and [`interaction-flow.md`](./03-dance-festival/interaction-flow.md) |
-| 4 | [`04-relay-ending/README.md`](./04-relay-ending/README.md) | Relay Spire, Guitar Farewell staging, Cicka Threshold Farewell, return state |
+| 1 | [`01-bridge/README.md`](./01-bridge/README.md) / [`dialogue.md`](./01-bridge/dialogue.md) | Blueprint Bridge, first resident-help soft gate, first Cicka attention cue |
+| 2 | [`02-concert/README.md`](./02-concert/README.md) / [`dialogue.md`](./02-concert/dialogue.md) | Concert Crossing, guitar acquisition, comfort-through-memory beat |
+| 3 | [`03-dance-festival/README.md`](./03-dance-festival/README.md) / [`dialogue.md`](./03-dance-festival/dialogue.md) | Opening Dance Shuttle index; local detail split into [`layout.md`](./03-dance-festival/layout.md), [`characters.md`](./03-dance-festival/characters.md), and [`interaction-flow.md`](./03-dance-festival/interaction-flow.md) |
+| 4 | [`04-relay-ending/README.md`](./04-relay-ending/README.md) / [`dialogue.md`](./04-relay-ending/dialogue.md) | Relay Spire, Guitar Farewell staging, Cicka Threshold Farewell, return state |
 
 ## Update Rules
 

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -44,6 +44,11 @@ Agent-Ready Slice Contract in [`../milestone-plan.md`](../milestone-plan.md):
 area, local beat state, prompt/dialogue IDs, blocker, world change, Cicka
 placement, exit condition, and acceptance checks.
 
+For first playable audio, use the First Playable Audio Floor: placeholder
+handmade ambience, blocker/world-change cues, Cicka cue if present, and only the
+small guitar or transition cues needed by that area. Use the audio reference
+pack for palette, not as a requirement to produce final songs or mixes.
+
 Ownership rule: root [`../open-questions.md`](../open-questions.md) is for
 route-level or taste-sensitive decisions. Area docs own local **Open Local
 Slots** such as topology, prompt wording, prop placement, resident silhouettes,

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -30,9 +30,20 @@ Use Minimal Route Guidance for area-local readability. Prefer blockers,
 composition, barks, Cicka placement, changed props, and contextual prompts over
 quest logs, checklists, minimaps, objective trackers, or "go talk to X" UI.
 
+Use Compact Area Transitions between required areas. An area exit should resolve
+through a short authored handoff, page/ink/blackout-style transition, soft
+travel cue or stinger, and framed respawn at the next local problem. Do not make
+area exits depend on playable travel routes, vehicle mini-games, long cutscenes,
+or a map screen in the First Playable Route.
+
 Use Role Names for First Playable residents and animals until a focused
 naming/tone pass accepts final proper names. Role labels are stable enough for
 area docs, dialogue IDs, implementation references, and issue writing.
+
+Use Tone-Locked Placeholder Dialogue for area-local writing: stable IDs, Role
+Name speakers, one to three provisional lines or prompts per required beat, and
+clear state outcomes. Save polished banter, deep branches, and final proper
+names for later writing passes.
 
 Keep each area's First Playable cast to the Minimum Route Cast. Add only the
 required route resident(s), Cicka, and the smallest useful barks or silhouettes
@@ -43,6 +54,13 @@ When an area-local detail becomes implementation work, package it through the
 Agent-Ready Slice Contract in [`../milestone-plan.md`](../milestone-plan.md):
 area, local beat state, prompt/dialogue IDs, blocker, world change, Cicka
 placement, exit condition, and acceptance checks.
+
+Before implementation starts, use the Area Paper Pass to make each local area
+doc agent-ready rather than final: define beat states, blocker or threshold,
+Cicka before/after, required prompt/dialogue IDs, rough stage composition,
+transition or reset behavior, audio floor needs, and acceptance checks. Do not
+turn the area docs into pixel maps, final scripts, complete dialogue trees, or
+final art briefs.
 
 For first playable audio, use the First Playable Audio Floor: placeholder
 handmade ambience, blocker/world-change cues, Cicka cue if present, and only the

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -16,26 +16,6 @@ staging, Cicka Resting Spot details, visual/audio notes, and area-specific open
 questions. Use [`../dialogue-conventions.md`](../dialogue-conventions.md) for
 dialogue file format, placeholder policy, and line ID rules.
 
-For the First Playable Route, each required area should be designed as a
-Compact Ridge Stage. Small Area Interior Pockets are allowed when they add
-depth or local richness, but they remain part of the same area/chapter and
-should not create sprawling mini-map navigation.
-
-Use the First Playable Interaction Vocabulary for area-local beats: movement,
-talk/interact, inspect, optional enter/exit, sit/play where appropriate, and
-contextual prompt confirms. Do not add local inventory, required rhythm/drawing
-checks, or fail states before the end-to-end route works.
-
-Use Minimal Route Guidance for area-local readability. Prefer blockers,
-composition, barks, Cicka placement, changed props, and contextual prompts over
-quest logs, checklists, minimaps, objective trackers, or "go talk to X" UI.
-
-Use Compact Area Transitions between required areas. An area exit should resolve
-through a short authored handoff, page/ink/blackout-style transition, soft
-travel cue or stinger, and framed respawn at the next local problem. Do not make
-area exits depend on playable travel routes, vehicle mini-games, long cutscenes,
-or a map screen in the First Playable Route.
-
 Use Role Names for First Playable residents and animals until a focused
 naming/tone pass accepts final proper names. Role labels are stable enough for
 area docs, dialogue IDs, implementation references, and issue writing.
@@ -45,36 +25,11 @@ Name speakers, one to three provisional lines or prompts per required beat, and
 clear state outcomes. Save polished banter, deep branches, and final proper
 names for later writing passes.
 
-Keep each area's First Playable cast to the Minimum Route Cast. Add only the
-required route resident(s), Cicka, and the smallest useful barks or silhouettes
-needed for staging; reserve richer optional residents and hangouts for later
-liveliness passes.
-
-When an area-local detail becomes implementation work, package it through the
-Agent-Ready Slice Contract in [`../milestone-plan.md`](../milestone-plan.md):
-area, local beat state, prompt/dialogue IDs, blocker, world change, Cicka
-placement, exit condition, and acceptance checks.
-
-Before implementation starts, use the Area Paper Pass to make each local area
-doc agent-ready rather than final: define beat states, blocker or threshold,
-Cicka before/after, required prompt/dialogue IDs, Rough Stage Composition,
-transition or reset behavior, audio floor needs, and acceptance checks. Rough
-Stage Composition should name beat order, entry/exit sides, blocker location,
-Cicka spot, resident/prop zone, optional Area Interior Pocket, and camera
-framing intent. Each area README should include a tiny Stage-Order Sketch, using
-ASCII arrows or equivalent simple text, for the first-read route shape. Do not
-turn the area docs into pixel maps, collision geometry, final scripts, complete
-dialogue trees, or final art briefs.
-
-For Concert, Dance Festival, and Relay, P1 acceptance checks are paper-level:
-list five to eight player-visible outcomes or documented requirements in the
-area README, but do not require runtime proof until those areas become
-implementation slices after the Bridge Tracer Slice.
-
-For first playable audio, use the First Playable Audio Floor: placeholder
-handmade ambience, blocker/world-change cues, Cicka cue if present, and only the
-small guitar or transition cues needed by that area. Use the audio reference
-pack for palette, not as a requirement to produce final songs or mixes.
+Implementation-readiness rules are owned by
+[`../milestone-plan.md`](../milestone-plan.md): P1 Area Paper Pass, Rough Stage
+Composition, Stage-Order Sketch, Paper-Level Acceptance Checks, First Playable
+Audio Floor, and the Agent-Ready Slice Contract. Area docs should apply those
+rules only as local facts, not restate the global contract.
 
 Ownership rule: root [`../open-questions.md`](../open-questions.md) is for
 route-level or taste-sensitive decisions. Area docs own local **Open Local

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -26,6 +26,10 @@ talk/interact, inspect, optional enter/exit, sit/play where appropriate, and
 contextual prompt confirms. Do not add local inventory, required rhythm/drawing
 checks, or fail states before the end-to-end route works.
 
+Use Minimal Route Guidance for area-local readability. Prefer blockers,
+composition, barks, Cicka placement, changed props, and contextual prompts over
+quest logs, checklists, minimaps, objective trackers, or "go talk to X" UI.
+
 Use Role Names for First Playable residents and animals until a focused
 naming/tone pass accepts final proper names. Role labels are stable enough for
 area docs, dialogue IDs, implementation references, and issue writing.
@@ -34,6 +38,11 @@ Keep each area's First Playable cast to the Minimum Route Cast. Add only the
 required route resident(s), Cicka, and the smallest useful barks or silhouettes
 needed for staging; reserve richer optional residents and hangouts for later
 liveliness passes.
+
+When an area-local detail becomes implementation work, package it through the
+Agent-Ready Slice Contract in [`../milestone-plan.md`](../milestone-plan.md):
+area, local beat state, prompt/dialogue IDs, blocker, world change, Cicka
+placement, exit condition, and acceptance checks.
 
 Ownership rule: root [`../open-questions.md`](../open-questions.md) is for
 route-level or taste-sensitive decisions. Area docs own local **Open Local

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -16,6 +16,11 @@ staging, Cicka Resting Spot details, visual/audio notes, and area-specific open
 questions. Use [`../dialogue-conventions.md`](../dialogue-conventions.md) for
 dialogue file format, placeholder policy, and line ID rules.
 
+For the First Playable Route, each required area should be designed as a
+Compact Ridge Stage. Small Area Interior Pockets are allowed when they add
+depth or local richness, but they remain part of the same area/chapter and
+should not create sprawling mini-map navigation.
+
 Ownership rule: root [`../open-questions.md`](../open-questions.md) is for
 route-level or taste-sensitive decisions. Area docs own local **Open Local
 Slots** such as topology, prompt wording, prop placement, resident silhouettes,

--- a/docs/game-design/ridge/areas/README.md
+++ b/docs/game-design/ridge/areas/README.md
@@ -21,6 +21,20 @@ Compact Ridge Stage. Small Area Interior Pockets are allowed when they add
 depth or local richness, but they remain part of the same area/chapter and
 should not create sprawling mini-map navigation.
 
+Use the First Playable Interaction Vocabulary for area-local beats: movement,
+talk/interact, inspect, optional enter/exit, sit/play where appropriate, and
+contextual prompt confirms. Do not add local inventory, required rhythm/drawing
+checks, or fail states before the end-to-end route works.
+
+Use Role Names for First Playable residents and animals until a focused
+naming/tone pass accepts final proper names. Role labels are stable enough for
+area docs, dialogue IDs, implementation references, and issue writing.
+
+Keep each area's First Playable cast to the Minimum Route Cast. Add only the
+required route resident(s), Cicka, and the smallest useful barks or silhouettes
+needed for staging; reserve richer optional residents and hangouts for later
+liveliness passes.
+
 Ownership rule: root [`../open-questions.md`](../open-questions.md) is for
 route-level or taste-sensitive decisions. Area docs own local **Open Local
 Slots** such as topology, prompt wording, prop placement, resident silhouettes,

--- a/docs/game-design/ridge/dialogue-conventions.md
+++ b/docs/game-design/ridge/dialogue-conventions.md
@@ -1,0 +1,106 @@
+# Ridge Dialogue Conventions
+
+> Status: accepted pre-production convention.
+> Read [`README.md`](./README.md) first for Ridge source-of-truth routing.
+
+This file defines how Ridge dialogue is documented during pre-production. It is
+not the final runtime data format.
+
+## Source Ownership
+
+Keep dialogue colocated with the area that owns the scene:
+
+- [`areas/01-bridge/dialogue.md`](./areas/01-bridge/dialogue.md)
+- [`areas/02-concert/dialogue.md`](./areas/02-concert/dialogue.md)
+- [`areas/03-dance-festival/dialogue.md`](./areas/03-dance-festival/dialogue.md)
+- [`areas/04-relay-ending/dialogue.md`](./areas/04-relay-ending/dialogue.md)
+
+Area dialogue files own local conversations, barks, prompts, and placeholder
+lines. Cross-area story dependencies belong in
+[`story-level-bible.md`](./story-level-bible.md), not duplicated in every
+dialogue file.
+
+## Pre-Production Format
+
+Use Markdown as the human design source until the dialogue shape stabilizes.
+Each conversation block should include:
+
+- purpose: why this exchange exists in the route
+- trigger: what starts it
+- state: when it can appear
+- lines: placeholder or draft lines with stable IDs
+- outcomes: route flags, world changes, prompt unlocks, or handoffs
+- open questions: local wording, staging, or branching details still unresolved
+
+Recommended block shape:
+
+```md
+### bridge.draftsperson.missing_span
+
+Purpose: Introduce the bridge problem and the missing toy car test.
+Trigger: Player talks to the Bridge Draftsperson at the unfinished blueprint.
+State: Before bridge completion.
+
+| ID | Speaker | Line / Prompt | Notes |
+| --- | --- | --- | --- |
+| bridge.draftsperson.missing_span.01 | Bridge Draftsperson | Placeholder line. | Tone note. |
+
+Outcome: Player understands the bridge needs a safe middle span and the toy car
+test matters.
+```
+
+## Line IDs
+
+Use stable, area-scoped IDs from the start:
+
+```text
+bridge.cicka.first_meet.01
+concert.guitarist.practice_riff.01
+dance.driver.one_step_practice.01
+relay.cicka.threshold_meow.01
+```
+
+IDs should describe area, speaker or beat, conversation purpose, and line order.
+Avoid final character names until names are accepted. Prefer role labels such as
+`bridge.draftsperson`, `concert.guitarist`, `dance.driver`, or
+`dance.operations_helper`.
+
+The exact runtime pipeline is deferred. These IDs should be able to survive a
+future migration into JSON, TypeScript dialogue data, a narrative scripting
+format, or another type-safe import system.
+
+## Placeholder Policy
+
+First Playable Route dialogue should be functional placeholder prose with tone,
+not final writing. A placeholder line is good enough when it proves:
+
+- what the player learns
+- what the character wants or feels
+- what prompt or route state changes next
+- whether the exchange feels kind, awkward, funny, quiet, or practical
+
+Do not polish every line before the route is playable. Do not leave a line so
+generic that implementation cannot tell what state, prompt, or emotional beat it
+supports.
+
+## Branching Scope
+
+For the First Playable Route, prefer short, recoverable conversations over deep
+branching trees. Choices may change pacing, flavor, or recovery, but they should
+not permanently block the first ending.
+
+Mark possible branches explicitly:
+
+```md
+- Option: Ask about the shuttle.
+- Option: Ask why the driver keeps rereading the clipboard.
+- Recovery: If the player asks too directly, locals redirect them toward
+  listening or helping with setup.
+```
+
+## Runtime Boundary
+
+Do not hardcode final user-facing dialogue in implementation while the route is
+still in pre-production. When implementation begins, either import from an
+external data source or mirror the accepted Markdown lines into a small typed
+data layer with the same IDs.

--- a/docs/game-design/ridge/dialogue-conventions.md
+++ b/docs/game-design/ridge/dialogue-conventions.md
@@ -73,6 +73,17 @@ The exact runtime pipeline is deferred. These IDs should be able to survive a
 future migration into JSON, TypeScript dialogue data, a narrative scripting
 format, or another type-safe import system.
 
+## First Slice ID Depth
+
+For the **Bridge Tracer Slice**, Bridge dialogue should have concrete
+Prompt/Dialogue IDs and Tone-Locked Placeholder Dialogue before implementation
+starts, because Bridge proves the import/data shape for later areas.
+
+Concert, Dance Festival, and Relay only need planned conversation IDs and
+obvious TODO slots until their implementation slices are next. Do not fill later
+areas with detailed placeholder lines just to look complete; add line-level IDs
+when the slice is close enough that implementation can use them.
+
 ## Tone-Locked Placeholder Policy
 
 First Playable Route dialogue should use **Tone-Locked Placeholder Dialogue**:

--- a/docs/game-design/ridge/dialogue-conventions.md
+++ b/docs/game-design/ridge/dialogue-conventions.md
@@ -65,6 +65,10 @@ Avoid final character names until names are accepted. Prefer role labels such as
 `bridge.draftsperson`, `concert.guitarist`, `dance.driver`, or
 `dance.operations_helper`.
 
+For First Playable Route dialogue, use stable Role Names instead of provisional
+proper names. Proper names can replace labels only after a naming/tone pass
+accepts them and the affected IDs or data migration are deliberate.
+
 The exact runtime pipeline is deferred. These IDs should be able to survive a
 future migration into JSON, TypeScript dialogue data, a narrative scripting
 format, or another type-safe import system.

--- a/docs/game-design/ridge/dialogue-conventions.md
+++ b/docs/game-design/ridge/dialogue-conventions.md
@@ -73,10 +73,22 @@ The exact runtime pipeline is deferred. These IDs should be able to survive a
 future migration into JSON, TypeScript dialogue data, a narrative scripting
 format, or another type-safe import system.
 
-## Placeholder Policy
+## Tone-Locked Placeholder Policy
 
-First Playable Route dialogue should be functional placeholder prose with tone,
-not final writing. A placeholder line is good enough when it proves:
+First Playable Route dialogue should use **Tone-Locked Placeholder Dialogue**:
+provisional writing with enough voice to test mood and implementation, but not a
+final banter or literary polish pass.
+
+For each required route beat, aim for one to three provisional lines or prompts
+with:
+
+- stable area-scoped IDs
+- a Role Name speaker or prompt speaker
+- the character's intent, feeling, or practical need
+- the route state, prompt unlock, handoff, or visible world change the line
+  supports
+
+A placeholder line is good enough when it proves:
 
 - what the player learns
 - what the character wants or feels
@@ -86,6 +98,9 @@ not final writing. A placeholder line is good enough when it proves:
 Do not polish every line before the route is playable. Do not leave a line so
 generic that implementation cannot tell what state, prompt, or emotional beat it
 supports.
+
+Avoid polished banter passes, deep branching trees, final proper names, or
+line-by-line literary tuning until the route works end to end.
 
 ## Branching Scope
 

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -73,15 +73,22 @@ product taste. Bridge, Concert, Dance Festival, and Relay should each define:
 4. Cicka's before/after placement or final field-presence role
 5. required Role Name characters from the Minimum Route Cast
 6. required prompt/dialogue IDs using Tone-Locked Placeholder Dialogue
-7. rough Compact Ridge Stage composition, including any Area Interior Pocket
+7. Rough Stage Composition for the Compact Ridge Stage, including any Area
+   Interior Pocket
 8. visible world change or ending handoff result
 9. Compact Area Transition, exit condition, or First Playable Reset Return
 10. first playable audio needs from the First Playable Audio Floor
 11. acceptance checks for the first implementation slice
 
+For Rough Stage Composition, P1 should resolve the left-to-right beat order,
+entry and exit sides, blocker location, Cicka spot, resident or prop zone,
+optional Area Interior Pocket if any, and camera framing intent. Leave pixel
+positions, collision geometry, parallax layer distances, and final prop
+placement to the Bridge Tracer Slice and later blockout work.
+
 P1 should not produce pixel-perfect maps, final scripts, final names, final art
 briefs, finished audio specs, complete dialogue trees, optional mini-game
-designs, or post-v0 liveliness scope.
+designs, final collision geometry, or post-v0 liveliness scope.
 
 ### Implementation Sequencing
 

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -58,6 +58,27 @@ Optional mini-games, old Cicka Home mutation work, and folded-desk topology
 enter these milestones only when an active route doc or issue pulls a specific
 piece forward.
 
+### P2 Blockout Completeness Contract
+
+For the first end-to-end **First Playable Route** blockout, each required
+Bridge, Concert, and Dance Festival area is blockout-complete when it has:
+
+1. an entry state where the player enters, can move, and the camera frames the
+   local problem
+2. a visible blocker where the next route is physically blocked before dialogue
+   explains it
+3. a Cicka cue near the problem, prop, or emotional handoff
+4. a resident help beat where one local resident has a practical reason they
+   can affect the blocker
+5. one simple interaction chain with two to four authored prompts or dialogue
+   beats and no fail state
+6. a visible world change that changes the map, not only dialogue
+7. a Cicka after-state where the local resting spot changes or settles
+8. an exit trigger that carries the player to the next Ridge Area
+
+Relay replaces the resident help beat with a brief playable linger, **Sit and
+Play**, authored farewell, **Dedication Card**, and clean Bridge reset.
+
 ## Source Stack
 
 For Ridge rework issues, link the smallest relevant set:

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -44,20 +44,57 @@ doc instead.
 - **P0 Decision Intake**: convert grilling/research transcripts into accepted
   route claims, rejected ideas, and open questions.
 - **P1 Area Paper Pass**: tighten Bridge, Concert, Dance Festival, and Relay
-  docs until each area has layout, resident beats, blockers, Cicka presence,
-  and exit conditions.
+  docs until each area is clear enough to turn into agent-ready implementation
+  slices. "Paper" means docs only: no pixel maps, final scripts, final art
+  specs, or complete dialogue trees.
 - **P2 First Playable Route Blockout**: prove the route can be walked end to
   end with a **Coherent Sketchbook Blockout** and no required precision
   platforming.
 - **P3 Route Readiness Feedback**: make area barricades, resident help, world
   changes, and Relay arrival readable without a visible chore checklist.
 - **P4 Ending Pass**: land Guitar Farewell as the final trigger, Cicka Threshold
-  Farewell, Dedication Card, First Playable Reset Return, and later long-term
-  Open Ridge Return State / Micka timing.
+  Farewell, Dedication Card, and clean First Playable Reset Return. Keep
+  long-term Open Ridge Return State and Micka timing as future/post-v0
+  questions.
 
 Optional mini-games, old Cicka Home mutation work, and folded-desk topology
 enter these milestones only when an active route doc or issue pulls a specific
 piece forward.
+
+### P1 Area Paper Pass Contract
+
+Before implementation starts, each required area should have enough local docs
+to satisfy the **Agent-Ready Slice Contract** without asking an agent to resolve
+product taste. Bridge, Concert, Dance Festival, and Relay should each define:
+
+1. the local route role and emotional idea
+2. local beat states and the intended before/after state for the area
+3. the visible blocker or ending threshold
+4. Cicka's before/after placement or final field-presence role
+5. required Role Name characters from the Minimum Route Cast
+6. required prompt/dialogue IDs using Tone-Locked Placeholder Dialogue
+7. rough Compact Ridge Stage composition, including any Area Interior Pocket
+8. visible world change or ending handoff result
+9. Compact Area Transition, exit condition, or First Playable Reset Return
+10. first playable audio needs from the First Playable Audio Floor
+11. acceptance checks for the first implementation slice
+
+P1 should not produce pixel-perfect maps, final scripts, final names, final art
+briefs, finished audio specs, complete dialogue trees, optional mini-game
+designs, or post-v0 liveliness scope.
+
+### Implementation Sequencing
+
+After the Area Paper Pass, begin implementation with the **Bridge Tracer
+Slice** rather than building all required areas in parallel. The first slice
+should include the Bridge blocker, Bridge Draftsperson, Cicka toy-car play,
+visible bridge change, and Bridge-to-Concert transition.
+
+This slice proves the shared seams before other areas fan out: First Playable
+Route State, prompt/dialogue data shape, camera framing, Cicka placement,
+Compact Area Transition handling, and Coherent Sketchbook Blockout conventions.
+Once the Bridge Tracer Slice is playable and verified, Concert, Dance Festival,
+and Relay can be split into Agent-Ready Slice Contract issues.
 
 ### P2 Blockout Completeness Contract
 
@@ -87,10 +124,13 @@ Bridge, Concert, and Dance Festival area is blockout-complete when it has:
    blocker/world-change cue, Cicka cue if present, and transition/guitar cue
    where relevant
 13. a tiny local beat state that feeds the shared First Playable Route State
-14. an exit trigger that carries the player to the next Ridge Area
+14. a Compact Area Transition that carries the player to the next Ridge Area
+    through a short authored handoff, cue/stinger, and framed respawn rather
+    than playable travel, a vehicle mini-game, long cutscene, or map screen
 
 Relay replaces the resident help beat with a brief playable linger, **Sit and
-Play**, authored farewell, **Dedication Card**, and clean Bridge reset.
+Play**, authored farewell, **Dedication Card**, and clean Bridge reset with no
+player-facing ending-seen marker, changed world, Micka tease, or new objective.
 
 ### Agent-Ready Slice Contract
 
@@ -100,12 +140,12 @@ small and concrete enough to implement without resolving product taste:
 1. Name the Ridge Area and route segment.
 2. Name the local beat state before and after the slice.
 3. Link the smallest relevant source docs from the Source Stack.
-4. List required prompt/dialogue IDs or say that the slice creates placeholder
-   IDs in the area's `dialogue.md`.
+4. List required prompt/dialogue IDs or say that the slice creates
+   Tone-Locked Placeholder Dialogue in the area's `dialogue.md`.
 5. Describe the visible blocker before the slice and the visible world-change
    result after it.
 6. Describe Cicka's before/after placement if the slice touches a route beat.
-7. Name the exit condition or transition unlocked by the slice.
+7. Name the exit condition or Compact Area Transition unlocked by the slice.
 8. State the constraints it must preserve: Compact Ridge Stage, Minimum Route
    Cast, Minimal Route Guidance, First Playable Interaction Vocabulary, and no
    new fail state.
@@ -119,6 +159,11 @@ Avoid vague assignments like "make Concert Area" or "add the Dance Festival."
 Prefer vertical route slices such as "Bridge blocker + Bridge Draftsperson +
 toy-car handoff + opened crossing" where an agent can prove a player-facing
 before/after state.
+
+The first implementation issue should use the **Bridge Tracer Slice**. Do not
+parallelize Concert, Dance Festival, or Relay implementation until Bridge has
+proved the shared route state, prompts/dialogue shape, camera framing, Cicka
+placement, transition handling, and blockout-art conventions.
 
 ## Source Stack
 

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -84,11 +84,39 @@ For Rough Stage Composition, P1 should resolve the left-to-right beat order,
 entry and exit sides, blocker location, Cicka spot, resident or prop zone,
 optional Area Interior Pocket if any, and camera framing intent. Leave pixel
 positions, collision geometry, parallax layer distances, and final prop
-placement to the Bridge Tracer Slice and later blockout work.
+placement to the Bridge Tracer Slice and later blockout work. Each area README
+should include a tiny **Stage-Order Sketch** so implementation agents can read
+the local route shape without treating it as a pixel map.
 
 P1 should not produce pixel-perfect maps, final scripts, final names, final art
 briefs, finished audio specs, complete dialogue trees, optional mini-game
 designs, final collision geometry, or post-v0 liveliness scope.
+
+For Prompt/Dialogue IDs, the Bridge Area should be filled to line/prompt level
+before the Bridge Tracer Slice. Concert, Dance Festival, and Relay may stay at
+planned conversation IDs plus explicit TODO slots until their implementation
+slices are next.
+
+For non-Bridge areas, P1 acceptance checks are **Paper-Level Acceptance
+Checks**: five to eight player-visible outcomes or documented slice
+requirements in the area README. They should confirm that the blocker, Cicka
+placement, resident role, prompt/dialogue ID plan, world change or ending
+handoff, transition/reset condition, and audio-floor need are named. They do
+not require runtime proof, screenshots, automated tests, or playability evidence
+until each area becomes an implementation slice after the Bridge Tracer Slice.
+
+### P1 Readiness Matrix
+
+Use this matrix as the paper-pass exit check before writing implementation
+issues. "Ready" here means the docs are ready to package a slice; only Bridge
+requires immediate runtime/playability proof because it is the tracer.
+
+| Area | Stage sketch | Prompt/dialogue IDs | Cicka placement | Transition/reset | Audio floor | Acceptance checks | Readiness |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Bridge | In area README | Concrete line/prompt IDs in `dialogue.md` | Before/after resting spot named | Bridge-to-Concert transition named | Bridge ambience, Cicka cue, bridge-change cue, transition cue named | Bridge Tracer Slice definition of done | Ready for tracer slice |
+| Concert | In area README | Planned conversation IDs | Hidden before, band/resting after | Dance transition exit named | Night ambience, guitar phrase, crowd-clearing cue, Cicka/transition cues named | Paper-Level Acceptance Checks | Paper-ready; implement after Bridge |
+| Dance Festival | In area README and `layout.md` | Planned conversation IDs | Operations/shuttle/service-gate before/after options named | Relay sunset transition named | Setup ambience, setup-clearance cue, Cicka/transition cues named | Paper-Level Acceptance Checks | Paper-ready; implement after Bridge |
+| Relay | In area README | Planned prompt IDs plus dedication text | Final field-presence / threshold role named | First Playable Reset Return named | Relay ambience, guitar phrase, raw meow, silence/reset cues named | Paper-Level Acceptance Checks | Paper-ready; implement after Bridge |
 
 ### Implementation Sequencing
 
@@ -102,6 +130,23 @@ Route State, prompt/dialogue data shape, camera framing, Cicka placement,
 Compact Area Transition handling, and Coherent Sketchbook Blockout conventions.
 Once the Bridge Tracer Slice is playable and verified, Concert, Dance Festival,
 and Relay can be split into Agent-Ready Slice Contract issues.
+
+The Bridge Tracer Slice is done when a player can:
+
+1. start at the Bridge nature/hill entry
+2. encounter Cicka with the toy car
+3. talk to the Bridge Draftsperson at the unfinished blueprint
+4. use Cicka Parallel Play to receive or unlock the toy car test prop
+5. run the toy-car bridge test
+6. see the crossing visibly change from blocked to usable
+7. cross or confirm the opened bridge exit
+8. trigger the Bridge-to-Concert Compact Area Transition
+
+The implementation should also prove the shared route state, prompt/dialogue
+lookup by Prompt/Dialogue ID, camera framing, Cicka placement, transition
+handoff, and Coherent Sketchbook Blockout conventions. Record basic playability
+evidence with the issue or PR so later area slices inherit a tested seam rather
+than a guess.
 
 ### P2 Blockout Completeness Contract
 

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -79,13 +79,41 @@ Bridge, Concert, and Dance Festival area is blockout-complete when it has:
    can affect the blocker
 8. one simple interaction chain with two to four authored prompts or dialogue
    beats using the First Playable Interaction Vocabulary and no fail state
-9. a visible world change that changes the map, not only dialogue
-10. a Cicka after-state where the local resting spot changes or settles
-11. a tiny local beat state that feeds the shared First Playable Route State
-12. an exit trigger that carries the player to the next Ridge Area
+9. Minimal Route Guidance: readable staging and contextual prompts, not a quest
+   log, checklist, minimap, objective tracker, or "go talk to X" UI
+10. a visible world change that changes the map, not only dialogue
+11. a Cicka after-state where the local resting spot changes or settles
+12. a tiny local beat state that feeds the shared First Playable Route State
+13. an exit trigger that carries the player to the next Ridge Area
 
 Relay replaces the resident help beat with a brief playable linger, **Sit and
 Play**, authored farewell, **Dedication Card**, and clean Bridge reset.
+
+### Agent-Ready Slice Contract
+
+Before assigning a Ridge implementation issue to an AFK agent, make the slice
+small and concrete enough to implement without resolving product taste:
+
+1. Name the Ridge Area and route segment.
+2. Name the local beat state before and after the slice.
+3. Link the smallest relevant source docs from the Source Stack.
+4. List required prompt/dialogue IDs or say that the slice creates placeholder
+   IDs in the area's `dialogue.md`.
+5. Describe the visible blocker before the slice and the visible world-change
+   result after it.
+6. Describe Cicka's before/after placement if the slice touches a route beat.
+7. Name the exit condition or transition unlocked by the slice.
+8. State the constraints it must preserve: Compact Ridge Stage, Minimum Route
+   Cast, Minimal Route Guidance, First Playable Interaction Vocabulary, and no
+   new fail state.
+9. Include acceptance checks: route reaches the slice start, the slice outcome
+   is visible, the next route state or transition unlocks, and required runtime
+   checks/playability evidence are recorded when code changes.
+
+Avoid vague assignments like "make Concert Area" or "add the Dance Festival."
+Prefer vertical route slices such as "Bridge blocker + Bridge Draftsperson +
+toy-car handoff + opened crossing" where an agent can prove a player-facing
+before/after state.
 
 ## Source Stack
 

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -47,7 +47,8 @@ doc instead.
   docs until each area has layout, resident beats, blockers, Cicka presence,
   and exit conditions.
 - **P2 First Playable Route Blockout**: prove the route can be walked end to
-  end with placeholder art and no required precision platforming.
+  end with a **Coherent Sketchbook Blockout** and no required precision
+  platforming.
 - **P3 Route Readiness Feedback**: make area barricades, resident help, world
   changes, and Relay arrival readable without a visible chore checklist.
 - **P4 Ending Pass**: land Guitar Farewell as the final trigger, Cicka Threshold
@@ -65,16 +66,18 @@ Bridge, Concert, and Dance Festival area is blockout-complete when it has:
 
 1. an entry state where the player enters, can move, and the camera frames the
    local problem
-2. a visible blocker where the next route is physically blocked before dialogue
+2. coherent sketchbook blockout art with a foreground frame, playable lane, and
+   background set dressing
+3. a visible blocker where the next route is physically blocked before dialogue
    explains it
-3. a Cicka cue near the problem, prop, or emotional handoff
-4. a resident help beat where one local resident has a practical reason they
+4. a Cicka cue near the problem, prop, or emotional handoff
+5. a resident help beat where one local resident has a practical reason they
    can affect the blocker
-5. one simple interaction chain with two to four authored prompts or dialogue
+6. one simple interaction chain with two to four authored prompts or dialogue
    beats and no fail state
-6. a visible world change that changes the map, not only dialogue
-7. a Cicka after-state where the local resting spot changes or settles
-8. an exit trigger that carries the player to the next Ridge Area
+7. a visible world change that changes the map, not only dialogue
+8. a Cicka after-state where the local resting spot changes or settles
+9. an exit trigger that carries the player to the next Ridge Area
 
 Relay replaces the resident help beat with a brief playable linger, **Sit and
 Play**, authored farewell, **Dedication Card**, and clean Bridge reset.

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -73,13 +73,16 @@ Bridge, Concert, and Dance Festival area is blockout-complete when it has:
 4. a visible blocker where the next route is physically blocked before dialogue
    explains it
 5. a Cicka cue near the problem, prop, or emotional handoff
-6. a resident help beat where one local resident has a practical reason they
+6. Minimum Route Cast presence: required route resident(s), Cicka, and only
+   the smallest useful barks or silhouettes for area readability
+7. a resident help beat where one local resident has a practical reason they
    can affect the blocker
-7. one simple interaction chain with two to four authored prompts or dialogue
-   beats and no fail state
-8. a visible world change that changes the map, not only dialogue
-9. a Cicka after-state where the local resting spot changes or settles
-10. an exit trigger that carries the player to the next Ridge Area
+8. one simple interaction chain with two to four authored prompts or dialogue
+   beats using the First Playable Interaction Vocabulary and no fail state
+9. a visible world change that changes the map, not only dialogue
+10. a Cicka after-state where the local resting spot changes or settles
+11. a tiny local beat state that feeds the shared First Playable Route State
+12. an exit trigger that carries the player to the next Ridge Area
 
 Relay replaces the resident help beat with a brief playable linger, **Sit and
 Play**, authored farewell, **Dedication Card**, and clean Bridge reset.

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -66,18 +66,20 @@ Bridge, Concert, and Dance Festival area is blockout-complete when it has:
 
 1. an entry state where the player enters, can move, and the camera frames the
    local problem
-2. coherent sketchbook blockout art with a foreground frame, playable lane, and
+2. one Compact Ridge Stage topology, with any Area Interior Pocket kept inside
+   the same area progress rather than becoming a second mini-map
+3. coherent sketchbook blockout art with a foreground frame, playable lane, and
    background set dressing
-3. a visible blocker where the next route is physically blocked before dialogue
+4. a visible blocker where the next route is physically blocked before dialogue
    explains it
-4. a Cicka cue near the problem, prop, or emotional handoff
-5. a resident help beat where one local resident has a practical reason they
+5. a Cicka cue near the problem, prop, or emotional handoff
+6. a resident help beat where one local resident has a practical reason they
    can affect the blocker
-6. one simple interaction chain with two to four authored prompts or dialogue
+7. one simple interaction chain with two to four authored prompts or dialogue
    beats and no fail state
-7. a visible world change that changes the map, not only dialogue
-8. a Cicka after-state where the local resting spot changes or settles
-9. an exit trigger that carries the player to the next Ridge Area
+8. a visible world change that changes the map, not only dialogue
+9. a Cicka after-state where the local resting spot changes or settles
+10. an exit trigger that carries the player to the next Ridge Area
 
 Relay replaces the resident help beat with a brief playable linger, **Sit and
 Play**, authored farewell, **Dedication Card**, and clean Bridge reset.

--- a/docs/game-design/ridge/milestone-plan.md
+++ b/docs/game-design/ridge/milestone-plan.md
@@ -83,8 +83,11 @@ Bridge, Concert, and Dance Festival area is blockout-complete when it has:
    log, checklist, minimap, objective tracker, or "go talk to X" UI
 10. a visible world change that changes the map, not only dialogue
 11. a Cicka after-state where the local resting spot changes or settles
-12. a tiny local beat state that feeds the shared First Playable Route State
-13. an exit trigger that carries the player to the next Ridge Area
+12. First Playable Audio Floor cues for the area: placeholder ambience,
+   blocker/world-change cue, Cicka cue if present, and transition/guitar cue
+   where relevant
+13. a tiny local beat state that feeds the shared First Playable Route State
+14. an exit trigger that carries the player to the next Ridge Area
 
 Relay replaces the resident help beat with a brief playable linger, **Sit and
 Play**, authored farewell, **Dedication Card**, and clean Bridge reset.
@@ -106,7 +109,9 @@ small and concrete enough to implement without resolving product taste:
 8. State the constraints it must preserve: Compact Ridge Stage, Minimum Route
    Cast, Minimal Route Guidance, First Playable Interaction Vocabulary, and no
    new fail state.
-9. Include acceptance checks: route reaches the slice start, the slice outcome
+9. For audio-touching slices, state whether the slice uses the First Playable
+   Audio Floor or deliberately defers audio with a silent placeholder.
+10. Include acceptance checks: route reaches the slice start, the slice outcome
    is visible, the next route state or transition unlocks, and required runtime
    checks/playability evidence are recorded when code changes.
 

--- a/docs/game-design/ridge/open-questions.md
+++ b/docs/game-design/ridge/open-questions.md
@@ -47,11 +47,12 @@ Area-local detail lives here:
 True design unknowns:
 
 - **Guitar Farewell micro-staging:** Given the accepted quiet, short Sit and
-  Play shape and authored post-prompt handoff, what are the exact camera,
-  animation, post-montage sunset playing beat, delayed soft prompt wording, and
-  audio beats from guitar phrase through Cicka's threshold departure? Exact
-  timing values should be delegated to prototype/playtest with tasteful
-  recommended defaults rather than locked in pre-production.
+  Play shape, authored post-prompt handoff, and Walkable Sketchbook Stage
+  presentation direction, what are the exact Relay framing, animation,
+  post-montage sunset playing beat, delayed soft prompt wording, and audio
+  beats from guitar phrase through Cicka's threshold departure? Exact timing
+  values should be delegated to prototype/playtest with tasteful recommended
+  defaults rather than locked in pre-production.
 - **Cicka Threshold Farewell staging:** What exact physical sequence carries
   Cicka's final threshold movement, turn-back, tiny raw meow, and warm
   sketchbook-threshold departure without relying on unseeded paw/page marks as a
@@ -96,9 +97,6 @@ Do not re-grill that scope unless Danilo changes the product target.
 
 Route blockout TBD:
 
-- **Route blockout checklist:** What exact rooms, prompts, blockers, route
-  changes, Cicka before/after states, and transition triggers must exist for a
-  complete Bridge -> Concert -> Dance -> Relay blockout pass?
 - **Cicka Resting Spots first-pass states:** Which exact before/after prop,
   posture, or visual trace is the smallest readable version for each required
   Ridge Area, and which of those states should echo in the Route Memory Montage?

--- a/docs/game-design/ridge/reference/m3-audio-pack.md
+++ b/docs/game-design/ridge/reference/m3-audio-pack.md
@@ -35,6 +35,22 @@ Active references:
 - Timing audio can support mastery, but every Telegraph cue needs a primary
   visual read and an assist-mode fallback.
 
+## First Playable Audio Floor
+
+For the First Playable Route, use this pack as palette guidance, not a demand
+for final production audio. The first playable audio floor is intentionally
+small:
+
+- simple handmade-feeling ambience per required area
+- one short guitar phrase that appears at Concert and returns at Relay
+- tiny Cicka meow/purr/chirp cues, including the final raw threshold meow
+- soft transition stingers for area changes
+- clear blocker/world-change cues where sound helps the authored change read
+
+Do not block v0 on full songs, voiced dialogue, adaptive score logic, final mix,
+or rhythm-game-quality guitar/audio production. Silent stubs are acceptable for
+non-critical cues until interaction timing and route readability are proven.
+
 ## Ridge Overworld Loop
 
 Goal: a short seamless loop that can run for several minutes without demanding

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -203,6 +203,15 @@ still reading as a linear route. Distance between areas can stay ambiguous, with
 background composition, distant Relay silhouettes, signage, or skyline changes
 implying progress toward the final ridge.
 
+Each required area should be a **Compact Ridge Stage** for the First Playable
+Route: one small readable stage/chapter, not a sprawling mini-map. Bridge,
+Concert, Dance Festival, and Relay may include **Area Interior Pockets** such as
+an enterable building, musician nook, operations-side alcove, or facade interior
+when that makes the level feel richer or creates staged depth. An Area Interior
+Pocket may use a Phaser scene change if useful, but it still belongs to the
+same Ridge Area, shares the same local progress, and should not become a
+separate navigation problem.
+
 Current time-of-day arc: Bridge begins during the day at a nature/hill edge;
 Concert moves into evening/night small-town festival energy; a short sleep/rest
 interlude carries the player from Concert night to Dance Festival daytime
@@ -322,6 +331,10 @@ cleanly.
 Start with three required main-path Ridge Areas before the Relay ending. Each
 Ridge Area can contain one main Resident Beat plus local interiors, optional
 interactions, and runtime Phaser Scenes.
+For the First Playable Route, keep each required Ridge Area structured as one
+Compact Ridge Stage. Use Area Interior Pockets only when they reinforce the
+local beat, depth, or richness without expanding the area into a sprawling
+mini-map.
 
 Area-specific accepted details live in [`areas/`](./areas/README.md). Keep this
 bible focused on the route spine, cross-area dependencies, and ending logic.

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -286,6 +286,16 @@ the First Playable Route. The player should feel progress through changed world
 state, area transitions, Cicka after-states, and contextual prompts rather than
 UI state.
 
+Use the **First Playable Audio Floor**, not a full soundtrack. Each area can
+have simple handmade-feeling ambience, clear blocker/world-change cues, and soft
+transition stingers. Concert and Relay should share one short guitar phrase so
+the guitar feels remembered rather than introduced at the ending. Cicka can use
+a tiny meow/purr/chirp set, with the final threshold sound still being one small
+raw meow. Do not require full songs, voiced dialogue, adaptive scoring, a
+polished mix, or rhythm-game-quality audio before the route works end to end.
+Use [`reference/m3-audio-pack.md`](./reference/m3-audio-pack.md) for palette and
+naming guidance when an audio slice is ready.
+
 Current time-of-day arc: Bridge begins during the day at a nature/hill edge;
 Concert moves into evening/night small-town festival energy; a short sleep/rest
 interlude carries the player from Concert night to Dance Festival daytime

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -44,6 +44,31 @@ Mini-games attach to the world as optional fun, rewards, shortcuts, or future
 alternate ways to finish a level. They should not become required first-ending
 proof or the default solution for main route blockers.
 
+## Camera And Presentation Direction
+
+Use a **Walkable Sketchbook Stage** direction for the active Ridge route: a
+Harold Halibut-like or theater-set 2.5D presentation that keeps side-view
+interaction simple while composing each Ridge Area like a hand-built paper set.
+
+This means Bridge, Concert, Dance Festival, and Relay can use shallow staged
+depth, foreground/background paper layers, and authored composition, but the
+player's main route movement remains side-view and forgiving. The target is
+closer to a walkable sketchbook stage than an isometric RPG map.
+
+For the First Playable Route, this direction should be expressed lightly:
+per-area bounds, readable spawn framing, visible blockers, simple paper-layer
+depth, and camera framing that supports the local problem. Authored camera
+zones, look-ahead, dead zones, profile blending, and richer parallax are
+follow-up runtime/art polish unless a narrow spike proves they are needed for
+blockout readability.
+
+Keep First Playable Route traversal strictly side-view and mostly left/right.
+Create depth through area composition, foreground/background paper layers,
+entered buildings or local interiors, prop staging, and silhouettes rather than
+small up/down lane movement. If a later area proves the simple model cannot
+support its staging, that area can earn a focused camera/traversal spike, but
+the first implementation should try the consistent simple model first.
+
 ## Canonical Ending
 
 The first ending is the **Cicka Threshold Farewell**. It is the canonical ending

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -120,6 +120,12 @@ Characters can still have strong silhouettes, props, placeholder voices, and
 local behavior before they have final names. Do not lock throwaway proper names
 into dialogue IDs or implementation data.
 
+Use **Tone-Locked Placeholder Dialogue** for First Playable writing. Each
+required route beat should have stable IDs and one to three provisional lines or
+prompts that capture intent, speaker role, emotional tone, and state outcome.
+This is enough for implementation and playtest without committing to final
+banter, deep branches, final proper names, or line-by-line literary polish.
+
 ## Cast Scope
 
 First Playable should use a **Minimum Route Cast**: only the characters and
@@ -201,7 +207,9 @@ Accepted ending outline:
    completed areas after the farewell, but that pays off only once optional
    mini-games, return content, and completed-area revisits exist.
    Do not surface any visible ending-seen memory in v0: no Micka, no changed
-   post-ending world, no special marker, and no new objective after reset.
+   post-ending world, no special marker, and no new objective after reset. An
+   internal ending-seen flag may exist only if useful for implementation or
+   debugging, and must remain invisible to the player in v0.
 
 Tone boundaries:
 
@@ -239,6 +247,19 @@ each area freedom to have its own time of day, environment, and staging while
 still reading as a linear route. Distance between areas can stay ambiguous, with
 background composition, distant Relay silhouettes, signage, or skyline changes
 implying progress toward the final ridge.
+
+Use **Compact Area Transitions** as the route handoff pattern. Each required
+area jump should be short and consistent: an exit prompt or resident line, a
+quick page/ink/blackout-style transition, one travel cue or soft stinger, then
+control resumes with the player framed at the next area's local problem. Do not
+add playable travel routes, vehicle mini-games, long cutscenes, or a map screen
+for the First Playable Route.
+
+The individual transitions can stay lightly authored. Bridge-to-Concert can be
+the simplest page-turn or ink handoff. Concert-to-Dance should imply rest after
+the night concert before the grounded Band Roadie Van Ride drops the player near
+the daytime Dance Festival area. Dance-to-Relay should use the accepted shuttle
+line/sound/brief blackout and respawn at Relay under sunset.
 
 Each required area should be a **Compact Ridge Stage** for the First Playable
 Route: one small readable stage/chapter, not a sprawling mini-map. Bridge,

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -69,6 +69,40 @@ small up/down lane movement. If a later area proves the simple model cannot
 support its staging, that area can earn a focused camera/traversal spike, but
 the first implementation should try the consistent simple model first.
 
+Use a **Coherent Sketchbook Blockout** as the First Playable Route art target:
+rough enough to revise cheaply, but visually directed enough that playtests can
+judge mood, readability, emotional staging, Cicka placement, blockers, resident
+roles, and before/after world changes. It should not be gray boxes, and it
+should not require final character designs, polished animation sets, full
+building interiors, or rich prop catalogs.
+
+Each required area should have enough visual language to prove the Walkable
+Sketchbook Stage direction: a foreground frame, playable lane, background set
+dressing, one unmistakable blocker, one readable resident silhouette or role,
+one Cicka field/resting spot, one visible before/after world change, and one
+exit or transition composition.
+
+## Dialogue Documentation Direction
+
+Use [`dialogue-conventions.md`](./dialogue-conventions.md) as the global
+pre-production convention for dialogue structure, line IDs, placeholder policy,
+and future migration into typed runtime data.
+
+Keep actual route dialogue colocated with the area that owns it:
+
+- Bridge lines live in [`areas/01-bridge/dialogue.md`](./areas/01-bridge/dialogue.md).
+- Concert lines live in [`areas/02-concert/dialogue.md`](./areas/02-concert/dialogue.md).
+- Dance Festival lines live in
+  [`areas/03-dance-festival/dialogue.md`](./areas/03-dance-festival/dialogue.md).
+- Relay Ending lines live in
+  [`areas/04-relay-ending/dialogue.md`](./areas/04-relay-ending/dialogue.md).
+
+During pre-production, these Markdown files are the human design source. They
+should use stable line IDs from the start so the same identifiers can later
+survive migration into JSON, TypeScript data, a narrative scripting format, or
+another type-safe dialogue pipeline. Do not choose the final runtime format
+until the route dialogue shape stops moving.
+
 ## Canonical Ending
 
 The first ending is the **Cicka Threshold Farewell**. It is the canonical ending

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -103,6 +103,43 @@ survive migration into JSON, TypeScript data, a narrative scripting format, or
 another type-safe dialogue pipeline. Do not choose the final runtime format
 until the route dialogue shape stops moving.
 
+Use **Role Names** for First Playable Route characters until a focused
+naming/tone pass accepts final proper names. Stable role labels are enough for
+docs, dialogue IDs, implementation references, and issue writing:
+
+- Bridge Draftsperson
+- Injured Guitarist
+- Band Roadie
+- Hill-Shuttle Driver
+- Last-Stop Operations Helper
+- Dance Teacher
+- Festival Steward
+- Unnamed Counterpart Cat
+
+Characters can still have strong silhouettes, props, placeholder voices, and
+local behavior before they have final names. Do not lock throwaway proper names
+into dialogue IDs or implementation data.
+
+## Cast Scope
+
+First Playable should use a **Minimum Route Cast**: only the characters and
+ambient presence needed to make the route alive, readable, and emotionally
+staged.
+
+- Bridge requires the Bridge Draftsperson and Cicka.
+- Concert requires the Injured Guitarist, Cicka, and just enough crowd or band
+  presence to make the delayed concert and later cleared crossing readable.
+- Dance Festival requires the Hill-Shuttle Driver, Last-Stop Operations Helper,
+  Dance Teacher or Festival Steward coverage for the practical handoff, Cicka,
+  and optionally the Unnamed Counterpart Cat as visual flavor.
+- Relay requires no NPCs beyond Cicka.
+
+Reserve richer residents, full crowd writing, recurring optional hangouts,
+enterable bars full of people, the post-concert campfire/tent hangout, and the
+Festival Superfan for after the route works unless a single cheap bark or
+silhouette is needed for staging. Empty spots, facades, and silhouettes may
+reserve liveliness without becoming required dialogue or implementation scope.
+
 ## Canonical Ending
 
 The first ending is the **Cicka Threshold Farewell**. It is the canonical ending
@@ -212,6 +249,37 @@ Pocket may use a Phaser scene change if useful, but it still belongs to the
 same Ridge Area, shares the same local progress, and should not become a
 separate navigation problem.
 
+Use a tiny **First Playable Interaction Vocabulary** across the route: move
+left/right, interact or talk, inspect, enter/exit an Area Interior Pocket when
+present, sit/play for Cicka or Relay guitar moments, and confirm contextual
+prompts. Contextual prompts carry the route. Object handoffs such as the toy
+car, guitar, folded song request, clipboard, lantern/sign, or setup props can
+exist, but they should be immediate authored interactions rather than a general
+inventory system.
+
+Do not add an inventory screen, freeform item combining, required rhythm,
+drawing, or dance skill checks, or fail states to the First Playable Route.
+Richer drawing, rhythm, dance, or item systems can become optional toys or later
+expressions after the route works end to end.
+
+Use a tiny linear **First Playable Route State**, not a quest log. Area docs can
+own local detail, but the shared route runtime should only need to know the
+current area, the current local beat state, whether the **Concert Guitar** has
+been received, and whether the Relay ending sequence is running. The exact
+runtime enum names are implementation detail, but the intended shape is:
+
+```text
+bridge: intro -> needs_toy_car -> bridge_complete
+concert: blocked -> practiced_riff -> concert_complete -> guitar_received
+dance: blocked -> readiness_favors_done -> shuttle_ready
+relay: arrived -> sit_and_play -> farewell_complete -> reset
+```
+
+Do not add a visible quest checklist, proof inventory, optional-area readiness
+score, or complex save model for the First Playable Route. The player should
+feel progress through changed world state, area transitions, Cicka after-states,
+and contextual prompts rather than UI state.
+
 Current time-of-day arc: Bridge begins during the day at a nature/hill edge;
 Concert moves into evening/night small-town festival energy; a short sleep/rest
 interlude carries the player from Concert night to Dance Festival daytime
@@ -256,6 +324,14 @@ but her role should evolve:
 - early: subtle attention cue near an obstacle
 - middle: observer of a changed object or resident moment
 - late: quiet trust marker near the threshold
+
+She should not need to guide the player much because the First Playable Route
+uses Compact Ridge Stages rather than giant searchable maps. Cicka can sit near
+the thing that matters, play with or avoid important props, react to world
+changes, and settle into new after-states. She should not speak, display
+thought bubbles, point with UI arrows, repeatedly lead the player, or become a
+hint system. If the player is lost, compact layout, NPC barks, camera framing,
+prop placement, and prompt availability should do the heavy lifting.
 
 Bridge Area can serve as the first Cicka encounter. In the current accepted
 opening, the game begins with a simple walk-right control introduction from a

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -262,6 +262,11 @@ drawing, or dance skill checks, or fail states to the First Playable Route.
 Richer drawing, rhythm, dance, or item systems can become optional toys or later
 expressions after the route works end to end.
 
+Use **Minimal Route Guidance**. The route should be readable through visible
+blockers, compact staging, NPC barks, Cicka placement, camera framing, changed
+world state, and contextual prompts. A tiny current-area prompt on first entry
+is allowed only if playtests show the route is unclear without it.
+
 Use a tiny linear **First Playable Route State**, not a quest log. Area docs can
 own local detail, but the shared route runtime should only need to know the
 current area, the current local beat state, whether the **Concert Guitar** has
@@ -276,9 +281,10 @@ relay: arrived -> sit_and_play -> farewell_complete -> reset
 ```
 
 Do not add a visible quest checklist, proof inventory, optional-area readiness
-score, or complex save model for the First Playable Route. The player should
-feel progress through changed world state, area transitions, Cicka after-states,
-and contextual prompts rather than UI state.
+score, minimap, objective tracker, "go talk to X" UI, or complex save model for
+the First Playable Route. The player should feel progress through changed world
+state, area transitions, Cicka after-states, and contextual prompts rather than
+UI state.
 
 Current time-of-day arc: Bridge begins during the day at a nature/hill edge;
 Concert moves into evening/night small-town festival energy; a short sleep/rest

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -270,58 +270,11 @@ Pocket may use a Phaser scene change if useful, but it still belongs to the
 same Ridge Area, shares the same local progress, and should not become a
 separate navigation problem.
 
-During the P1 Area Paper Pass, capture only the **Rough Stage Composition** for
-each Compact Ridge Stage: beat order, entry and exit sides, blocker location,
-Cicka spot, resident or prop zone, optional Area Interior Pocket, and camera
-framing intent. Exact coordinates, collision shapes, parallax distances, and
-final prop placement belong to the Bridge Tracer Slice or later blockout passes.
-
-Use a tiny **First Playable Interaction Vocabulary** across the route: move
-left/right, interact or talk, inspect, enter/exit an Area Interior Pocket when
-present, sit/play for Cicka or Relay guitar moments, and confirm contextual
-prompts. Contextual prompts carry the route. Object handoffs such as the toy
-car, guitar, folded song request, clipboard, lantern/sign, or setup props can
-exist, but they should be immediate authored interactions rather than a general
-inventory system.
-
-Do not add an inventory screen, freeform item combining, required rhythm,
-drawing, or dance skill checks, or fail states to the First Playable Route.
-Richer drawing, rhythm, dance, or item systems can become optional toys or later
-expressions after the route works end to end.
-
-Use **Minimal Route Guidance**. The route should be readable through visible
-blockers, compact staging, NPC barks, Cicka placement, camera framing, changed
-world state, and contextual prompts. A tiny current-area prompt on first entry
-is allowed only if playtests show the route is unclear without it.
-
-Use a tiny linear **First Playable Route State**, not a quest log. Area docs can
-own local detail, but the shared route runtime should only need to know the
-current area, the current local beat state, whether the **Concert Guitar** has
-been received, and whether the Relay ending sequence is running. The exact
-runtime enum names are implementation detail, but the intended shape is:
-
-```text
-bridge: intro -> needs_toy_car -> bridge_complete
-concert: blocked -> practiced_riff -> concert_complete -> guitar_received
-dance: blocked -> readiness_favors_done -> shuttle_ready
-relay: arrived -> sit_and_play -> farewell_complete -> reset
-```
-
-Do not add a visible quest checklist, proof inventory, optional-area readiness
-score, minimap, objective tracker, "go talk to X" UI, or complex save model for
-the First Playable Route. The player should feel progress through changed world
-state, area transitions, Cicka after-states, and contextual prompts rather than
-UI state.
-
-Use the **First Playable Audio Floor**, not a full soundtrack. Each area can
-have simple handmade-feeling ambience, clear blocker/world-change cues, and soft
-transition stingers. Concert and Relay should share one short guitar phrase so
-the guitar feels remembered rather than introduced at the ending. Cicka can use
-a tiny meow/purr/chirp set, with the final threshold sound still being one small
-raw meow. Do not require full songs, voiced dialogue, adaptive scoring, a
-polished mix, or rhythm-game-quality audio before the route works end to end.
-Use [`reference/m3-audio-pack.md`](./reference/m3-audio-pack.md) for palette and
-naming guidance when an audio slice is ready.
+Implementation readiness, acceptance checks, shared route-state shape, and
+paper-pass boundaries are owned by
+[`milestone-plan.md`](./milestone-plan.md). Keep this bible focused on route
+spine, story causality, emotional logic, and cross-area dependencies; area-local
+implementation detail belongs in [`areas/`](./areas/README.md).
 
 Current time-of-day arc: Bridge begins during the day at a nature/hill edge;
 Concert moves into evening/night small-town festival energy; a short sleep/rest

--- a/docs/game-design/ridge/story-level-bible.md
+++ b/docs/game-design/ridge/story-level-bible.md
@@ -270,6 +270,12 @@ Pocket may use a Phaser scene change if useful, but it still belongs to the
 same Ridge Area, shares the same local progress, and should not become a
 separate navigation problem.
 
+During the P1 Area Paper Pass, capture only the **Rough Stage Composition** for
+each Compact Ridge Stage: beat order, entry and exit sides, blocker location,
+Cicka spot, resident or prop zone, optional Area Interior Pocket, and camera
+framing intent. Exact coordinates, collision shapes, parallax distances, and
+final prop placement belong to the Bridge Tracer Slice or later blockout passes.
+
 Use a tiny **First Playable Interaction Vocabulary** across the route: move
 left/right, interact or talk, inspect, enter/exit an Area Interior Pocket when
 present, sit/play for Cicka or Relay guitar moments, and confirm contextual

--- a/docs/research/provenance/README.md
+++ b/docs/research/provenance/README.md
@@ -11,6 +11,8 @@ source rationale, comparison material, or a fresh synthesis pass.
 
 - `agents/`: deep research reports that informed specialist agent/skill design.
 - `audio/`: background audio research and Audio Designer provenance.
+- `design-theory/`: source research for general game design theory, including
+  camera, level, and playability patterns.
 - `narrative/`: background narrative and tribute writing research.
 - `visual/`: background visual-direction, character-design, asset-pipeline, and
   style-system research.

--- a/docs/research/provenance/design-theory/README.md
+++ b/docs/research/provenance/design-theory/README.md
@@ -1,0 +1,12 @@
+# Design Theory Provenance
+
+Deep research reports and source-background notes for general game design
+theory. These files are not specs; use the browseable summaries in
+`../../summaries/design-theory/` first unless you need the original intake
+context.
+
+## Files
+
+- [`video-game-camera-systems-gemini-research.md`](./video-game-camera-systems-gemini-research.md):
+  Gemini-supplied research intake on virtual camera taxonomy, transitions,
+  debugging, and genre-specific camera patterns.

--- a/docs/research/provenance/design-theory/video-game-camera-systems-gemini-research.md
+++ b/docs/research/provenance/design-theory/video-game-camera-systems-gemini-research.md
@@ -1,0 +1,215 @@
+# Technical Architectures Of Virtual Camera Systems
+
+> Status: provenance / AI-generated research intake.
+> Source: Gemini deep research shared by Danilo on 2026-05-30.
+> Verification: not independently source-checked. Treat as background material,
+> not as a current design spec or authoritative citation.
+
+## Core Claim
+
+The virtual camera is the player's perceptual loop into the game world. A good
+camera balances gameplay utility, spatial readability, player comfort, and
+authored composition. A poor camera can create motion sickness, obscure hazards,
+break distance judgment, and disorient player inputs.
+
+## Camera Taxonomy
+
+| Camera model | Mechanical basis | Typical fit | Advantages | Constraints |
+| --- | --- | --- | --- | --- |
+| First-person | Camera locked to a sensory origin; look input controls pitch/yaw | First-person shooters, immersive sims, horror | Direct aim alignment, strong embodiment, precise close inspection | Limited rear/lateral awareness, motion-sickness risk, weak character visibility |
+| True first-person | Camera attached to a full character skeleton/head rig | Immersive action and simulation | Stronger body presence | Animation noise can make the view uncomfortable without filtering |
+| Over-the-shoulder | Close third-person offset with asymmetric framing | Third-person shooters, stealth, action adventure | Keeps avatar visible while preserving forward aim space | Weak platforming depth cues and foot visibility |
+| Orbital third-person | Camera orbits a target pivot with distance, pitch, yaw, damping, and collision | 3D platformers, action RPGs, melee games | Strong surrounding awareness and depth judgment | Requires occlusion/collision handling and can burden players with manual rotation |
+| Fixed cinematic | Trigger volumes switch between authored static cameras | Survival horror, narrative adventure | Strong composition, suspense, and pre-authored lighting | Input disorientation and abrupt angle changes |
+| Isometric / orthographic | Fixed high-angle projection with no depth scaling | Strategy, tactical RPGs, top-down ARPGs | Excellent tactical readability and uniform object size | Less intimacy, weaker natural depth cues, rotation can disorient |
+| 2D side-scroller | Camera constrained to a 2D play plane | Platformers, Metroidvanias, run-and-gun games | Precise jump readability and low player camera burden | Depends heavily on level layout to avoid blind jumps |
+
+## First-Person Notes
+
+First-person cameras align the view vector and aim vector, which makes ranged
+interaction mechanically clear. They can also deepen embodiment when paired
+with expressive hand, body, or interaction animations.
+
+Main risks:
+
+- Head-bob and animation-driven camera rotation can induce nausea.
+- Wide fields of view improve peripheral awareness but can distort screen-edge
+  geometry.
+- Melee hit detection can feel inconsistent when visual contact and combat math
+  disagree.
+- The player has poor rear and lateral awareness unless the game compensates
+  through audio, radar, encounter design, or movement tools.
+
+## Third-Person And Orbital Notes
+
+Third-person cameras decouple the viewpoint from the character's sensory origin.
+They work especially well when the player needs to see the avatar body, nearby
+hazards, melee spacing, or platforming arcs.
+
+Over-the-shoulder cameras are a specialized third-person form optimized for
+ranged action. They become weaker when the game asks for precise jumping,
+close-range crowd awareness, or foot placement. Hybrid action games often widen
+the camera, add lock-on, or change profile during melee encounters.
+
+## Top-Down, Isometric, And Orthographic Notes
+
+High-angle cameras prioritize map readability over embodied intimacy.
+Orthographic projection preserves object size regardless of depth, which helps
+tactical planning but removes natural perspective cues. Games using this view
+often need exaggerated silhouettes, clean layering, and stylized diorama-like
+lighting to keep units and routes readable.
+
+Dense vertical environments may require temporary hiding, fading, or slicing of
+overhead geometry so the player and key interactables remain visible.
+
+## Parametric Camera Model
+
+The source research describes robust cameras as parameter-driven systems rather
+than ad hoc world-space transforms.
+
+Useful parameters:
+
+- Tracking position: the world-space target or target pivot.
+- Framing: screen-space offset for the target, such as centered or
+  over-the-shoulder bias.
+- Distance or zoom: scalar offset from target or orthographic zoom.
+- Pitch: vertical look angle in 3D cameras.
+- Yaw: horizontal orbit angle in 3D cameras.
+- Smoothing: damping applied to position, framing, zoom, and orientation.
+- Bounds: level, room, or authored world limits.
+
+Important implementation idea: smooth the camera's target before applying the
+final camera transform. Do not blindly copy the player's raw transform, because
+small jumps, steps, slopes, or animation noise can become visible camera jitter.
+
+## Projection Notes
+
+Perspective projection scales points by depth, which supports natural distance
+perception. Orthographic projection removes depth scaling, which supports
+tactical clarity but weakens natural distance cues.
+
+For 2D games, the practical equivalent is how parallax, foreground framing,
+screen shake, and layer motion communicate depth without damaging playable-layer
+readability.
+
+## Transition Patterns
+
+| Transition | Behavior | Use when | Risk |
+| --- | --- | --- | --- |
+| Cut | Switch instantly to a new camera state | Fixed angles, security cameras, large orientation changes, hard narrative beats | Can disorient input and spatial memory |
+| Parametric blend | Interpolate position, framing, zoom, and orientation | Traversal-to-aim, target changes, cinematic pans, camera profile changes | Needs clear curves and collision handling |
+
+Priority-based virtual camera systems can select the active camera by context:
+default traversal, trigger zones, lock-on, dialogue, tight interiors, or
+scripted moments. To avoid jarring snaps, the incoming camera can inherit the
+outgoing camera's current transform and then blend toward its target parameters.
+
+## Camera Debugging
+
+The research recommends visible camera telemetry during development:
+
+- Active virtual camera or camera profile.
+- Target position, camera position, and offsets.
+- Pitch, yaw, field of view, zoom, and framing values where relevant.
+- Trigger volumes and priority changes.
+- Occlusion and collision test results.
+- Dead zones, camera windows, and world bounds.
+- A detached debug camera for inspecting camera behavior externally.
+
+For 2D work, the most relevant overlay is a viewport-space display of camera
+window, look-ahead vector, target, world bounds, room bounds, and profile
+triggers.
+
+## Occlusion And Collision
+
+For 3D orbit cameras, the camera can clip into walls or lose line of sight to
+the avatar. Common responses include:
+
+- Raycasts or sphere casts from target to ideal camera point.
+- Pulling the camera forward when geometry blocks the ideal position.
+- Sliding along contact planes.
+- Fading or hiding blocking geometry.
+
+The 2D equivalent is less about physical camera collision and more about
+foreground occlusion, ceiling clutter, player visibility, and whether the
+camera frame reveals the information needed for the next movement choice.
+
+## Performance And Visibility
+
+The research lists common visibility optimizations:
+
+| Method | Purpose | Trade-off |
+| --- | --- | --- |
+| Distance culling | Skip far objects | Can cause pop-in if thresholds are short |
+| View-frustum culling | Skip objects outside the camera view | Does not handle hidden objects inside the view |
+| Precomputed visibility | Use baked cells to decide visible geometry | Memory cost and poor dynamic-object handling |
+| Hierarchical Z-buffer | Cull occluded objects with depth data | GPU cost |
+
+For Ridge, this mostly translates to Phaser scene culling, tile/layer visibility,
+parallax cost, and keeping debug visualizations optional.
+
+## 2D Side-Scroller Patterns
+
+2D camera design and level design must be planned together.
+
+Key patterns:
+
+- Camera windows/dead zones prevent the camera from tracking every small avatar
+  movement.
+- Directional framing bias gives more screen space in the movement direction.
+- Vertical movement can be ignored during normal jumps and followed during
+  sustained climbing or falling.
+- Manual look controls can help players inspect vertical routes, but should be
+  optional and intentionally designed.
+- Enemy spawning tied directly to viewport edges can create frustrating
+  respawn loops during backtracking.
+- Off-screen attacks need strong telegraphing or should be avoided.
+
+The research references older platformers as examples of vertical camera-window
+tuning: stable windows for normal jumps, delayed recentering after landing, and
+wider vertical windows for high-altitude routes.
+
+## Fixed Cameras And Tank Controls
+
+Fixed cinematic cameras can create strong authored suspense, especially in
+survival horror, but they complicate input. Camera-relative controls can invert
+when the view cuts to an opposite angle. Character-relative "tank" controls
+solve that by making up/down/left/right relative to the character heading rather
+than the camera plane.
+
+Transferable lesson: when a camera cuts or rotates, preserve player intent. If
+the input reference frame changes, transition rules must prevent the player from
+reversing direction accidentally.
+
+## Continuous Single-Shot Cameras
+
+The research uses continuous single-shot action games as an example of camera
+as choreography. Without cuts, the game must handle animation blending, asset
+streaming, combat-to-cinematic transitions, and dialogue staging through camera
+motion and route design.
+
+Transferable lesson: a "no hard cuts" rule is not just a camera rule. It affects
+level pacing, loading masks, animation handoffs, and narrative blocking.
+
+## Adaptive Multi-Genre Cameras
+
+Hybrid games often switch views by task:
+
+- First-person for precise aiming or close inspection.
+- Third-person/orbital for melee and platforming.
+- Side-view or static framing for dangerous jumps.
+
+For a 2D Ridge implementation, this suggests camera profiles rather than full
+perspective changes: exploration, precision traversal, dialogue, chase,
+interior, tribute beat, or relay-ending profile.
+
+## Actionable Guidelines
+
+- Match camera mechanics to the player's current task.
+- Keep camera state explicit and parameterized.
+- Filter noisy target movement before it becomes camera motion.
+- Bias framing toward intent, hazards, exits, and rewards.
+- Treat camera transitions as authored state changes with debug visibility.
+- Pair side-scroller cameras with dead zones and directional look-ahead.
+- Avoid off-screen unfairness unless it is heavily telegraphed.
+- Inspect camera framing whenever traversal feels unfair.

--- a/docs/research/summaries/design-theory/README.md
+++ b/docs/research/summaries/design-theory/README.md
@@ -5,3 +5,15 @@ Use these docs as background when reviewing a design or planning a synthesis
 pass.
 
 Combat-only theory was pruned until a current Ridge slice needs it again.
+
+## Files
+
+- [`2d-map-design-principles.md`](./2d-map-design-principles.md): map design,
+  cognitive topology, wayfinding, and Hollow Knight-oriented comparison notes.
+- [`automated-2d-level-playability-testing.md`](./automated-2d-level-playability-testing.md):
+  automated playability and route-validation theory.
+- [`indie-2d-level-design.md`](./indie-2d-level-design.md): 2D level design
+  framework for movement metrics, pedagogy, pacing, and production workflow.
+- [`video-game-camera-systems.md`](./video-game-camera-systems.md): camera
+  taxonomy, 2D camera-window patterns, adaptive profiles, and camera debug
+  checklist.

--- a/docs/research/summaries/design-theory/video-game-camera-systems.md
+++ b/docs/research/summaries/design-theory/video-game-camera-systems.md
@@ -1,0 +1,171 @@
+# Video Game Camera Systems
+
+> Status: research summary / design-theory reference.
+> Source: Gemini deep research shared by Danilo on 2026-05-30.
+> This is not a current Sketchbook Ridge spec. Use it as comparison material
+> when designing or reviewing camera behavior.
+> If a camera direction becomes accepted canon, move that decision into
+> `docs/game-design/ridge/` rather than treating this summary as the source of
+> truth.
+
+## Why This Matters For Ridge
+
+Sketchbook Ridge is currently a 2D Phaser project, so the most useful parts of
+the camera research are not first-person or 3D orbit mechanics. The useful
+takeaways are the player-comfort rules that generalize across camera types:
+
+- The camera should support the player's immediate spatial task, not simply
+  follow the avatar transform.
+- Small vertical movements should usually be damped or ignored, especially
+  during jumps, steps, and uneven-ground traversal.
+- The viewport should bias toward player intent so the player sees hazards,
+  routes, exits, and rewards before committing.
+- Camera behavior and level layout are one system. A level that requires a
+  blind jump is often a camera/layout problem before it is a player-skill
+  problem.
+- Debugging tools should expose active camera mode, bounds, dead zones,
+  look-ahead, trigger volumes, and world limits.
+
+## Useful Ridge Candidate: 2.5D Sketchbook Diorama
+
+The most promising reference direction from this research is not pure
+side-scroller and not true isometric. It is a **2.5D sketchbook diorama camera**:
+side-view interaction simplicity with shallow staged depth, authored camera
+zones, and foreground/background paper layers that make each area feel like a
+small handmade set.
+
+Treat this as reference synthesis, not canon. If adopted, the current Ridge
+game-design docs should define the actual camera contract.
+
+Potential fit:
+
+- **Bridge**: frame the hill edge, Cicka's toy car, blueprint table, and
+  unfinished crossing as a readable paper construction set.
+- **Concert**: present crowd, street facades, stage edge, and musician-side nook
+  as a compact town-block diorama rather than a flat corridor.
+- **Dance Festival**: use shallow plaza depth so the shuttle, operations table,
+  service gate, lantern lines, and dance floor can all be legible anchors.
+- **Relay Threshold**: lock into a quiet sunset tableau after **Sit and Play**,
+  then hold the empty spot after Cicka leaves instead of chasing motion.
+
+Avoid defaulting to true isometric unless a deliberate prototype proves it is
+worth the added movement, depth-sorting, collision, touch-control, and tiny-Cicka
+readability cost. Pure isometric risks making Ridge feel more like a tactical
+map than an intimate sketchbook route.
+
+## Camera Model Taxonomy
+
+| Camera model | Core mechanics | Good for | Main risks |
+| --- | --- | --- | --- |
+| First-person | Camera locked near the character's sensory origin | Precise aiming, close inspection, embodiment | Limited peripheral awareness, motion sickness, weak rear awareness |
+| Over-the-shoulder | Close asymmetric third-person framing | Ranged action, stealth, character visibility | Poor foot visibility and depth judgment for platforming |
+| Orbital third-person | Variable camera offset around a target | 3D traversal, melee, platforming | Collision, occlusion, manual rotation burden |
+| Fixed cinematic | Triggered static viewpoints | Horror, authored composition, narrative beats | Disorienting input changes and abrupt cuts |
+| Isometric / orthographic | Fixed high-angle projection without perspective scaling | Tactical readability, diorama style, strategy | Reduced intimacy, rotation disorientation, weak distance cues |
+| 2D side-scroller | Camera constrained to a 2D plane | Platforming, Metroidvania traversal, readable jumps | Blind hazards if framing and level layout disagree |
+
+## 2D Camera Patterns
+
+### Camera Window / Dead Zone
+
+Instead of centering the player every frame, define a box inside the viewport.
+The camera only moves when the player pushes against that box.
+
+Use this when:
+
+- Jump arcs should not cause constant camera bob.
+- The player needs stable framing for precise platforming.
+- Short local movement should feel like avatar motion, not world motion.
+
+Design note: the vertical window can be wider than the horizontal window so
+normal jumps do not drag the camera up and down. The camera can recenter only
+after landing or after the player reaches a sustained climb.
+
+### Directional Look-Ahead
+
+Bias the camera toward the player's velocity, aim, or intended route. This keeps
+the avatar on the trailing side of the viewport and gives more forward sight.
+
+Use this when:
+
+- The route has hazards, gaps, interactables, or enemies ahead.
+- The player is moving quickly enough that centered framing feels late.
+- A scene wants a stronger sense of downhill/uphill momentum.
+
+Risk: look-ahead can feel jittery if it flips immediately when the player taps
+left/right. Smooth or threshold it so small corrections do not yank the frame.
+
+### Vertical Intent Rules
+
+Treat vertical motion differently depending on intent.
+
+| Situation | Better camera behavior |
+| --- | --- |
+| Normal jump | Hold or lightly damp vertical tracking |
+| Long fall or drop | Bias downward early enough to preview landing risk |
+| Climb or sustained ascent | Move camera after the player reaches the upper window |
+| Landing | Ease back to the local composition rather than snapping |
+
+### Off-Screen Fairness
+
+Camera policy should define what can happen outside the viewport.
+
+- Do not let enemies or hazards require reactions the player cannot see.
+- If an off-screen threat matters, telegraph it with audio, particles, screen
+  edge indicators, or level composition before it becomes dangerous.
+- Avoid spawn logic that repeatedly respawns enemies just because the camera
+  crosses a boundary during backtracking.
+
+## Adaptive Camera Modes
+
+Hybrid games often switch cameras based on task. In a 2D Ridge context, that
+does not need to mean switching perspective. It can mean switching camera
+profiles:
+
+| Mode | Possible profile |
+| --- | --- |
+| Exploration | Wider dead zone, soft look-ahead, stable parallax |
+| Precision platforming | Tighter horizontal control, restrained vertical motion |
+| Dialogue or tribute beat | Locked or gently staged composition |
+| Chase / urgency | Stronger forward bias, faster catch-up, wider preview |
+| Interior / tight space | Reduced look-ahead and narrower world bounds |
+
+Treat these as authored camera states with clear triggers and blend rules.
+Camera cuts should be reserved for moments where a blend would be misleading or
+too slow.
+
+## Implementation Heuristics
+
+- Keep camera parameters explicit: target, viewport bounds, dead zone,
+  look-ahead, smoothing, zoom, world bounds, and active profile.
+- Blend between camera profiles in parameter space instead of snapping raw
+  camera coordinates.
+- Ignore high-frequency avatar jitter before it reaches the camera target.
+- Keep parallax subordinate to gameplay readability.
+- Ensure trigger zones have visible authoring/debug overlays during
+  development.
+- When a route feels unfair, inspect the camera frame and level composition
+  before increasing tutorial text or player stats.
+
+## Debug Checklist
+
+A useful camera debug overlay should expose:
+
+- Active camera profile or mode.
+- Camera world position and target position.
+- Dead-zone/window rectangle.
+- Look-ahead vector and current bias.
+- World bounds and room bounds.
+- Trigger volumes that change camera profile.
+- Parallax layer offsets.
+- Recent camera cuts or blends.
+
+## Ridge Follow-Up Questions
+
+- Which Ridge areas need authored camera profiles instead of default traversal?
+- Should bridge, concert, dance festival, and relay ending each define camera
+  intent alongside spatial layout?
+- Do manual "look up/down" controls belong in exploration, accessibility, or
+  debug-only tooling?
+- Should the playability tester include camera-window and blind-jump checks in
+  smoke paths?

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -67,6 +67,12 @@
       "skillPath": "skills/engineering/tdd/SKILL.md",
       "computedHash": "15a7b5e36383ebadb2dec5e586679e55e9663d292da418926b8da6fc0ef27d84"
     },
+    "thermo-nuclear-code-quality-review": {
+      "source": "cursor/plugins",
+      "sourceType": "github",
+      "skillPath": "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
+      "computedHash": "9052b01b46b1d8dbf94c45f9313ec1983443f9a460e83d49cdc7fe0f640ca476"
+    },
     "to-issues": {
       "source": "mattpocock/skills",
       "sourceType": "github",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -13,6 +13,12 @@
       "skillPath": "skills/engineering/diagnose/SKILL.md",
       "computedHash": "15939a26f86edec2d4862042b8564e5a062cb81d04e047a0cea6305c8830b5f5"
     },
+    "git-guardrails-claude-code": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/misc/git-guardrails-claude-code/SKILL.md",
+      "computedHash": "53a1de29d2b76481202608376fa4a20a8bd7e65b0b8a907a8c9578e629cf313f"
+    },
     "grill-me": {
       "source": "mattpocock/skills",
       "sourceType": "github",
@@ -23,19 +29,37 @@
       "source": "mattpocock/skills",
       "sourceType": "github",
       "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
-      "computedHash": "31a5b1ae116558bf7d3f633f442835f54bd7645923d4f45c7823e52a97317666"
+      "computedHash": "eb0e91e84277283dc2b23ed544399e53afd6b5287e5b6929f25fe8aa608e164b"
+    },
+    "handoff": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/handoff/SKILL.md",
+      "computedHash": "1a78d774f8a59db5daa6e65e20a6596872fa8cde769f9a6e3a09b678dd5ae8cc"
     },
     "improve-codebase-architecture": {
       "source": "mattpocock/skills",
       "sourceType": "github",
       "skillPath": "skills/engineering/improve-codebase-architecture/SKILL.md",
-      "computedHash": "c77b86b4332919499608f9af1880074e1fec65a59b95c70c27a9f39cd137865e"
+      "computedHash": "ef32aea0a8fab9b365ff9e08a95f8d353e20ca21ea46ec2e73587c86dd341351"
+    },
+    "prototype": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/prototype/SKILL.md",
+      "computedHash": "e4d0c8f8cb3fc096ee99405a15491da466545cf4a3694bee5a0c9db2fa621a43"
     },
     "setup-matt-pocock-skills": {
       "source": "mattpocock/skills",
       "sourceType": "github",
       "skillPath": "skills/engineering/setup-matt-pocock-skills/SKILL.md",
-      "computedHash": "3a32f8f1ed8160c9d286a2aabe88ee9b884c6f3f88a7a6c47b7d5d552c959587"
+      "computedHash": "0164a8b1ef998abca426056c6ed8a7716a9d4692fc6daa5378f68381a6dafd24"
+    },
+    "setup-pre-commit": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/misc/setup-pre-commit/SKILL.md",
+      "computedHash": "f9aeedf0a1f560ec465c3939c54434c2d949ac8b958a0493db52216f688a0366"
     },
     "tdd": {
       "source": "mattpocock/skills",
@@ -47,13 +71,13 @@
       "source": "mattpocock/skills",
       "sourceType": "github",
       "skillPath": "skills/engineering/to-issues/SKILL.md",
-      "computedHash": "73a91f30784523aa59ec9b02769576ebfc738e2cd5ad8f6441076031f0a5d5ac"
+      "computedHash": "47f648f3414848ccfc62cb41d2828b7e575fb5e7cbd6c4bdf630c063b5dc5e82"
     },
     "to-prd": {
       "source": "mattpocock/skills",
       "sourceType": "github",
       "skillPath": "skills/engineering/to-prd/SKILL.md",
-      "computedHash": "fd8c259f9c44eff08e29a1a2fc71a806a3568d279a55387a361f78620b10f2aa"
+      "computedHash": "6d741474efd4bc3db55fabc2722ed78ca9c374cabcb6212936d79d4fd4a30fcb"
     },
     "triage": {
       "source": "mattpocock/skills",


### PR DESCRIPTION
## Summary
- Consolidates the Ridge pre-production route into a clearer source of truth for Bridge, Concert, Dance Festival, and Relay.
- Adds the Walkable Sketchbook Stage camera direction, compact stage/topology rules, dialogue doc conventions, and the P1 readiness matrix.
- Defines the Bridge Tracer Slice as the first implementation slice and records Bridge-specific placeholder dialogue, blockout, and audio requirements.
- Captures remaining open questions for later grilling without blocking first implementation.

## Testing
- Not run (not requested).
- Docs-only update; no runtime changes were made.