### PR TITLE
[codex] Implement Ridge Bridge tracer slice

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -151,6 +151,40 @@ provisional lines or prompts, clear intent, and the route or world-state outcome
 it supports.
 _Avoid_: final polish pass, generic placeholder text, deep branching tree, final proper names too early
 
+**Character Conversation Overlay**:
+A reusable deliberate-conversation UI pattern for Ridge character interactions.
+When the player chooses to talk, sit, or respond to a resident, exploration
+pauses or the player stands still, a stylized lower-screen conversation panel
+appears with a character icon or portrait, and the line text can reveal with a
+typed effect before the player advances or closes it. The first version shows
+one speaker and one active line at a time, while still allowing authored line
+sequences to advance and switch speaker between lines. Its first character
+icons should come from the local visual coherence pass for the area using the
+overlay, not from generic unrelated UI symbols. While it is open, player control
+and interaction target switching should freeze, but harmless ambient animation
+such as paper sway, blinking, idle bobs, or line boil can continue.
+_Avoid_: sticky top-of-screen debug text, ambient bark bubble, quest log,
+dialogue tree by default, multiple simultaneous portraits, backlog/history,
+route objective panel
+
+**Interactive Shell Screen-Usage Investigation**:
+A focused layout investigation for making interactive mode use more available
+viewport space, potentially through a fullscreen or fuller-bleed game shell.
+It should evaluate Ridge readability, conversation overlay placement, touch
+controls, header/footer chrome, safe areas, and desktop/mobile framing before
+committing to a shell rewrite.
+_Avoid_: Bridge art pass, per-scene asset polish, hiding required controls,
+unreviewed fullscreen-only layout, changing gameplay scale without camera tests
+
+**Ambient Bark Bubble**:
+A lightweight in-world bubble above or near a character for background flavor,
+short reactions, or local noise. It does not freeze exploration, does not open
+the Character Conversation Overlay, and should stay short enough to read while
+moving. Implement it as a later separate issue from the first Character
+Conversation Overlay pass, while keeping the data model boundaries distinct.
+_Avoid_: deliberate conversation UI, required progress prompt, long dialogue
+line, objective hint spam
+
 **Prompt/Dialogue ID**:
 A stable area-scoped label for a prompt, line, bark, or interaction beat before
 the final text is locked. The ID lets docs, implementation issues, runtime data,
@@ -312,6 +346,15 @@ The first implementation slice after the Area Paper Pass. It proves the Bridge
 route seam before Concert, Dance Festival, and Relay implementation fan out; the
 done checklist is owned by the Ridge milestone plan.
 _Avoid_: parallelizing all areas first, full Bridge polish, isolated tech spike, final art pass
+
+**Bridge Visual Coherence Pass**:
+The follow-up Bridge Area staging pass after the Bridge Tracer Slice. It makes
+the existing Bridge route feel like an authored paper stage by grounding Cicka
+and the toy car, giving the Bridge Draftsperson a distinct work zone, separating
+their spaces with local terrain or trees, and unifying bridge, floor,
+background, and prop placeholders into one readable handmade set.
+_Avoid_: final art pass, production asset pack, generic beautification pass,
+new route mechanics, expanding the Bridge Area into a larger map
 
 **First Playable Audio Floor**:
 The smallest placeholder audio layer needed to test route mood, timing, and

--- a/docs/game-design/ridge/areas/01-bridge/README.md
+++ b/docs/game-design/ridge/areas/01-bridge/README.md
@@ -126,6 +126,53 @@ First Playable Audio Floor needs for the tracer: gentle Bridge/nature ambience,
 Cicka chirp or purr cue, toy-car bridge-test cue, visible bridge-change cue, and
 a soft Bridge-to-Concert transition stinger.
 
+## Bridge Visual Coherence Pass
+
+Track this as a new follow-up issue after the Bridge Tracer Slice rather than
+expanding the tracer PR. Run it after the Bridge Tracer Slice works and before
+Concert Area implementation begins. The goal is not final art; it is to make
+Bridge Area a credible **Walkable Sketchbook Stage** that sets the visual bar
+for the rest of the First Playable Route.
+
+Sequence after the Bridge Tracer Slice:
+
+1. Run the Bridge Visual Coherence Pass.
+2. Build the route-wide **Character Conversation Overlay** as a React Scene UI
+   surface, first integrated into Bridge Area. Phaser should own conversation
+   start, player stand-still/freeze behavior, and active dialogue IDs; React
+   should own the lower-screen panel, character icon/portrait frame, typed text
+   reveal, and advance/close affordance. The first version should show one
+   speaker and one active line at a time, Persona-like, while allowing authored
+   line sequences to advance and switch speaker between lines. Conversation
+   state should freeze player control and interaction target switching, while
+   harmless ambient animation can continue. Do not include Ambient Bark Bubbles
+   in this first conversation overlay issue beyond preserving a clean data
+   boundary between deliberate conversations and later non-blocking barks.
+3. Investigate interactive shell screen usage / fullscreen direction if the
+   conversation overlay or Bridge staging still feels cramped in the current
+   game card.
+4. Begin Concert Area implementation.
+
+Minimum outcomes:
+
+- Cicka is grounded at the Bridge Resting Spot and visibly plays with the toy
+  car / weight-test prop instead of floating near a generic marker.
+- The Bridge Draftsperson has a distinct blueprint work zone, such as a tiny
+  drafting shelter, cabin facade, desk, or taped paper construction nook.
+- Cicka's space and the Draftsperson's work zone are separated by local terrain,
+  trees, paper folds, or foreground/background staging so the Draftsperson does
+  not appear able to see Cicka holding the toy car.
+- The bridge, missing span, completed span, floor, background, and prop
+  placeholders read as one handmade paper set rather than unrelated debug
+  shapes.
+- The pass produces tiny role portrait/icon placeholders for the first
+  **Character Conversation Overlay** integration: Cicka, Bridge Draftsperson,
+  and neutral Prompt/narration.
+- The pass may create a small reusable Bridge art kit, but it should stay rough,
+  scene-owned, and conservative until repeated asset-pipeline pain is proven.
+- Keep staging compatible with the route-wide **Character Conversation Overlay**
+  follow-up, but do not expand this visual pass into the final conversation UI.
+
 ## Boundaries
 
 - Do not make Bridge Area a platforming test.

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -42,7 +42,9 @@ Current runtime characteristics:
   blocked blueprint bridge, Bridge Draftsperson, auto-success toy-car test,
   completed crossing, and Bridge-to-Concert handoff.
 - First Playable Route progress lives in the bridge store as
-  `firstPlayableRoute`, currently tracking `activeAreaId` and `bridgeBeat`.
+  `firstPlayableRoute`, a typed route state that only permits active Bridge
+  beats while `activeAreaId` is `bridge` and records the Concert handoff as the
+  post-Bridge area state.
 - Bridge prompts and dialogue are mirrored into a small typed runtime data layer
   from the accepted Bridge dialogue IDs.
 - The folded desk blockout, generated facts, traversal helpers, Cicka Home

--- a/docs/game-design/ridge/ridge-snapshot.md
+++ b/docs/game-design/ridge/ridge-snapshot.md
@@ -12,14 +12,16 @@
 - **Ridge source router:** [`README.md`](./README.md).
 - **Active story/route canon:** [`story-level-bible.md`](./story-level-bible.md).
 - **Active area design:** [`areas/`](./areas/README.md).
-- **Runtime spatial data:** [`folded-desk-ridge.source.ts`](../../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts).
+- **Legacy blockout spatial data:** [`folded-desk-ridge.source.ts`](../../../src/game/scenes/ridge/blockout/sources/folded-desk-ridge.source.ts).
 - **Blockout language contract:** [`map-language.md`](./map-language.md).
 - **Legacy folded topology reference:** [`legacy/`](./legacy/README.md).
 - **Product vision:** [`summit.md`](./summit.md).
 - **Live implementation work:** GitHub Issues.
 
-If this file disagrees with the folded desk Ridge blockout about room layout,
-route order, anchors, shortcuts, or progress-gated geometry, the blockout wins.
+If this file disagrees with the current Ridge runtime code about implemented
+behavior, the code wins. If this file describes the legacy folded desk blockout
+and disagrees with the folded desk Ridge blockout about room layout, route
+order, anchors, shortcuts, or progress-gated geometry, the blockout wins.
 If this file disagrees with GitHub about active work state, GitHub wins.
 If this file disagrees with `story-level-bible.md` or the matching `areas/`
 doc about future route intent, the active design docs win.
@@ -35,22 +37,20 @@ Ridge is a separate Phaser scene that can boot directly in development with:
 Current runtime characteristics:
 
 - Ridge uses shared side-view movement and camera/runtime support.
-- The scene imports the generated Ridge blockout artifact, derives geometry,
-  compiles typed facts, and hands those facts to scene-owned presentation,
-  traversal, interaction, and Cicka Home mutation modules.
-- The runtime source is the folded Ridge blockout, not a separate hand-coded
-  room catalog.
-- Stampede can be reached from the Ridge Trail Card path.
-- Telegraph, Domino, high ledge, underpath, and other future beats are present
-  as route promises or disabled/teased anchors until their implementation
-  slices exist.
-- Ridge remains a proof-of-concept surface. The current playable traversal code
-  can be replaced if the next design pass preserves the useful source contract,
-  compiler, generated facts, and viewer/debugger workflow.
-- Newer story-route planning demotes Cicka Home from canonical hub to local
-  **Cicka Resting Spots** inside each required Ridge Area. The current
-  Cicka Home runtime pieces are proof-of-concept infrastructure until a route
-  rewrite chooses whether to adapt or remove them.
+- The active `ridge` scene is now the **Bridge Tracer Slice**: a flat
+  Bridge-only route from nature/hill entry to Cicka's toy-car play spot,
+  blocked blueprint bridge, Bridge Draftsperson, auto-success toy-car test,
+  completed crossing, and Bridge-to-Concert handoff.
+- First Playable Route progress lives in the bridge store as
+  `firstPlayableRoute`, currently tracking `activeAreaId` and `bridgeBeat`.
+- Bridge prompts and dialogue are mirrored into a small typed runtime data layer
+  from the accepted Bridge dialogue IDs.
+- The folded desk blockout, generated facts, traversal helpers, Cicka Home
+  mutation code, Trail Cards, and Stampede reward path remain in the repo as
+  protected prototype/reference assets, but they are not the active Ridge route
+  presented by the `ridge` scene.
+- Stampede remains loadable as its own scene and through development tooling,
+  but the active Bridge slice does not route to Stampede/Telegraph/Domino.
 
 ## Protected PoC Assets
 
@@ -72,7 +72,25 @@ Disposable if a better Ridge emerges:
 - current folded-desk room arrangement.
 - any runtime module whose main job was proving the old platformer-like route.
 
-## Current Route Read
+## Active Runtime Route Read
+
+The current playable Ridge route is the Bridge tracer:
+
+```text
+Nature / hill entry
+  -> Cicka + toy car play spot
+  -> blocked bridge + unfinished blueprint
+  -> Bridge Draftsperson
+  -> Cicka Parallel Play
+  -> toy-car bridge test
+  -> completed crossing
+  -> Bridge-to-Concert handoff
+```
+
+The Bridge-to-Concert handoff is only a transition proof. Concert, Dance
+Festival, Relay, and the ending sequence remain future implementation slices.
+
+## Legacy Folded Blockout Read
 
 The current blockout route is the folded desk Ridge:
 
@@ -126,9 +144,13 @@ Durable Ridge progress is intentionally small:
 - manual pages
 - glide pips
 - shortcuts
+- first playable route state
 
 Current accepted behavior:
 
+- Bridge route state tracks the Bridge beat from `intro` through
+  `concert_handoff` without introducing inventory, quest logs, or objective
+  trackers.
 - First Stampede clear awards the `stampede-sketch` Ridge stamp.
 - First Stampede clear awards one glide pip.
 - Repeat Stampede clears do not duplicate those rewards.

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -89,6 +89,12 @@ re-apply camera bounds/profile math.
   game card. Stampede uses this for status/start/result UI; Potassium uses it
   for draft choices and terminal actions while Phaser keeps the active HUD and
   gameplay field.
+- Route-wide character conversations should use the same scene UI seam: Phaser
+  owns when a conversation starts, when the player stands still, and which
+  dialogue IDs are active; React owns the Character Conversation Overlay,
+  portrait/icon frame, typed text reveal, and advance/close controls.
+  Conversation state should freeze player control and interaction target
+  switching without necessarily pausing harmless ambient scene animation.
 - Use shell header chrome policy for app navigation controls that belong
   outside the Phaser card, such as Back buttons for arcade scenes. Do not push
   those controls through scene-owned UI unless they need scene gameplay state.

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -34,8 +34,8 @@ game vocabulary is explicit:
   pause Phaser automatically; the owning scene decides whether gameplay is
   gated and consumes one-shot UI actions through the bridge.
 - **Scene header chrome** - `src/game/shell/sceneHeaderChrome.ts` owns the
-  small shell-level policy for replacing default Inventory/Dev controls with a
-  scene navigation control in presentation-heavy arcade scenes.
+  small shell-level policy for replacing default shell controls with a scene
+  navigation control in presentation-heavy arcade scenes.
 - **Notebook shell profile policy** - `src/game/shell/notebookShellProfile.ts`
   maps runtime scenes onto shared Notebook Shell layout primitives. Potassium
   uses the `ruledBoardPage` focus profile; Stampede uses the `survivalPage`

--- a/docs/runtime-modes.md
+++ b/docs/runtime-modes.md
@@ -58,12 +58,11 @@ Use this path when checking pattern refactors:
 4. Open and close a hobby overlay from inside the hobbies scene.
 5. Enter the Developer Basement, open the computer console, and close it back
    to the basement scene.
-6. Boot `?startScene=ridge`; verify the Ridge shell renders, movement works,
-   and walking near a Stampede/Telegraph/Domino prop shows `[E] INTERACT`.
-   Interact with the Stampede prop to open its Trail Card, confirm `Enter`
-   starts Stampede Sketch, confirm the Stampede Notebook shell renders, drag
-   from outside the visible page to move, and return to Ridge. Telegraph and
-   Domino cards should still keep primary entry disabled.
+6. Boot `?startScene=ridge`; verify the Ridge shell renders the Bridge tracer,
+   movement works from the nature/hill entry, Cicka appears with the toy car,
+   the Bridge Draftsperson advances the missing-span beat, Cicka Parallel Play
+   unlocks the toy car test, the auto-success bridge test visibly opens the
+   crossing, and the opened crossing triggers the Bridge-to-Concert handoff.
 7. Open inventory from the overworld and from a child scene.
 8. In Potassium, confirm the Notebook shell renders with Back and Static Mode,
    then drag/release from outside the visible board area and confirm launch or

--- a/docs/runtime-modes.md
+++ b/docs/runtime-modes.md
@@ -63,11 +63,10 @@ Use this path when checking pattern refactors:
    the Bridge Draftsperson advances the missing-span beat, Cicka Parallel Play
    unlocks the toy car test, the auto-success bridge test visibly opens the
    crossing, and the opened crossing triggers the Bridge-to-Concert handoff.
-7. Open inventory from the overworld and from a child scene.
-8. In Potassium, confirm the Notebook shell renders with Back and Static Mode,
+7. In Potassium, confirm the Notebook shell renders with Back and Static Mode,
    then drag/release from outside the visible board area and confirm launch or
    recall still works. Clear or dev-skip a wave and confirm the upgrade-choice
    panel is a React scene UI panel above the notebook stage; choose an upgrade
    and confirm play continues. Confirm terminal Retry/Return actions work from
    the React panel.
-9. Verify mobile touch movement, jump, and interact one-shots.
+8. Verify mobile touch movement, jump, and interact one-shots.

--- a/src/game/bridge/store.test.ts
+++ b/src/game/bridge/store.test.ts
@@ -171,7 +171,11 @@ describe('bridgeStore', () => {
         mobility: {
           glidePips: 0
         },
-        shortcutIds: []
+        shortcutIds: [],
+        firstPlayableRoute: {
+          activeAreaId: 'bridge',
+          bridgeBeat: 'intro'
+        }
       });
       expect(bridgeStore.getState().inventory.ownedItemIds).toEqual([]);
       expect(bridgeStore.getState().equipment.equippedItemIds).toEqual([]);
@@ -197,7 +201,11 @@ describe('bridgeStore', () => {
         mobility: {
           glidePips: 0
         },
-        shortcutIds: []
+        shortcutIds: [],
+        firstPlayableRoute: {
+          activeAreaId: 'bridge',
+          bridgeBeat: 'intro'
+        }
       });
       expect(bridgeStore.getState().inventory.ownedItemIds).toEqual([]);
       expect(bridgeStore.getState().equipment.equippedItemIds).toEqual([]);
@@ -253,11 +261,37 @@ describe('bridgeStore', () => {
       bridgeActions.awardRidgeStamp('stampede-sketch');
       expect(bridgeStore.getState().progress.ridge).not.toHaveProperty('stickerIds');
       expect(Object.keys(bridgeStore.getState().progress.ridge).sort()).toEqual([
+        'firstPlayableRoute',
         'manualPageIds',
         'mobility',
         'shortcutIds',
         'stampIds'
       ]);
+    });
+
+    it('tracks the first playable Ridge route handoff separately from rewards', () => {
+      expect(bridgeStore.getState().progress.ridge.firstPlayableRoute).toEqual({
+        activeAreaId: 'bridge',
+        bridgeBeat: 'intro'
+      });
+
+      bridgeActions.setRidgeBridgeBeat('needs_toy_car');
+      expect(bridgeStore.getState().progress.ridge.firstPlayableRoute).toEqual({
+        activeAreaId: 'bridge',
+        bridgeBeat: 'needs_toy_car'
+      });
+
+      bridgeActions.triggerRidgeConcertHandoff();
+      expect(bridgeStore.getState().progress.ridge.firstPlayableRoute).toEqual({
+        activeAreaId: 'concert',
+        bridgeBeat: 'concert_handoff'
+      });
+
+      bridgeActions.resetProgress();
+      expect(bridgeStore.getState().progress.ridge.firstPlayableRoute).toEqual({
+        activeAreaId: 'bridge',
+        bridgeBeat: 'intro'
+      });
     });
 
     it('keeps Potassium Circuit ownership derived from inventory', () => {

--- a/src/game/bridge/store.ts
+++ b/src/game/bridge/store.ts
@@ -49,6 +49,19 @@ export interface BridgeEquipmentState {
 export type RidgeStampId = string;
 export type RidgeManualPageId = string;
 export type RidgeShortcutId = string;
+export type RidgeFirstPlayableAreaId = 'bridge' | 'concert' | 'danceFestival' | 'relay';
+export type RidgeBridgeBeatState =
+  | 'intro'
+  | 'needs_toy_car'
+  | 'toy_car_shared'
+  | 'testing_bridge'
+  | 'bridge_complete'
+  | 'concert_handoff';
+
+export interface RidgeFirstPlayableRouteState {
+  activeAreaId: RidgeFirstPlayableAreaId;
+  bridgeBeat: RidgeBridgeBeatState;
+}
 
 export interface BridgeRidgeProgressState {
   stampIds: RidgeStampId[];
@@ -57,6 +70,7 @@ export interface BridgeRidgeProgressState {
     glidePips: number;
   };
   shortcutIds: RidgeShortcutId[];
+  firstPlayableRoute: RidgeFirstPlayableRouteState;
 }
 
 export interface BridgeProgressState {
@@ -120,7 +134,15 @@ function createInitialRidgeProgress(): BridgeRidgeProgressState {
     mobility: {
       glidePips: 0
     },
-    shortcutIds: []
+    shortcutIds: [],
+    firstPlayableRoute: createInitialRidgeFirstPlayableRoute()
+  };
+}
+
+function createInitialRidgeFirstPlayableRoute(): RidgeFirstPlayableRouteState {
+  return {
+    activeAreaId: 'bridge',
+    bridgeBeat: 'intro'
   };
 }
 
@@ -262,6 +284,10 @@ function setState(updater: (current: BridgeState) => BridgeState): void {
     arraysEqual(previous.progress.ridge.manualPageIds, candidate.progress.ridge.manualPageIds) &&
     previous.progress.ridge.mobility.glidePips === candidate.progress.ridge.mobility.glidePips &&
     arraysEqual(previous.progress.ridge.shortcutIds, candidate.progress.ridge.shortcutIds) &&
+    previous.progress.ridge.firstPlayableRoute.activeAreaId ===
+      candidate.progress.ridge.firstPlayableRoute.activeAreaId &&
+    previous.progress.ridge.firstPlayableRoute.bridgeBeat ===
+      candidate.progress.ridge.firstPlayableRoute.bridgeBeat &&
     previous.sceneHintText === candidate.sceneHintText &&
     previous.touch.left === candidate.touch.left &&
     previous.touch.right === candidate.touch.right &&
@@ -461,6 +487,37 @@ export const bridgeActions = {
         }
       };
     });
+  },
+  setRidgeBridgeBeat(bridgeBeat: RidgeBridgeBeatState): void {
+    setState((current) => ({
+      ...current,
+      progress: {
+        ...current.progress,
+        ridge: {
+          ...current.progress.ridge,
+          firstPlayableRoute: {
+            ...current.progress.ridge.firstPlayableRoute,
+            activeAreaId: 'bridge',
+            bridgeBeat
+          }
+        }
+      }
+    }));
+  },
+  triggerRidgeConcertHandoff(): void {
+    setState((current) => ({
+      ...current,
+      progress: {
+        ...current.progress,
+        ridge: {
+          ...current.progress.ridge,
+          firstPlayableRoute: {
+            activeAreaId: 'concert',
+            bridgeBeat: 'concert_handoff'
+          }
+        }
+      }
+    }));
   },
   resetProgress(): void {
     setState((current) => ({

--- a/src/game/bridge/store.ts
+++ b/src/game/bridge/store.ts
@@ -57,11 +57,18 @@ export type RidgeBridgeBeatState =
   | 'testing_bridge'
   | 'bridge_complete'
   | 'concert_handoff';
+export type RidgeBridgeAreaBeatState = Exclude<RidgeBridgeBeatState, 'concert_handoff'>;
+export type RidgePostBridgeAreaId = Exclude<RidgeFirstPlayableAreaId, 'bridge'>;
 
-export interface RidgeFirstPlayableRouteState {
-  activeAreaId: RidgeFirstPlayableAreaId;
-  bridgeBeat: RidgeBridgeBeatState;
-}
+export type RidgeFirstPlayableRouteState =
+  | {
+      activeAreaId: 'bridge';
+      bridgeBeat: RidgeBridgeAreaBeatState;
+    }
+  | {
+      activeAreaId: RidgePostBridgeAreaId;
+      bridgeBeat: 'concert_handoff';
+    };
 
 export interface BridgeRidgeProgressState {
   stampIds: RidgeStampId[];
@@ -488,7 +495,7 @@ export const bridgeActions = {
       };
     });
   },
-  setRidgeBridgeBeat(bridgeBeat: RidgeBridgeBeatState): void {
+  setRidgeBridgeBeat(bridgeBeat: RidgeBridgeAreaBeatState): void {
     setState((current) => ({
       ...current,
       progress: {

--- a/src/game/bridge/store.ts
+++ b/src/game/bridge/store.ts
@@ -54,7 +54,6 @@ export type RidgeBridgeBeatState =
   | 'intro'
   | 'needs_toy_car'
   | 'toy_car_shared'
-  | 'testing_bridge'
   | 'bridge_complete'
   | 'concert_handoff';
 export type RidgeBridgeAreaBeatState = Exclude<RidgeBridgeBeatState, 'concert_handoff'>;

--- a/src/game/scenes/ridge/cicka/homeMutations.test.ts
+++ b/src/game/scenes/ridge/cicka/homeMutations.test.ts
@@ -20,6 +20,10 @@ function createRidgeProgress(
       glidePips: 0
     },
     shortcutIds: [],
+    firstPlayableRoute: {
+      activeAreaId: 'bridge',
+      bridgeBeat: 'intro'
+    },
     ...overrides
   };
 }

--- a/src/game/scenes/ridge/dialogue/bridgeDialogue.test.ts
+++ b/src/game/scenes/ridge/dialogue/bridgeDialogue.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BRIDGE_DIALOGUE_CONVERSATION_IDS,
+  getBridgeDialogueLine,
+  getBridgeDialogueLines,
+  getBridgePromptText
+} from './bridgeDialogue';
+
+describe('Bridge dialogue lookup', () => {
+  it('keeps the accepted Bridge Tracer conversation ids available', () => {
+    expect(BRIDGE_DIALOGUE_CONVERSATION_IDS).toEqual([
+      'bridge.cicka.first_meet',
+      'bridge.draftsperson.missing_span',
+      'bridge.cicka.parallel_play',
+      'bridge.draftsperson.toy_car_test',
+      'bridge.exit.opened_crossing'
+    ]);
+  });
+
+  it('looks up placeholder lines by stable line id', () => {
+    expect(getBridgeDialogueLine('bridge.cicka.parallel_play.04')).toMatchObject({
+      conversationId: 'bridge.cicka.parallel_play',
+      speaker: 'Prompt',
+      text: 'Cicka leaves the tiny car beside you.'
+    });
+  });
+
+  it('returns conversation lines in authored order', () => {
+    expect(getBridgeDialogueLines('bridge.draftsperson.toy_car_test').map((line) => line.id)).toEqual([
+      'bridge.draftsperson.toy_car_test.01',
+      'bridge.draftsperson.toy_car_test.02',
+      'bridge.draftsperson.toy_car_test.03',
+      'bridge.draftsperson.toy_car_test.04'
+    ]);
+  });
+
+  it('uses the same data source for prompts and dialogue text', () => {
+    expect(getBridgePromptText('bridge.exit.opened_crossing.01')).toBe(
+      'Cross the finished bridge'
+    );
+  });
+});

--- a/src/game/scenes/ridge/dialogue/bridgeDialogue.ts
+++ b/src/game/scenes/ridge/dialogue/bridgeDialogue.ts
@@ -1,3 +1,5 @@
+import { getMessages } from '@/shared/i18n';
+
 export const BRIDGE_DIALOGUE_CONVERSATION_IDS = [
   'bridge.cicka.first_meet',
   'bridge.draftsperson.missing_span',
@@ -9,140 +11,145 @@ export const BRIDGE_DIALOGUE_CONVERSATION_IDS = [
 export type BridgeDialogueConversationId =
   (typeof BRIDGE_DIALOGUE_CONVERSATION_IDS)[number];
 
-export type BridgeDialogueSpeaker = 'Prompt' | 'Cicka' | 'Bridge Draftsperson';
+type BridgeDialogueCopy = ReturnType<typeof getMessages>['scenes']['ridge']['bridge'];
+export type BridgeDialogueSpeakerId = keyof BridgeDialogueCopy['speakers'];
+
+export type BridgeDialogueSpeaker =
+  BridgeDialogueCopy['speakers'][BridgeDialogueSpeakerId];
 
 export interface BridgeDialogueLine {
   id: string;
   conversationId: BridgeDialogueConversationId;
+  speakerId: BridgeDialogueSpeakerId;
   speaker: BridgeDialogueSpeaker;
   text: string;
 }
 
-const BRIDGE_DIALOGUE_LINES = [
+interface BridgeDialogueLineDefinition {
+  id: keyof BridgeDialogueCopy['dialogue'];
+  conversationId: BridgeDialogueConversationId;
+  speakerId: BridgeDialogueSpeakerId;
+}
+
+const BRIDGE_DIALOGUE_LINE_DEFINITIONS = [
   {
     id: 'bridge.cicka.first_meet.01',
     conversationId: 'bridge.cicka.first_meet',
-    speaker: 'Prompt',
-    text: 'Sit near Cicka'
+    speakerId: 'prompt'
   },
   {
     id: 'bridge.cicka.first_meet.02',
     conversationId: 'bridge.cicka.first_meet',
-    speaker: 'Cicka',
-    text: 'Small chirp.'
+    speakerId: 'cicka'
   },
   {
     id: 'bridge.cicka.first_meet.03',
     conversationId: 'bridge.cicka.first_meet',
-    speaker: 'Prompt',
-    text: 'Cicka bats the tiny car back into place.'
+    speakerId: 'prompt'
   },
   {
     id: 'bridge.draftsperson.missing_span.01',
     conversationId: 'bridge.draftsperson.missing_span',
-    speaker: 'Bridge Draftsperson',
-    text: 'The middle span keeps looking brave until I imagine someone crossing it.'
+    speakerId: 'bridgeDraftsperson'
   },
   {
     id: 'bridge.draftsperson.missing_span.02',
     conversationId: 'bridge.draftsperson.missing_span',
-    speaker: 'Bridge Draftsperson',
-    text: 'I had a tiny test car for this. It was here a minute ago.'
+    speakerId: 'bridgeDraftsperson'
   },
   {
     id: 'bridge.draftsperson.missing_span.03',
     conversationId: 'bridge.draftsperson.missing_span',
-    speaker: 'Prompt',
-    text: 'Look for the tiny test car'
+    speakerId: 'prompt'
   },
   {
     id: 'bridge.cicka.parallel_play.01',
     conversationId: 'bridge.cicka.parallel_play',
-    speaker: 'Prompt',
-    text: 'Sit with Cicka'
+    speakerId: 'prompt'
   },
   {
     id: 'bridge.cicka.parallel_play.02',
     conversationId: 'bridge.cicka.parallel_play',
-    speaker: 'Prompt',
-    text: 'Roll the car back gently'
+    speakerId: 'prompt'
   },
   {
     id: 'bridge.cicka.parallel_play.03',
     conversationId: 'bridge.cicka.parallel_play',
-    speaker: 'Cicka',
-    text: 'Quiet purr.'
+    speakerId: 'cicka'
   },
   {
     id: 'bridge.cicka.parallel_play.04',
     conversationId: 'bridge.cicka.parallel_play',
-    speaker: 'Prompt',
-    text: 'Cicka leaves the tiny car beside you.'
+    speakerId: 'prompt'
   },
   {
     id: 'bridge.draftsperson.toy_car_test.01',
     conversationId: 'bridge.draftsperson.toy_car_test',
-    speaker: 'Prompt',
-    text: 'Set the tiny car on the drawing'
+    speakerId: 'prompt'
   },
   {
     id: 'bridge.draftsperson.toy_car_test.02',
     conversationId: 'bridge.draftsperson.toy_car_test',
-    speaker: 'Bridge Draftsperson',
-    text: 'If it can carry this much courage, maybe it can carry us.'
+    speakerId: 'bridgeDraftsperson'
   },
   {
     id: 'bridge.draftsperson.toy_car_test.03',
     conversationId: 'bridge.draftsperson.toy_car_test',
-    speaker: 'Prompt',
-    text: 'The toy car rolls across the new span.'
+    speakerId: 'prompt'
   },
   {
     id: 'bridge.draftsperson.toy_car_test.04',
     conversationId: 'bridge.draftsperson.toy_car_test',
-    speaker: 'Bridge Draftsperson',
-    text: 'That line holds. The bridge knows it now.'
+    speakerId: 'bridgeDraftsperson'
   },
   {
     id: 'bridge.exit.opened_crossing.01',
     conversationId: 'bridge.exit.opened_crossing',
-    speaker: 'Prompt',
-    text: 'Cross the finished bridge'
+    speakerId: 'prompt'
   },
   {
     id: 'bridge.exit.opened_crossing.02',
     conversationId: 'bridge.exit.opened_crossing',
-    speaker: 'Bridge Draftsperson',
-    text: 'Thank you. I think I can leave this line alone now.'
+    speakerId: 'bridgeDraftsperson'
   },
   {
     id: 'bridge.exit.opened_crossing.03',
     conversationId: 'bridge.exit.opened_crossing',
-    speaker: 'Prompt',
-    text: 'The page turns toward evening music.'
+    speakerId: 'prompt'
   }
-] as const satisfies readonly BridgeDialogueLine[];
+] as const satisfies readonly BridgeDialogueLineDefinition[];
 
-export type BridgeDialogueLineId = (typeof BRIDGE_DIALOGUE_LINES)[number]['id'];
+export type BridgeDialogueLineId =
+  (typeof BRIDGE_DIALOGUE_LINE_DEFINITIONS)[number]['id'];
 
-const BRIDGE_DIALOGUE_BY_ID = new Map<BridgeDialogueLineId, BridgeDialogueLine>(
-  BRIDGE_DIALOGUE_LINES.map((line) => [line.id, line])
+const BRIDGE_DIALOGUE_BY_ID = new Map<
+  BridgeDialogueLineId,
+  (typeof BRIDGE_DIALOGUE_LINE_DEFINITIONS)[number]
+>(
+  BRIDGE_DIALOGUE_LINE_DEFINITIONS.map((line) => [line.id, line])
 );
 
 export function getBridgeDialogueLine(id: BridgeDialogueLineId): BridgeDialogueLine {
-  const line = BRIDGE_DIALOGUE_BY_ID.get(id);
-  if (!line) {
+  const lineDefinition = BRIDGE_DIALOGUE_BY_ID.get(id);
+  if (!lineDefinition) {
     throw new Error(`Unknown Bridge dialogue line: ${id}`);
   }
-  return line;
+  const bridgeCopy = getMessages().scenes.ridge.bridge;
+  return {
+    id: lineDefinition.id,
+    conversationId: lineDefinition.conversationId,
+    speakerId: lineDefinition.speakerId,
+    speaker: bridgeCopy.speakers[lineDefinition.speakerId],
+    text: bridgeCopy.dialogue[lineDefinition.id]
+  };
 }
 
 export function getBridgeDialogueLines(
   conversationId: BridgeDialogueConversationId
 ): BridgeDialogueLine[] {
-  return BRIDGE_DIALOGUE_LINES.filter(
+  return BRIDGE_DIALOGUE_LINE_DEFINITIONS.filter(
     (line) => line.conversationId === conversationId
-  );
+  ).map((line) => getBridgeDialogueLine(line.id));
 }
 
 export function getBridgePromptText(id: BridgeDialogueLineId): string {

--- a/src/game/scenes/ridge/dialogue/bridgeDialogue.ts
+++ b/src/game/scenes/ridge/dialogue/bridgeDialogue.ts
@@ -1,0 +1,150 @@
+export const BRIDGE_DIALOGUE_CONVERSATION_IDS = [
+  'bridge.cicka.first_meet',
+  'bridge.draftsperson.missing_span',
+  'bridge.cicka.parallel_play',
+  'bridge.draftsperson.toy_car_test',
+  'bridge.exit.opened_crossing'
+] as const;
+
+export type BridgeDialogueConversationId =
+  (typeof BRIDGE_DIALOGUE_CONVERSATION_IDS)[number];
+
+export type BridgeDialogueSpeaker = 'Prompt' | 'Cicka' | 'Bridge Draftsperson';
+
+export interface BridgeDialogueLine {
+  id: string;
+  conversationId: BridgeDialogueConversationId;
+  speaker: BridgeDialogueSpeaker;
+  text: string;
+}
+
+const BRIDGE_DIALOGUE_LINES = [
+  {
+    id: 'bridge.cicka.first_meet.01',
+    conversationId: 'bridge.cicka.first_meet',
+    speaker: 'Prompt',
+    text: 'Sit near Cicka'
+  },
+  {
+    id: 'bridge.cicka.first_meet.02',
+    conversationId: 'bridge.cicka.first_meet',
+    speaker: 'Cicka',
+    text: 'Small chirp.'
+  },
+  {
+    id: 'bridge.cicka.first_meet.03',
+    conversationId: 'bridge.cicka.first_meet',
+    speaker: 'Prompt',
+    text: 'Cicka bats the tiny car back into place.'
+  },
+  {
+    id: 'bridge.draftsperson.missing_span.01',
+    conversationId: 'bridge.draftsperson.missing_span',
+    speaker: 'Bridge Draftsperson',
+    text: 'The middle span keeps looking brave until I imagine someone crossing it.'
+  },
+  {
+    id: 'bridge.draftsperson.missing_span.02',
+    conversationId: 'bridge.draftsperson.missing_span',
+    speaker: 'Bridge Draftsperson',
+    text: 'I had a tiny test car for this. It was here a minute ago.'
+  },
+  {
+    id: 'bridge.draftsperson.missing_span.03',
+    conversationId: 'bridge.draftsperson.missing_span',
+    speaker: 'Prompt',
+    text: 'Look for the tiny test car'
+  },
+  {
+    id: 'bridge.cicka.parallel_play.01',
+    conversationId: 'bridge.cicka.parallel_play',
+    speaker: 'Prompt',
+    text: 'Sit with Cicka'
+  },
+  {
+    id: 'bridge.cicka.parallel_play.02',
+    conversationId: 'bridge.cicka.parallel_play',
+    speaker: 'Prompt',
+    text: 'Roll the car back gently'
+  },
+  {
+    id: 'bridge.cicka.parallel_play.03',
+    conversationId: 'bridge.cicka.parallel_play',
+    speaker: 'Cicka',
+    text: 'Quiet purr.'
+  },
+  {
+    id: 'bridge.cicka.parallel_play.04',
+    conversationId: 'bridge.cicka.parallel_play',
+    speaker: 'Prompt',
+    text: 'Cicka leaves the tiny car beside you.'
+  },
+  {
+    id: 'bridge.draftsperson.toy_car_test.01',
+    conversationId: 'bridge.draftsperson.toy_car_test',
+    speaker: 'Prompt',
+    text: 'Set the tiny car on the drawing'
+  },
+  {
+    id: 'bridge.draftsperson.toy_car_test.02',
+    conversationId: 'bridge.draftsperson.toy_car_test',
+    speaker: 'Bridge Draftsperson',
+    text: 'If it can carry this much courage, maybe it can carry us.'
+  },
+  {
+    id: 'bridge.draftsperson.toy_car_test.03',
+    conversationId: 'bridge.draftsperson.toy_car_test',
+    speaker: 'Prompt',
+    text: 'The toy car rolls across the new span.'
+  },
+  {
+    id: 'bridge.draftsperson.toy_car_test.04',
+    conversationId: 'bridge.draftsperson.toy_car_test',
+    speaker: 'Bridge Draftsperson',
+    text: 'That line holds. The bridge knows it now.'
+  },
+  {
+    id: 'bridge.exit.opened_crossing.01',
+    conversationId: 'bridge.exit.opened_crossing',
+    speaker: 'Prompt',
+    text: 'Cross the finished bridge'
+  },
+  {
+    id: 'bridge.exit.opened_crossing.02',
+    conversationId: 'bridge.exit.opened_crossing',
+    speaker: 'Bridge Draftsperson',
+    text: 'Thank you. I think I can leave this line alone now.'
+  },
+  {
+    id: 'bridge.exit.opened_crossing.03',
+    conversationId: 'bridge.exit.opened_crossing',
+    speaker: 'Prompt',
+    text: 'The page turns toward evening music.'
+  }
+] as const satisfies readonly BridgeDialogueLine[];
+
+export type BridgeDialogueLineId = (typeof BRIDGE_DIALOGUE_LINES)[number]['id'];
+
+const BRIDGE_DIALOGUE_BY_ID = new Map<BridgeDialogueLineId, BridgeDialogueLine>(
+  BRIDGE_DIALOGUE_LINES.map((line) => [line.id, line])
+);
+
+export function getBridgeDialogueLine(id: BridgeDialogueLineId): BridgeDialogueLine {
+  const line = BRIDGE_DIALOGUE_BY_ID.get(id);
+  if (!line) {
+    throw new Error(`Unknown Bridge dialogue line: ${id}`);
+  }
+  return line;
+}
+
+export function getBridgeDialogueLines(
+  conversationId: BridgeDialogueConversationId
+): BridgeDialogueLine[] {
+  return BRIDGE_DIALOGUE_LINES.filter(
+    (line) => line.conversationId === conversationId
+  );
+}
+
+export function getBridgePromptText(id: BridgeDialogueLineId): string {
+  return getBridgeDialogueLine(id).text;
+}

--- a/src/game/scenes/ridge/runtime/BridgeTracerStageRuntime.ts
+++ b/src/game/scenes/ridge/runtime/BridgeTracerStageRuntime.ts
@@ -148,10 +148,9 @@ class BridgeTracerStageRuntimeImpl implements BridgeTracerStageRuntime {
     player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody
   ): void {
     const crossingOpen = isBridgeCrossingOpen(bridgeBeat);
-    const drawingVisible = bridgeBeat === 'testing_bridge' || crossingOpen;
 
     this.setVisible(this.blockedBridgeObjects, !crossingOpen);
-    this.setVisible(this.completedBridgeObjects, drawingVisible);
+    this.setVisible(this.completedBridgeObjects, crossingOpen);
     this.syncBridgePhysics(crossingOpen, player);
     this.syncCickaAndToyCar(bridgeBeat);
     this.handoffNote?.setVisible(bridgeBeat === 'concert_handoff');
@@ -164,6 +163,7 @@ class BridgeTracerStageRuntimeImpl implements BridgeTracerStageRuntime {
     if (this.toyCarTestRunning) return false;
     this.toyCarTestRunning = true;
     this.showDialogue(lineIds, BRIDGE_DIALOGUE_DURATION_MS + BRIDGE_TEST_DURATION_MS);
+    this.setVisible(this.completedBridgeObjects, true);
 
     if (!this.toyCar) {
       this.toyCarTestRunning = false;

--- a/src/game/scenes/ridge/runtime/BridgeTracerStageRuntime.ts
+++ b/src/game/scenes/ridge/runtime/BridgeTracerStageRuntime.ts
@@ -4,6 +4,7 @@ import {
   GAME_DESIGN_WIDTH
 } from '@/game/sharedSceneRuntime/config';
 import { createUiText } from '@/game/sharedSceneRuntime/text/createUiText';
+import { getMessages } from '@/shared/i18n';
 import {
   CICKA_ANIMATION_KEYS,
   CICKA_FRAME_INDEX,
@@ -130,7 +131,7 @@ class BridgeTracerStageRuntimeImpl implements BridgeTracerStageRuntime {
     if (!this.dialogueContainer || !this.dialogueText) return;
     const text = lineIds.map((id) => {
       const line = getBridgeDialogueLine(id);
-      return line.speaker === 'Prompt'
+      return line.speakerId === 'prompt'
         ? line.text
         : `${line.speaker}: ${line.text}`;
     }).join('\n');
@@ -398,7 +399,7 @@ class BridgeTracerStageRuntimeImpl implements BridgeTracerStageRuntime {
       this.scene,
       BRIDGE_TRACER_WORLD.exit.x + 70,
       BRIDGE_TRACER_WORLD.exit.y - 130,
-      'evening music ahead',
+      getMessages().scenes.ridge.bridge.handoffNote,
       {
         fontSize: '14px',
         color: '#1a1a1a',

--- a/src/game/scenes/ridge/runtime/BridgeTracerStageRuntime.ts
+++ b/src/game/scenes/ridge/runtime/BridgeTracerStageRuntime.ts
@@ -1,0 +1,572 @@
+import * as Phaser from 'phaser';
+import type { RidgeBridgeBeatState } from '@/game/bridge/store';
+import {
+  GAME_DESIGN_WIDTH
+} from '@/game/sharedSceneRuntime/config';
+import { createUiText } from '@/game/sharedSceneRuntime/text/createUiText';
+import {
+  CICKA_ANIMATION_KEYS,
+  CICKA_FRAME_INDEX,
+  CICKA_ORIGIN,
+  CICKA_RUNTIME_SCALE,
+  CICKA_TEXTURE_KEY
+} from '../cicka/assets';
+import {
+  getBridgeDialogueLine,
+  getBridgePromptText,
+  type BridgeDialogueLineId
+} from '../dialogue/bridgeDialogue';
+import {
+  BRIDGE_TRACER_WORLD,
+  hasCickaSharedToyCar,
+  isBridgeCrossingOpen,
+  type BridgeTracerInteractionTarget
+} from './bridgeTracerSlice';
+
+type VisibleGameObject = Phaser.GameObjects.GameObject & {
+  setVisible(visible: boolean): VisibleGameObject;
+};
+
+const BRIDGE_GROUND_COLLIDER_HEIGHT = 24;
+const BRIDGE_DIALOGUE_DURATION_MS = 5600;
+const BRIDGE_TEST_DURATION_MS = 1900;
+const BRIDGE_DIALOGUE_PANEL_WIDTH = 460;
+const BRIDGE_DIALOGUE_TEXT_WIDTH = 418;
+
+export interface BridgeTracerStageRuntime {
+  readonly platforms: readonly Phaser.GameObjects.Zone[];
+  dispose(): void;
+  hidePrompt(): void;
+  showPrompt(target: BridgeTracerInteractionTarget, x: number, y: number): void;
+  showDialogue(lineIds: readonly BridgeDialogueLineId[], durationMs?: number): void;
+  syncBeat(
+    bridgeBeat: RidgeBridgeBeatState,
+    player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody
+  ): void;
+  runToyCarTest(
+    lineIds: readonly BridgeDialogueLineId[],
+    onComplete: () => void
+  ): boolean;
+}
+
+export function createBridgeTracerStageRuntime(
+  scene: Phaser.Scene
+): BridgeTracerStageRuntime {
+  const stage = new BridgeTracerStageRuntimeImpl(scene);
+  stage.create();
+  return stage;
+}
+
+class BridgeTracerStageRuntimeImpl implements BridgeTracerStageRuntime {
+  private readonly scene: Phaser.Scene;
+  private readonly groundPlatforms: Phaser.GameObjects.Zone[] = [];
+  private bridgeSpanCollider?: Phaser.GameObjects.Zone;
+  private bridgeBlockerCollider?: Phaser.GameObjects.Zone;
+  private blockedBridgeObjects: VisibleGameObject[] = [];
+  private completedBridgeObjects: VisibleGameObject[] = [];
+  private cickaSprite?: Phaser.GameObjects.Sprite;
+  private cickaShadow?: Phaser.GameObjects.Ellipse;
+  private toyCar?: Phaser.GameObjects.Container;
+  private handoffNote?: Phaser.GameObjects.Text;
+  private interactPrompt?: Phaser.GameObjects.Text;
+  private dialogueContainer?: Phaser.GameObjects.Container;
+  private dialogueText?: Phaser.GameObjects.Text;
+  private dialogueHideEvent?: Phaser.Time.TimerEvent;
+  private toyCarTween?: Phaser.Tweens.Tween;
+  private toyCarTestRunning = false;
+
+  constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+  }
+
+  get platforms(): readonly Phaser.GameObjects.Zone[] {
+    return this.groundPlatforms;
+  }
+
+  create(): void {
+    this.scene.add.rectangle(
+      BRIDGE_TRACER_WORLD.bounds.width / 2,
+      BRIDGE_TRACER_WORLD.bounds.height / 2,
+      BRIDGE_TRACER_WORLD.bounds.width,
+      BRIDGE_TRACER_WORLD.bounds.height,
+      0xf7f1df,
+      1
+    ).setDepth(-100);
+
+    this.addBackdropInk();
+    this.createBridgeGround();
+    this.createCickaPlaySpot();
+    this.createBridgeDraftsperson();
+    this.createBridgeCrossingVisuals();
+    this.createConcertHandoffNote();
+    this.createInteractionPrompt();
+    this.createDialoguePanel();
+  }
+
+  dispose(): void {
+    this.dialogueHideEvent?.remove(false);
+    this.dialogueHideEvent = undefined;
+    this.toyCarTween?.stop();
+    this.toyCarTween = undefined;
+    this.toyCarTestRunning = false;
+  }
+
+  hidePrompt(): void {
+    this.interactPrompt?.setVisible(false);
+  }
+
+  showPrompt(target: BridgeTracerInteractionTarget, x: number, y: number): void {
+    const prompt = getBridgePromptText(target.promptLineId);
+    this.interactPrompt
+      ?.setText(`[E] ${prompt}`)
+      .setPosition(x, y)
+      .setVisible(true);
+  }
+
+  showDialogue(
+    lineIds: readonly BridgeDialogueLineId[],
+    durationMs: number = BRIDGE_DIALOGUE_DURATION_MS
+  ): void {
+    if (!this.dialogueContainer || !this.dialogueText) return;
+    const text = lineIds.map((id) => {
+      const line = getBridgeDialogueLine(id);
+      return line.speaker === 'Prompt'
+        ? line.text
+        : `${line.speaker}: ${line.text}`;
+    }).join('\n');
+
+    this.dialogueText.setText(text);
+    this.dialogueContainer.setVisible(true);
+    this.dialogueHideEvent?.remove(false);
+    this.dialogueHideEvent = this.scene.time.delayedCall(durationMs, () => {
+      this.dialogueContainer?.setVisible(false);
+    });
+  }
+
+  syncBeat(
+    bridgeBeat: RidgeBridgeBeatState,
+    player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody
+  ): void {
+    const crossingOpen = isBridgeCrossingOpen(bridgeBeat);
+    const drawingVisible = bridgeBeat === 'testing_bridge' || crossingOpen;
+
+    this.setVisible(this.blockedBridgeObjects, !crossingOpen);
+    this.setVisible(this.completedBridgeObjects, drawingVisible);
+    this.syncBridgePhysics(crossingOpen, player);
+    this.syncCickaAndToyCar(bridgeBeat);
+    this.handoffNote?.setVisible(bridgeBeat === 'concert_handoff');
+  }
+
+  runToyCarTest(
+    lineIds: readonly BridgeDialogueLineId[],
+    onComplete: () => void
+  ): boolean {
+    if (this.toyCarTestRunning) return false;
+    this.toyCarTestRunning = true;
+    this.showDialogue(lineIds, BRIDGE_DIALOGUE_DURATION_MS + BRIDGE_TEST_DURATION_MS);
+
+    if (!this.toyCar) {
+      this.toyCarTestRunning = false;
+      onComplete();
+      return true;
+    }
+
+    this.toyCar.setVisible(true);
+    this.toyCar.setPosition(
+      BRIDGE_TRACER_WORLD.blueprint.x - 22,
+      BRIDGE_TRACER_WORLD.blueprint.y + 44
+    );
+    this.toyCarTween?.stop();
+    this.toyCarTween = this.scene.tweens.add({
+      targets: this.toyCar,
+      x: BRIDGE_TRACER_WORLD.bridge.rightBankStartX + 120,
+      y: BRIDGE_TRACER_WORLD.floorY - 4,
+      duration: BRIDGE_TEST_DURATION_MS,
+      ease: 'Sine.easeInOut',
+      onComplete: () => {
+        this.toyCarTestRunning = false;
+        onComplete();
+        this.showDialogue(['bridge.draftsperson.toy_car_test.04'], 3600);
+      }
+    });
+    return true;
+  }
+
+  private addBackdropInk(): void {
+    const graphics = this.scene.add.graphics().setDepth(-80);
+    graphics.lineStyle(2, 0x1f1f1d, 0.06);
+    for (let y = 116; y < BRIDGE_TRACER_WORLD.bounds.height; y += 96) {
+      graphics.strokeLineShape(new Phaser.Geom.Line(0, y, BRIDGE_TRACER_WORLD.bounds.width, y));
+    }
+
+    graphics.lineStyle(4, 0x1f1f1d, 0.12);
+    graphics.beginPath();
+    graphics.moveTo(0, BRIDGE_TRACER_WORLD.floorY - 34);
+    graphics.lineTo(220, BRIDGE_TRACER_WORLD.floorY - 58);
+    graphics.lineTo(460, BRIDGE_TRACER_WORLD.floorY - 34);
+    graphics.lineTo(760, BRIDGE_TRACER_WORLD.floorY - 46);
+    graphics.strokePath();
+
+    for (let x = 180; x < 1000; x += 190) {
+      graphics.lineStyle(3, 0x1f1f1d, 0.12);
+      graphics.strokeTriangle(
+        x,
+        BRIDGE_TRACER_WORLD.floorY - 72,
+        x - 34,
+        BRIDGE_TRACER_WORLD.floorY - 14,
+        x + 40,
+        BRIDGE_TRACER_WORLD.floorY - 14
+      );
+      graphics.lineStyle(2, 0x1f1f1d, 0.1);
+      graphics.strokeLineShape(new Phaser.Geom.Line(
+        x,
+        BRIDGE_TRACER_WORLD.floorY - 54,
+        x,
+        BRIDGE_TRACER_WORLD.floorY - 12
+      ));
+    }
+
+    graphics.lineStyle(5, 0x1f1f1d, 0.14);
+    graphics.strokeLineShape(new Phaser.Geom.Line(1980, 332, 2060, 250));
+    graphics.strokeLineShape(new Phaser.Geom.Line(2060, 250, 2140, 332));
+    graphics.lineStyle(3, 0x1f1f1d, 0.1);
+    graphics.strokeLineShape(new Phaser.Geom.Line(2024, 292, 2094, 292));
+  }
+
+  private createBridgeGround(): void {
+    const { floorY, bridge, bounds } = BRIDGE_TRACER_WORLD;
+    const groundY = floorY + BRIDGE_GROUND_COLLIDER_HEIGHT / 2;
+
+    this.scene.add.rectangle(
+      bridge.leftBankEndX / 2,
+      floorY + 24,
+      bridge.leftBankEndX,
+      48,
+      0xf7f1df,
+      1
+    )
+      .setStrokeStyle(4, 0x1f1f1d, 0.8)
+      .setDepth(1);
+    this.scene.add.rectangle(
+      bridge.rightBankStartX + (bounds.width - bridge.rightBankStartX) / 2,
+      floorY + 24,
+      bounds.width - bridge.rightBankStartX,
+      48,
+      0xf7f1df,
+      1
+    )
+      .setStrokeStyle(4, 0x1f1f1d, 0.8)
+      .setDepth(1);
+
+    this.addHatching(40, floorY + 8, bridge.leftBankEndX - 80, 34, 14, 0.12);
+    this.addHatching(
+      bridge.rightBankStartX + 34,
+      floorY + 8,
+      bounds.width - bridge.rightBankStartX - 80,
+      34,
+      14,
+      0.12
+    );
+
+    this.groundPlatforms.push(
+      this.addStaticZone(
+        bridge.leftBankEndX / 2,
+        groundY,
+        bridge.leftBankEndX,
+        BRIDGE_GROUND_COLLIDER_HEIGHT
+      ),
+      this.addStaticZone(
+        bridge.rightBankStartX + (bounds.width - bridge.rightBankStartX) / 2,
+        groundY,
+        bounds.width - bridge.rightBankStartX,
+        BRIDGE_GROUND_COLLIDER_HEIGHT
+      )
+    );
+  }
+
+  private createCickaPlaySpot(): void {
+    const { cickaPlaySpot } = BRIDGE_TRACER_WORLD;
+    this.cickaShadow = this.scene.add.ellipse(
+      cickaPlaySpot.x,
+      cickaPlaySpot.y + 8,
+      92,
+      18,
+      0x1f1f1d,
+      0.12
+    ).setDepth(15);
+    this.cickaSprite = this.scene.add.sprite(
+      cickaPlaySpot.x,
+      cickaPlaySpot.y,
+      CICKA_TEXTURE_KEY,
+      CICKA_FRAME_INDEX.perchSit
+    )
+      .setOrigin(CICKA_ORIGIN.x, CICKA_ORIGIN.y)
+      .setScale(CICKA_RUNTIME_SCALE)
+      .setDepth(26);
+    this.cickaSprite.play(CICKA_ANIMATION_KEYS.perchIdle);
+    this.toyCar = this.createToyCar(cickaPlaySpot.x + 66, cickaPlaySpot.y + 8);
+  }
+
+  private createBridgeDraftsperson(): void {
+    const { draftsperson, blueprint } = BRIDGE_TRACER_WORLD;
+    this.scene.add.ellipse(draftsperson.x, draftsperson.y + 10, 80, 18, 0x1f1f1d, 0.1).setDepth(14);
+    this.scene.add.rectangle(draftsperson.x, draftsperson.y - 40, 38, 62, 0xf7f1df, 1)
+      .setStrokeStyle(4, 0x1f1f1d, 0.86)
+      .setDepth(21);
+    this.scene.add.circle(draftsperson.x, draftsperson.y - 82, 26, 0xf7f1df, 1)
+      .setStrokeStyle(4, 0x1f1f1d, 0.9)
+      .setDepth(22);
+    this.scene.add.line(draftsperson.x + 6, draftsperson.y - 87, -6, 0, 6, 0, 0x1f1f1d, 0.8)
+      .setLineWidth(3)
+      .setDepth(23);
+    this.scene.add.line(draftsperson.x - 16, draftsperson.y - 90, -5, -4, 5, 4, 0x1f1f1d, 0.65)
+      .setLineWidth(2)
+      .setDepth(23);
+    this.scene.add.line(draftsperson.x + 16, draftsperson.y - 90, -5, 4, 5, -4, 0x1f1f1d, 0.65)
+      .setLineWidth(2)
+      .setDepth(23);
+
+    this.scene.add.rectangle(blueprint.x, blueprint.y, 184, 116, 0xf7f1df, 1)
+      .setStrokeStyle(4, 0x1f1f1d, 0.82)
+      .setAngle(-2)
+      .setDepth(12);
+    this.scene.add.line(blueprint.x - 48, blueprint.y - 6, -54, 0, -12, -18, 0x1f1f1d, 0.7)
+      .setLineWidth(4)
+      .setDepth(13);
+    this.scene.add.line(blueprint.x + 42, blueprint.y - 2, 10, -18, 54, 2, 0x1f1f1d, 0.7)
+      .setLineWidth(4)
+      .setDepth(13);
+    this.completedBridgeObjects.push(this.asVisible(this.scene.add.line(
+      blueprint.x,
+      blueprint.y - 13,
+      -26,
+      -6,
+      26,
+      6,
+      0x1f1f1d,
+      0.86
+    ).setLineWidth(4).setDepth(14)));
+    this.addHatching(blueprint.x - 74, blueprint.y + 28, 142, 24, 11, 0.1);
+  }
+
+  private createBridgeCrossingVisuals(): void {
+    const { bridge, floorY } = BRIDGE_TRACER_WORLD;
+    this.scene.add.rectangle(bridge.leftBankEndX - 18, floorY - 22, 34, 88, 0xf7f1df, 1)
+      .setStrokeStyle(4, 0x1f1f1d, 0.84)
+      .setDepth(5);
+    this.scene.add.rectangle(bridge.rightBankStartX + 18, floorY - 22, 34, 88, 0xf7f1df, 1)
+      .setStrokeStyle(4, 0x1f1f1d, 0.84)
+      .setDepth(5);
+
+    this.blockedBridgeObjects.push(
+      this.asVisible(this.scene.add.rectangle(bridge.centerX, floorY - 40, 220, 44, 0xf7f1df, 0.7)
+        .setStrokeStyle(3, 0x1f1f1d, 0.45)
+        .setDepth(6)),
+      this.asVisible(this.scene.add.line(bridge.centerX - 58, floorY - 42, -38, -22, 38, 22, 0x1f1f1d, 0.72)
+        .setLineWidth(5)
+        .setDepth(7)),
+      this.asVisible(this.scene.add.line(bridge.centerX + 58, floorY - 42, -38, 22, 38, -22, 0x1f1f1d, 0.72)
+        .setLineWidth(5)
+        .setDepth(7))
+    );
+
+    const deck = this.scene.add.rectangle(
+      bridge.centerX,
+      bridge.deckY - 12,
+      bridge.deckWidth,
+      24,
+      0xf7f1df,
+      1
+    )
+      .setStrokeStyle(5, 0x1f1f1d, 0.9)
+      .setDepth(8);
+    const topLine = this.scene.add.line(bridge.centerX, bridge.deckY - 30, -130, 0, 130, 0, 0x1f1f1d, 0.62)
+      .setLineWidth(3)
+      .setDepth(9);
+    const bottomLine = this.scene.add.line(bridge.centerX, bridge.deckY + 2, -128, 0, 128, 0, 0x1f1f1d, 0.36)
+      .setLineWidth(2)
+      .setDepth(9);
+    this.completedBridgeObjects.push(
+      this.asVisible(deck),
+      this.asVisible(topLine),
+      this.asVisible(bottomLine)
+    );
+  }
+
+  private createConcertHandoffNote(): void {
+    this.handoffNote = createUiText(
+      this.scene,
+      BRIDGE_TRACER_WORLD.exit.x + 70,
+      BRIDGE_TRACER_WORLD.exit.y - 130,
+      'evening music ahead',
+      {
+        fontSize: '14px',
+        color: '#1a1a1a',
+        backgroundColor: '#f7f1df',
+        padding: { x: 6, y: 3 }
+      }
+    )
+      .setOrigin(0.5)
+      .setAngle(-2)
+      .setDepth(24)
+      .setVisible(false);
+  }
+
+  private createInteractionPrompt(): void {
+    this.interactPrompt?.destroy();
+    this.interactPrompt = createUiText(this.scene, 0, 0, '', {
+      fontSize: '15px',
+      color: '#1a1a1a',
+      backgroundColor: '#f7f1df',
+      padding: { x: 6, y: 3 }
+    })
+      .setOrigin(0.5)
+      .setDepth(100)
+      .setVisible(false);
+  }
+
+  private createDialoguePanel(): void {
+    const container = this.scene.add.container(GAME_DESIGN_WIDTH / 2, 78)
+      .setDepth(220)
+      .setScrollFactor(0)
+      .setVisible(false);
+    const panel = this.scene.add.rectangle(0, 0, BRIDGE_DIALOGUE_PANEL_WIDTH, 150, 0xf7f1df, 0.96)
+      .setStrokeStyle(4, 0x1f1f1d, 0.9);
+    const label = createUiText(this.scene, -210, -66, 'Bridge Tracer', {
+      fontSize: '12px',
+      color: '#4b4337'
+    }).setOrigin(0, 0.5);
+    const text = createUiText(this.scene, -210, -46, '', {
+      fontSize: '12px',
+      color: '#1a1a1a',
+      lineSpacing: 5,
+      wordWrap: { width: BRIDGE_DIALOGUE_TEXT_WIDTH }
+    }).setOrigin(0, 0);
+
+    container.add([panel, label, text]);
+    this.dialogueContainer = container;
+    this.dialogueText = text;
+  }
+
+  private syncBridgePhysics(
+    crossingOpen: boolean,
+    player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody
+  ): void {
+    if (crossingOpen) {
+      this.bridgeBlockerCollider?.destroy();
+      this.bridgeBlockerCollider = undefined;
+      if (!this.bridgeSpanCollider) {
+        this.bridgeSpanCollider = this.addStaticZone(
+          BRIDGE_TRACER_WORLD.bridge.centerX,
+          BRIDGE_TRACER_WORLD.floorY + BRIDGE_GROUND_COLLIDER_HEIGHT / 2,
+          BRIDGE_TRACER_WORLD.bridge.deckWidth,
+          BRIDGE_GROUND_COLLIDER_HEIGHT
+        );
+        if (player) {
+          this.scene.physics.add.collider(player, this.bridgeSpanCollider);
+        }
+      }
+      return;
+    }
+
+    this.bridgeSpanCollider?.destroy();
+    this.bridgeSpanCollider = undefined;
+    if (!this.bridgeBlockerCollider) {
+      this.bridgeBlockerCollider = this.addStaticZone(
+        BRIDGE_TRACER_WORLD.bridge.leftBankEndX - 22,
+        BRIDGE_TRACER_WORLD.floorY - 58,
+        34,
+        126
+      );
+      if (player) {
+        this.scene.physics.add.collider(player, this.bridgeBlockerCollider);
+      }
+    }
+  }
+
+  private syncCickaAndToyCar(bridgeBeat: RidgeBridgeBeatState): void {
+    const crossingOpen = isBridgeCrossingOpen(bridgeBeat);
+    const cickaSpot = crossingOpen
+      ? BRIDGE_TRACER_WORLD.cickaSettledSpot
+      : BRIDGE_TRACER_WORLD.cickaPlaySpot;
+    this.cickaSprite?.setPosition(cickaSpot.x, cickaSpot.y);
+    this.cickaShadow?.setPosition(cickaSpot.x, cickaSpot.y + 8);
+
+    if (!this.toyCar || this.toyCarTestRunning) return;
+
+    if (!hasCickaSharedToyCar(bridgeBeat)) {
+      this.toyCar.setVisible(true);
+      this.toyCar.setPosition(
+        BRIDGE_TRACER_WORLD.cickaPlaySpot.x + 66,
+        BRIDGE_TRACER_WORLD.cickaPlaySpot.y + 8
+      );
+      return;
+    }
+
+    if (bridgeBeat === 'toy_car_shared') {
+      this.toyCar.setVisible(true);
+      this.toyCar.setPosition(
+        BRIDGE_TRACER_WORLD.blueprint.x - 22,
+        BRIDGE_TRACER_WORLD.blueprint.y + 44
+      );
+      return;
+    }
+
+    this.toyCar.setVisible(true);
+    this.toyCar.setPosition(
+      BRIDGE_TRACER_WORLD.bridge.rightBankStartX + 120,
+      BRIDGE_TRACER_WORLD.floorY - 4
+    );
+  }
+
+  private createToyCar(x: number, y: number): Phaser.GameObjects.Container {
+    const container = this.scene.add.container(x, y).setDepth(25);
+    const body = this.scene.add.rectangle(0, -7, 48, 20, 0xf7f1df, 1)
+      .setStrokeStyle(3, 0x1f1f1d, 0.88);
+    const roof = this.scene.add.rectangle(-4, -20, 24, 14, 0xf7f1df, 1)
+      .setStrokeStyle(2, 0x1f1f1d, 0.72);
+    const wheelLeft = this.scene.add.circle(-15, 6, 6, 0x1f1f1d, 0.9);
+    const wheelRight = this.scene.add.circle(16, 6, 6, 0x1f1f1d, 0.9);
+    container.add([body, roof, wheelLeft, wheelRight]);
+    return container;
+  }
+
+  private addHatching(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    spacing: number,
+    alpha: number
+  ): void {
+    const graphics = this.scene.add.graphics().setDepth(4);
+    graphics.lineStyle(2, 0x1f1f1d, alpha);
+    for (let offset = 0; offset <= width + height; offset += spacing) {
+      graphics.strokeLineShape(new Phaser.Geom.Line(
+        x + offset,
+        y,
+        x + offset - height,
+        y + height
+      ));
+    }
+  }
+
+  private addStaticZone(
+    x: number,
+    y: number,
+    width: number,
+    height: number
+  ): Phaser.GameObjects.Zone {
+    const zone = this.scene.add.zone(x, y, width, height);
+    this.scene.physics.add.existing(zone, true);
+    return zone;
+  }
+
+  private asVisible<GameObject extends VisibleGameObject>(gameObject: GameObject): GameObject {
+    return gameObject;
+  }
+
+  private setVisible(objects: readonly VisibleGameObject[], visible: boolean): void {
+    objects.forEach((object) => object.setVisible(visible));
+  }
+}

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -160,6 +160,8 @@ export class RidgeScene extends Phaser.Scene {
 
     if (interaction.effect) {
       this.handleBridgeInteractionEffect(interaction.effect);
+      this.syncDevRuntimeState();
+      return;
     }
 
     this.bridgeStage?.showPrompt(

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -1,12 +1,14 @@
 import * as Phaser from 'phaser';
-import { PHASER_SCENE_KEYS } from '@/game/scenes/sceneIds';
 import {
+  bridgeActions,
   bridgeStore,
   isItemEquipped,
-  type OpenOverlayOptions
+  type OpenOverlayOptions,
+  type RidgeBridgeBeatState,
+  type RidgeFirstPlayableRouteState
 } from '@/game/bridge/store';
-import { TRAIL_CARD_OVERLAY_ID, type OverlayId } from '@/game/overlays/overlayIds';
-import { getMessages } from '@/shared/i18n';
+import { type OverlayId } from '@/game/overlays/overlayIds';
+import { PHASER_SCENE_KEYS } from '@/game/scenes/sceneIds';
 import {
   GAME_DESIGN_HEIGHT,
   GAME_DESIGN_WIDTH,
@@ -16,56 +18,47 @@ import {
   SIDE_VIEW_WALK_SPEED
 } from '@/game/sharedSceneRuntime/config';
 import {
-  createSideViewPlayerRuntime,
-  type SideViewPlayerRuntime
-} from '@/game/sharedSceneRuntime/player/SideViewPlayerRuntime';
-import { TextureGenerator } from '@/game/sharedSceneRuntime/textures/TextureGenerator';
-import { createUiText } from '@/game/sharedSceneRuntime/text/createUiText';
-import {
   createInteriorInteractionRuntime,
   type InteriorInteractionRuntime
 } from '@/game/sharedSceneRuntime/interactions/InteriorInteractionRuntime';
 import {
-  RIDGE_BLOCKOUT,
-  compileRidgeBlockoutFacts,
-  deriveRidgeBlockoutGeometry,
-  type RidgeBlockoutGeometry,
-  type RidgeBlockoutFacts
-} from '../blockout';
-import { getRidgeWorldMemories } from '../worldMemory';
+  createSideViewPlayerRuntime,
+  type SideViewPlayerRuntime
+} from '@/game/sharedSceneRuntime/player/SideViewPlayerRuntime';
+import { createUiText } from '@/game/sharedSceneRuntime/text/createUiText';
+import { TextureGenerator } from '@/game/sharedSceneRuntime/textures/TextureGenerator';
 import {
-  shouldShowCickaInteractionPrompt
-} from '../cicka/interaction';
+  CICKA_ANIMATION_KEYS,
+  CICKA_FRAME_INDEX,
+  CICKA_ORIGIN,
+  CICKA_RUNTIME_SCALE,
+  CICKA_TEXTURE_KEY
+} from '../cicka/assets';
 import {
   createCickaAnimations,
   preloadCickaAssets
 } from '../cicka/assets';
-import type { CickaPerch } from '../cicka/CickaPerch';
-import { resolveCickaHomeMutations } from '../cicka/homeMutations';
 import {
-  createRidgeTraversalRuntime,
-  type RidgeTraversalRuntime
-} from './ridgeTraversalRuntime';
+  getBridgeDialogueLine,
+  getBridgePromptText,
+  type BridgeDialogueLineId
+} from '../dialogue/bridgeDialogue';
 import {
   applyRidgeDevTeleportToPlayer,
   RIDGE_DEFAULT_CAMERA_ZOOM,
-  RIDGE_PLAYER_SPAWN_OFFSET_Y,
-  resolveRidgeDevDebugSettings,
   resolveRidgeDevCameraZoom,
   type RidgeDevControls
 } from './ridgeDevControls';
-import { createRidgeBlockoutPresentation } from './ridgeBlockoutPresentation';
-import { createRidgeLandmarkPresentation } from './ridgeLandmarkPresentation';
 import {
-  createRidgeDebugOverlay,
-  type RidgeDebugOverlay
-} from './ridgeDebugOverlay';
-import {
-  createRidgeInteractionTargets,
-  type RidgeInteractionEffect,
-  type RidgeInteractionTarget,
-  type RidgeInteractionTargetId
-} from './ridgeInteractionTargets';
+  BRIDGE_TRACER_INTERACT_RADIUS,
+  BRIDGE_TRACER_WORLD,
+  createBridgeTracerInteractionTargets,
+  hasCickaSharedToyCar,
+  isBridgeCrossingOpen,
+  type BridgeTracerEffect,
+  type BridgeTracerInteractionTarget,
+  type BridgeTracerTargetId
+} from './bridgeTracerSlice';
 
 interface RidgeSceneStartData {
   onClose?: () => void;
@@ -75,28 +68,50 @@ interface RidgeSceneStartData {
   ridgeDevControls?: RidgeDevControls;
 }
 
+type VisibleGameObject = Phaser.GameObjects.GameObject & {
+  setVisible(visible: boolean): VisibleGameObject;
+};
+
 const RIDGE_PLAYER_EDGE_PADDING = 48;
 const RIDGE_COYOTE_TIME_MS = 120;
 const RIDGE_JUMP_BUFFER_MS = 120;
+const BRIDGE_GROUND_COLLIDER_HEIGHT = 24;
+const BRIDGE_DIALOGUE_DURATION_MS = 5600;
+const BRIDGE_TEST_DURATION_MS = 1900;
+const BRIDGE_DIALOGUE_PANEL_WIDTH = 460;
+const BRIDGE_DIALOGUE_TEXT_WIDTH = 418;
 
 export class RidgeScene extends Phaser.Scene {
   player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
   interactPrompt?: Phaser.GameObjects.Text;
 
   private playerRuntime?: SideViewPlayerRuntime;
-  private traversalRuntime?: RidgeTraversalRuntime;
-  private interactionRuntime?: InteriorInteractionRuntime<RidgeInteractionTargetId, RidgeInteractionEffect>;
-  private cickaPerch?: CickaPerch;
+  private interactionRuntime?: InteriorInteractionRuntime<BridgeTracerTargetId, BridgeTracerEffect>;
   private onClose: () => void = () => {};
-  private onOpenOverlay?: (overlayId: OverlayId, options?: OpenOverlayOptions) => void;
   private isPaused = false;
   private resumePosition?: { x: number; y: number };
   private ridgeDevControls?: RidgeDevControls;
-  private currentGeometry?: RidgeBlockoutGeometry;
-  private ridgeInteractionTargets: RidgeInteractionTarget[] = [];
-  private ridgeDebugOverlay?: RidgeDebugOverlay;
-  private ridgeSpawnPosition?: { x: number; y: number };
+  private ridgeSpawnPosition = { ...BRIDGE_TRACER_WORLD.spawn };
   private lastCameraZoom = RIDGE_DEFAULT_CAMERA_ZOOM;
+  private routeState: RidgeFirstPlayableRouteState = {
+    activeAreaId: 'bridge',
+    bridgeBeat: 'intro'
+  };
+
+  private groundPlatforms: Phaser.GameObjects.Zone[] = [];
+  private bridgeSpanCollider?: Phaser.GameObjects.Zone;
+  private bridgeBlockerCollider?: Phaser.GameObjects.Zone;
+  private blockedBridgeObjects: VisibleGameObject[] = [];
+  private completedBridgeObjects: VisibleGameObject[] = [];
+  private cickaSprite?: Phaser.GameObjects.Sprite;
+  private cickaShadow?: Phaser.GameObjects.Ellipse;
+  private toyCar?: Phaser.GameObjects.Container;
+  private handoffNote?: Phaser.GameObjects.Text;
+  private dialogueContainer?: Phaser.GameObjects.Container;
+  private dialogueText?: Phaser.GameObjects.Text;
+  private dialogueHideEvent?: Phaser.Time.TimerEvent;
+  private toyCarTween?: Phaser.Tweens.Tween;
+  private toyCarTestRunning = false;
 
   constructor() {
     super(PHASER_SCENE_KEYS.ridge);
@@ -104,7 +119,6 @@ export class RidgeScene extends Phaser.Scene {
 
   init(data: RidgeSceneStartData = {}): void {
     this.onClose = data.onClose ?? (() => {});
-    this.onOpenOverlay = data.onOpenOverlay;
     this.isPaused = data.isPaused ?? false;
     this.resumePosition = data.resumePosition;
     this.ridgeDevControls = import.meta.env.DEV ? data.ridgeDevControls : undefined;
@@ -128,74 +142,34 @@ export class RidgeScene extends Phaser.Scene {
 
   create(data: RidgeSceneStartData = {}): void {
     this.onClose = data.onClose ?? this.onClose;
-    this.onOpenOverlay = data.onOpenOverlay ?? this.onOpenOverlay;
     this.ridgeDevControls = import.meta.env.DEV
       ? data.ridgeDevControls ?? this.ridgeDevControls
       : undefined;
-    const messages = getMessages();
-    const ridgeProgress = bridgeStore.getState().progress.ridge;
-    const blockout = RIDGE_BLOCKOUT;
-    const geometry = deriveRidgeBlockoutGeometry(blockout, {
-      stampIds: ridgeProgress.stampIds
-    });
-    this.currentGeometry = geometry;
-    this.ridgeInteractionTargets = [];
-    this.ridgeDebugOverlay?.destroy();
-    this.ridgeDebugOverlay = undefined;
-    const facts = compileRidgeBlockoutFacts(blockout, {
-      geometry
-    });
-    const cickaHomeMutations = resolveCickaHomeMutations(
-      facts.homeMutations,
-      ridgeProgress
-    );
-    this.traversalRuntime = undefined;
+    this.routeState = bridgeStore.getState().progress.ridge.firstPlayableRoute;
+    this.resetRuntimeObjects();
 
     this.cameras.main.setBackgroundColor('#f7f1df');
     this.physics.world.setBounds(
-      geometry.bounds.x,
-      geometry.bounds.y,
-      geometry.bounds.width,
-      geometry.bounds.height
+      BRIDGE_TRACER_WORLD.bounds.x,
+      BRIDGE_TRACER_WORLD.bounds.y,
+      BRIDGE_TRACER_WORLD.bounds.width,
+      BRIDGE_TRACER_WORLD.bounds.height
     );
     createCickaAnimations(this);
 
-    const blockoutPresentation = createRidgeBlockoutPresentation({
-      scene: this,
-      facts,
-      geometry
-    });
-    const landmarkPresentation = createRidgeLandmarkPresentation({
-      scene: this,
-      facts,
-      copy: {
-        title: messages.catalog.ridge.ridge.name,
-        stampedeFirstClearLabel: messages.scenes.ridge.memory.stampedeFirstClearLabel,
-        cickaWalkByLine: messages.scenes.ridge.memory.cickaWalkByBark
-      },
-      worldMemories: getRidgeWorldMemories(ridgeProgress),
-      cickaHomeMutations: cickaHomeMutations.active
-    });
-    this.cickaPerch = landmarkPresentation.cickaPerch;
-    this.createPlayer(blockoutPresentation.platforms, facts, geometry);
-    this.ridgeInteractionTargets = createRidgeInteractionTargets({
-      facts,
-      cickaPerch: this.cickaPerch,
-      cickaInteractionCopy: messages.scenes.ridge.cicka.interaction,
-      getWorldMemories: () => getRidgeWorldMemories(bridgeStore.getState().progress.ridge)
-    });
-    this.createRidgeInteractions(messages.navigation.interact, this.ridgeInteractionTargets);
+    this.createBridgeBlockoutStage();
+    this.createPlayer(this.groundPlatforms);
+    this.createDialoguePanel();
+    this.syncBridgeRouteState();
+    this.createBridgeInteractions();
     this.setPaused(this.isPaused);
     this.playerRuntime?.syncAppearance();
     this.syncDevRuntimeState();
   }
 
-  update(_time: number, delta: number): void {
+  update(): void {
     this.applyDevControls();
 
-    if (this.player) {
-      this.traversalRuntime?.primeGrounding(this.player);
-    }
     const playerUpdate = this.playerRuntime?.update();
     if (!playerUpdate || playerUpdate.paused) {
       this.syncDevRuntimeState();
@@ -208,77 +182,324 @@ export class RidgeScene extends Phaser.Scene {
       return;
     }
 
-    if (this.player) {
-      this.traversalRuntime?.update({
-        player: this.player,
-        commands: playerUpdate.commands,
-        deltaMs: delta
-      });
-    }
-
-    this.cickaPerch?.update({
-      playerX: this.player?.x ?? 0,
-      playerY: this.player?.y ?? 0,
-      nowMs: this.time.now
-    });
-
     const interaction = this.interactionRuntime?.update({
       playerX: this.player?.x ?? 0,
       playerY: this.player?.y ?? 0,
       interactRequested: playerUpdate.step.interactRequested,
-      exitRequested: playerUpdate.commands.exitContext
+      exitRequested: false
     });
 
-    if (!interaction) {
+    if (!interaction?.prompt.visible || !interaction.activeTarget) {
       this.interactPrompt?.setVisible(false);
       this.syncDevRuntimeState();
       return;
     }
 
-    if (interaction.effect?.kind === 'openTrailCard') {
-      this.onOpenOverlay?.(TRAIL_CARD_OVERLAY_ID, {
-        params: interaction.effect.params,
-        returnToSceneId: PHASER_SCENE_KEYS.ridge
-      });
-    } else if (interaction.effect?.kind === 'showCickaResponse') {
-      this.cickaPerch?.showLine(interaction.effect.response.line, this.time.now);
+    if (interaction.effect) {
+      this.handleBridgeInteractionEffect(interaction.effect);
     }
 
-    if (
-      !interaction.prompt.visible ||
-      !shouldShowCickaInteractionPrompt({
-        activeTargetId: interaction.activeTarget?.id ?? null,
-        responseVisible: this.cickaPerch?.isSpeechVisible(this.time.now) ?? false
-      })
-    ) {
-      this.interactPrompt?.setVisible(false);
-      this.syncDevRuntimeState();
-      return;
-    }
-
-    this.interactPrompt?.setPosition(interaction.prompt.x, interaction.prompt.y).setVisible(true);
+    this.showBridgePrompt(
+      interaction.activeTarget as BridgeTracerInteractionTarget,
+      interaction.prompt.x,
+      interaction.prompt.y
+    );
     this.syncDevRuntimeState();
   }
 
-  private createPlayer(
-    platforms: readonly Phaser.GameObjects.Zone[],
-    facts: RidgeBlockoutFacts,
-    geometry: RidgeBlockoutGeometry
-  ): void {
-    const spawn = facts.spawn;
-    this.ridgeSpawnPosition = {
-      x: spawn.x,
-      y: spawn.y + RIDGE_PLAYER_SPAWN_OFFSET_Y
-    };
+  private resetRuntimeObjects(): void {
+    this.groundPlatforms = [];
+    this.bridgeSpanCollider = undefined;
+    this.bridgeBlockerCollider = undefined;
+    this.blockedBridgeObjects = [];
+    this.completedBridgeObjects = [];
+    this.cickaSprite = undefined;
+    this.cickaShadow = undefined;
+    this.toyCar = undefined;
+    this.handoffNote = undefined;
+    this.dialogueContainer = undefined;
+    this.dialogueText = undefined;
+    this.dialogueHideEvent?.remove(false);
+    this.dialogueHideEvent = undefined;
+    this.toyCarTween?.stop();
+    this.toyCarTween = undefined;
+    this.toyCarTestRunning = false;
+  }
+
+  private createBridgeBlockoutStage(): void {
+    this.add.rectangle(
+      BRIDGE_TRACER_WORLD.bounds.width / 2,
+      BRIDGE_TRACER_WORLD.bounds.height / 2,
+      BRIDGE_TRACER_WORLD.bounds.width,
+      BRIDGE_TRACER_WORLD.bounds.height,
+      0xf7f1df,
+      1
+    ).setDepth(-100);
+
+    this.addBackdropInk();
+    this.createBridgeGround();
+    this.createCickaPlaySpot();
+    this.createBridgeDraftsperson();
+    this.createBridgeCrossingVisuals();
+    this.createConcertHandoffNote();
+    this.createInteractionPrompt();
+  }
+
+  private addBackdropInk(): void {
+    const graphics = this.add.graphics().setDepth(-80);
+    graphics.lineStyle(2, 0x1f1f1d, 0.06);
+    for (let y = 116; y < BRIDGE_TRACER_WORLD.bounds.height; y += 96) {
+      graphics.strokeLineShape(new Phaser.Geom.Line(0, y, BRIDGE_TRACER_WORLD.bounds.width, y));
+    }
+
+    graphics.lineStyle(4, 0x1f1f1d, 0.12);
+    graphics.beginPath();
+    graphics.moveTo(0, BRIDGE_TRACER_WORLD.floorY - 34);
+    graphics.lineTo(220, BRIDGE_TRACER_WORLD.floorY - 58);
+    graphics.lineTo(460, BRIDGE_TRACER_WORLD.floorY - 34);
+    graphics.lineTo(760, BRIDGE_TRACER_WORLD.floorY - 46);
+    graphics.strokePath();
+
+    for (let x = 180; x < 1000; x += 190) {
+      graphics.lineStyle(3, 0x1f1f1d, 0.12);
+      graphics.strokeTriangle(
+        x,
+        BRIDGE_TRACER_WORLD.floorY - 72,
+        x - 34,
+        BRIDGE_TRACER_WORLD.floorY - 14,
+        x + 40,
+        BRIDGE_TRACER_WORLD.floorY - 14
+      );
+      graphics.lineStyle(2, 0x1f1f1d, 0.1);
+      graphics.strokeLineShape(new Phaser.Geom.Line(
+        x,
+        BRIDGE_TRACER_WORLD.floorY - 54,
+        x,
+        BRIDGE_TRACER_WORLD.floorY - 12
+      ));
+    }
+
+    graphics.lineStyle(5, 0x1f1f1d, 0.14);
+    graphics.strokeLineShape(new Phaser.Geom.Line(1980, 332, 2060, 250));
+    graphics.strokeLineShape(new Phaser.Geom.Line(2060, 250, 2140, 332));
+    graphics.lineStyle(3, 0x1f1f1d, 0.1);
+    graphics.strokeLineShape(new Phaser.Geom.Line(2024, 292, 2094, 292));
+  }
+
+  private createBridgeGround(): void {
+    const { floorY, bridge, bounds } = BRIDGE_TRACER_WORLD;
+    const groundY = floorY + BRIDGE_GROUND_COLLIDER_HEIGHT / 2;
+
+    this.add.rectangle(
+      bridge.leftBankEndX / 2,
+      floorY + 24,
+      bridge.leftBankEndX,
+      48,
+      0xf7f1df,
+      1
+    )
+      .setStrokeStyle(4, 0x1f1f1d, 0.8)
+      .setDepth(1);
+    this.add.rectangle(
+      bridge.rightBankStartX + (bounds.width - bridge.rightBankStartX) / 2,
+      floorY + 24,
+      bounds.width - bridge.rightBankStartX,
+      48,
+      0xf7f1df,
+      1
+    )
+      .setStrokeStyle(4, 0x1f1f1d, 0.8)
+      .setDepth(1);
+
+    this.addHatching(40, floorY + 8, bridge.leftBankEndX - 80, 34, 14, 0.12);
+    this.addHatching(bridge.rightBankStartX + 34, floorY + 8, bounds.width - bridge.rightBankStartX - 80, 34, 14, 0.12);
+
+    this.groundPlatforms.push(
+      this.addStaticZone(bridge.leftBankEndX / 2, groundY, bridge.leftBankEndX, BRIDGE_GROUND_COLLIDER_HEIGHT),
+      this.addStaticZone(
+        bridge.rightBankStartX + (bounds.width - bridge.rightBankStartX) / 2,
+        groundY,
+        bounds.width - bridge.rightBankStartX,
+        BRIDGE_GROUND_COLLIDER_HEIGHT
+      )
+    );
+  }
+
+  private createCickaPlaySpot(): void {
+    const { cickaPlaySpot } = BRIDGE_TRACER_WORLD;
+    this.cickaShadow = this.add.ellipse(
+      cickaPlaySpot.x,
+      cickaPlaySpot.y + 8,
+      92,
+      18,
+      0x1f1f1d,
+      0.12
+    ).setDepth(15);
+    this.cickaSprite = this.add.sprite(
+      cickaPlaySpot.x,
+      cickaPlaySpot.y,
+      CICKA_TEXTURE_KEY,
+      CICKA_FRAME_INDEX.perchSit
+    )
+      .setOrigin(CICKA_ORIGIN.x, CICKA_ORIGIN.y)
+      .setScale(CICKA_RUNTIME_SCALE)
+      .setDepth(26);
+    this.cickaSprite.play(CICKA_ANIMATION_KEYS.perchIdle);
+    this.toyCar = this.createToyCar(cickaPlaySpot.x + 66, cickaPlaySpot.y + 8);
+  }
+
+  private createBridgeDraftsperson(): void {
+    const { draftsperson, blueprint } = BRIDGE_TRACER_WORLD;
+    this.add.ellipse(draftsperson.x, draftsperson.y + 10, 80, 18, 0x1f1f1d, 0.1).setDepth(14);
+    this.add.rectangle(draftsperson.x, draftsperson.y - 40, 38, 62, 0xf7f1df, 1)
+      .setStrokeStyle(4, 0x1f1f1d, 0.86)
+      .setDepth(21);
+    this.add.circle(draftsperson.x, draftsperson.y - 82, 26, 0xf7f1df, 1)
+      .setStrokeStyle(4, 0x1f1f1d, 0.9)
+      .setDepth(22);
+    this.add.line(draftsperson.x + 6, draftsperson.y - 87, -6, 0, 6, 0, 0x1f1f1d, 0.8)
+      .setLineWidth(3)
+      .setDepth(23);
+    this.add.line(draftsperson.x - 16, draftsperson.y - 90, -5, -4, 5, 4, 0x1f1f1d, 0.65)
+      .setLineWidth(2)
+      .setDepth(23);
+    this.add.line(draftsperson.x + 16, draftsperson.y - 90, -5, 4, 5, -4, 0x1f1f1d, 0.65)
+      .setLineWidth(2)
+      .setDepth(23);
+
+    this.add.rectangle(blueprint.x, blueprint.y, 184, 116, 0xf7f1df, 1)
+      .setStrokeStyle(4, 0x1f1f1d, 0.82)
+      .setAngle(-2)
+      .setDepth(12);
+    this.add.line(blueprint.x - 48, blueprint.y - 6, -54, 0, -12, -18, 0x1f1f1d, 0.7)
+      .setLineWidth(4)
+      .setDepth(13);
+    this.add.line(blueprint.x + 42, blueprint.y - 2, 10, -18, 54, 2, 0x1f1f1d, 0.7)
+      .setLineWidth(4)
+      .setDepth(13);
+    this.completedBridgeObjects.push(this.asVisible(this.add.line(
+      blueprint.x,
+      blueprint.y - 13,
+      -26,
+      -6,
+      26,
+      6,
+      0x1f1f1d,
+      0.86
+    ).setLineWidth(4).setDepth(14)));
+    this.addHatching(blueprint.x - 74, blueprint.y + 28, 142, 24, 11, 0.1);
+  }
+
+  private createBridgeCrossingVisuals(): void {
+    const { bridge, floorY } = BRIDGE_TRACER_WORLD;
+    this.add.rectangle(bridge.leftBankEndX - 18, floorY - 22, 34, 88, 0xf7f1df, 1)
+      .setStrokeStyle(4, 0x1f1f1d, 0.84)
+      .setDepth(5);
+    this.add.rectangle(bridge.rightBankStartX + 18, floorY - 22, 34, 88, 0xf7f1df, 1)
+      .setStrokeStyle(4, 0x1f1f1d, 0.84)
+      .setDepth(5);
+
+    this.blockedBridgeObjects.push(
+      this.asVisible(this.add.rectangle(bridge.centerX, floorY - 40, 220, 44, 0xf7f1df, 0.7)
+        .setStrokeStyle(3, 0x1f1f1d, 0.45)
+        .setDepth(6)),
+      this.asVisible(this.add.line(bridge.centerX - 58, floorY - 42, -38, -22, 38, 22, 0x1f1f1d, 0.72)
+        .setLineWidth(5)
+        .setDepth(7)),
+      this.asVisible(this.add.line(bridge.centerX + 58, floorY - 42, -38, 22, 38, -22, 0x1f1f1d, 0.72)
+        .setLineWidth(5)
+        .setDepth(7))
+    );
+
+    const deck = this.add.rectangle(
+      bridge.centerX,
+      bridge.deckY - 12,
+      bridge.deckWidth,
+      24,
+      0xf7f1df,
+      1
+    )
+      .setStrokeStyle(5, 0x1f1f1d, 0.9)
+      .setDepth(8);
+    const topLine = this.add.line(bridge.centerX, bridge.deckY - 30, -130, 0, 130, 0, 0x1f1f1d, 0.62)
+      .setLineWidth(3)
+      .setDepth(9);
+    const bottomLine = this.add.line(bridge.centerX, bridge.deckY + 2, -128, 0, 128, 0, 0x1f1f1d, 0.36)
+      .setLineWidth(2)
+      .setDepth(9);
+    this.completedBridgeObjects.push(
+      this.asVisible(deck),
+      this.asVisible(topLine),
+      this.asVisible(bottomLine)
+    );
+  }
+
+  private createConcertHandoffNote(): void {
+    this.handoffNote = createUiText(
+      this,
+      BRIDGE_TRACER_WORLD.exit.x + 70,
+      BRIDGE_TRACER_WORLD.exit.y - 130,
+      'evening music ahead',
+      {
+        fontSize: '14px',
+        color: '#1a1a1a',
+        backgroundColor: '#f7f1df',
+        padding: { x: 6, y: 3 }
+      }
+    )
+      .setOrigin(0.5)
+      .setAngle(-2)
+      .setDepth(24)
+      .setVisible(false);
+  }
+
+  private createInteractionPrompt(): void {
+    this.interactPrompt?.destroy();
+    this.interactPrompt = createUiText(this, 0, 0, '', {
+      fontSize: '15px',
+      color: '#1a1a1a',
+      backgroundColor: '#f7f1df',
+      padding: { x: 6, y: 3 }
+    })
+      .setOrigin(0.5)
+      .setDepth(100)
+      .setVisible(false);
+  }
+
+  private createDialoguePanel(): void {
+    const container = this.add.container(GAME_DESIGN_WIDTH / 2, 78)
+      .setDepth(220)
+      .setScrollFactor(0)
+      .setVisible(false);
+    const panel = this.add.rectangle(0, 0, BRIDGE_DIALOGUE_PANEL_WIDTH, 150, 0xf7f1df, 0.96)
+      .setStrokeStyle(4, 0x1f1f1d, 0.9);
+    const label = createUiText(this, -210, -66, 'Bridge Tracer', {
+      fontSize: '12px',
+      color: '#4b4337'
+    }).setOrigin(0, 0.5);
+    const text = createUiText(this, -210, -46, '', {
+      fontSize: '12px',
+      color: '#1a1a1a',
+      lineSpacing: 5,
+      wordWrap: { width: BRIDGE_DIALOGUE_TEXT_WIDTH }
+    }).setOrigin(0, 0);
+
+    container.add([panel, label, text]);
+    this.dialogueContainer = container;
+    this.dialogueText = text;
+  }
+
+  private createPlayer(platforms: readonly Phaser.GameObjects.Zone[]): void {
+    this.ridgeSpawnPosition = { ...BRIDGE_TRACER_WORLD.spawn };
     const playerRuntime = createSideViewPlayerRuntime({
       scene: this,
       start: this.ridgeSpawnPosition,
       resumePosition: this.resumePosition,
       resumeClamp: {
-        minX: geometry.bounds.x + RIDGE_PLAYER_EDGE_PADDING,
-        maxX: geometry.bounds.x + geometry.bounds.width - RIDGE_PLAYER_EDGE_PADDING,
-        minY: geometry.bounds.y + RIDGE_PLAYER_EDGE_PADDING,
-        maxY: geometry.bounds.y + geometry.bounds.height - RIDGE_PLAYER_EDGE_PADDING
+        minX: BRIDGE_TRACER_WORLD.bounds.x + RIDGE_PLAYER_EDGE_PADDING,
+        maxX: BRIDGE_TRACER_WORLD.bounds.x + BRIDGE_TRACER_WORLD.bounds.width - RIDGE_PLAYER_EDGE_PADDING,
+        minY: BRIDGE_TRACER_WORLD.bounds.y + RIDGE_PLAYER_EDGE_PADDING,
+        maxY: BRIDGE_TRACER_WORLD.bounds.y + BRIDGE_TRACER_WORLD.bounds.height - RIDGE_PLAYER_EDGE_PADDING
       },
       sprite: {
         depth: 30,
@@ -292,7 +513,7 @@ export class RidgeScene extends Phaser.Scene {
         jumpBufferMs: RIDGE_JUMP_BUFFER_MS
       },
       input: {
-        allowJump: true,
+        allowJump: false,
         allowSprint: true,
         includeEscapeKey: true
       },
@@ -302,50 +523,257 @@ export class RidgeScene extends Phaser.Scene {
         glassesTextureKey: 'player_glasses'
       },
       camera: {
-        worldBounds: geometry.bounds,
+        worldBounds: BRIDGE_TRACER_WORLD.bounds,
         designSize: {
           width: GAME_DESIGN_WIDTH,
           height: GAME_DESIGN_HEIGHT
         },
         resolveProfile: () => ({
           zoom: this.resolveCameraZoom(),
-          followOffsetY: 0
+          followOffsetY: 10
         })
       }
     });
     this.playerRuntime = playerRuntime;
-    const player = playerRuntime.player;
-    this.player = player;
+    this.player = playerRuntime.player;
     platforms.forEach((platform) => {
-      this.physics.add.collider(player, platform);
-    });
-    this.traversalRuntime = createRidgeTraversalRuntime({
-      geometry,
-      initialSafePosition: { x: player.x, y: player.y }
+      this.physics.add.collider(playerRuntime.player, platform);
     });
   }
 
-  private createRidgeInteractions(
-    promptText: string,
-    targets: RidgeInteractionTarget[]
-  ): void {
-    this.interactPrompt?.destroy();
-
-    this.interactPrompt = createUiText(this, 0, 0, promptText, {
-      fontSize: '16px',
-      color: '#1a1a1a',
-      backgroundColor: '#ffffff',
-      padding: { x: 5, y: 2 }
-    }).setOrigin(0.5).setDepth(100).setVisible(false);
-
+  private createBridgeInteractions(): void {
+    const targets = createBridgeTracerInteractionTargets(this.routeState);
     this.interactionRuntime = createInteriorInteractionRuntime<
-      RidgeInteractionTargetId,
-      RidgeInteractionEffect
+      BridgeTracerTargetId,
+      BridgeTracerEffect
     >({
-      interactRadius: 72,
-      exitEffect: { kind: 'close' },
+      interactRadius: BRIDGE_TRACER_INTERACT_RADIUS,
       targets
     });
+  }
+
+  private handleBridgeInteractionEffect(effect: BridgeTracerEffect): void {
+    if (effect.kind === 'showDialogue') {
+      this.showBridgeDialogue(effect.lineIds);
+      if (effect.nextBeat) {
+        bridgeActions.setRidgeBridgeBeat(effect.nextBeat);
+        this.syncBridgeRouteState();
+        this.createBridgeInteractions();
+      }
+      return;
+    }
+
+    if (effect.kind === 'runToyCarTest') {
+      this.runToyCarBridgeTest(effect.lineIds);
+      return;
+    }
+
+    this.showBridgeDialogue(effect.lineIds, 7200);
+    bridgeActions.triggerRidgeConcertHandoff();
+    this.syncBridgeRouteState();
+    this.createBridgeInteractions();
+  }
+
+  private runToyCarBridgeTest(lineIds: readonly BridgeDialogueLineId[]): void {
+    if (this.toyCarTestRunning) return;
+    this.toyCarTestRunning = true;
+    this.showBridgeDialogue(lineIds, BRIDGE_DIALOGUE_DURATION_MS + BRIDGE_TEST_DURATION_MS);
+    bridgeActions.setRidgeBridgeBeat('testing_bridge');
+    this.syncBridgeRouteState();
+    this.createBridgeInteractions();
+
+    if (!this.toyCar) {
+      bridgeActions.setRidgeBridgeBeat('bridge_complete');
+      this.syncBridgeRouteState();
+      this.createBridgeInteractions();
+      this.toyCarTestRunning = false;
+      return;
+    }
+
+    this.toyCar.setVisible(true);
+    this.toyCar.setPosition(
+      BRIDGE_TRACER_WORLD.blueprint.x - 22,
+      BRIDGE_TRACER_WORLD.blueprint.y + 44
+    );
+    this.toyCarTween?.stop();
+    this.toyCarTween = this.tweens.add({
+      targets: this.toyCar,
+      x: BRIDGE_TRACER_WORLD.bridge.rightBankStartX + 120,
+      y: BRIDGE_TRACER_WORLD.floorY - 4,
+      duration: BRIDGE_TEST_DURATION_MS,
+      ease: 'Sine.easeInOut',
+      onComplete: () => {
+        this.toyCarTestRunning = false;
+        bridgeActions.setRidgeBridgeBeat('bridge_complete');
+        this.syncBridgeRouteState();
+        this.createBridgeInteractions();
+        this.showBridgeDialogue(['bridge.draftsperson.toy_car_test.04'], 3600);
+      }
+    });
+  }
+
+  private syncBridgeRouteState(): void {
+    this.routeState = bridgeStore.getState().progress.ridge.firstPlayableRoute;
+    const beat = this.routeState.bridgeBeat;
+    const crossingOpen = isBridgeCrossingOpen(beat);
+    const drawingVisible = beat === 'testing_bridge' || crossingOpen;
+
+    this.setVisible(this.blockedBridgeObjects, !crossingOpen);
+    this.setVisible(this.completedBridgeObjects, drawingVisible);
+    this.syncBridgePhysics(crossingOpen);
+    this.syncCickaAndToyCar(beat);
+    this.handoffNote?.setVisible(beat === 'concert_handoff');
+  }
+
+  private syncBridgePhysics(crossingOpen: boolean): void {
+    if (crossingOpen) {
+      this.bridgeBlockerCollider?.destroy();
+      this.bridgeBlockerCollider = undefined;
+      if (!this.bridgeSpanCollider) {
+        this.bridgeSpanCollider = this.addStaticZone(
+          BRIDGE_TRACER_WORLD.bridge.centerX,
+          BRIDGE_TRACER_WORLD.floorY + BRIDGE_GROUND_COLLIDER_HEIGHT / 2,
+          BRIDGE_TRACER_WORLD.bridge.deckWidth,
+          BRIDGE_GROUND_COLLIDER_HEIGHT
+        );
+        if (this.player) {
+          this.physics.add.collider(this.player, this.bridgeSpanCollider);
+        }
+      }
+      return;
+    }
+
+    this.bridgeSpanCollider?.destroy();
+    this.bridgeSpanCollider = undefined;
+    if (!this.bridgeBlockerCollider) {
+      this.bridgeBlockerCollider = this.addStaticZone(
+        BRIDGE_TRACER_WORLD.bridge.leftBankEndX - 22,
+        BRIDGE_TRACER_WORLD.floorY - 58,
+        34,
+        126
+      );
+      if (this.player) {
+        this.physics.add.collider(this.player, this.bridgeBlockerCollider);
+      }
+    }
+  }
+
+  private syncCickaAndToyCar(bridgeBeat: RidgeBridgeBeatState): void {
+    const crossingOpen = isBridgeCrossingOpen(bridgeBeat);
+    const cickaSpot = crossingOpen
+      ? BRIDGE_TRACER_WORLD.cickaSettledSpot
+      : BRIDGE_TRACER_WORLD.cickaPlaySpot;
+    this.cickaSprite?.setPosition(cickaSpot.x, cickaSpot.y);
+    this.cickaShadow?.setPosition(cickaSpot.x, cickaSpot.y + 8);
+
+    if (!this.toyCar || this.toyCarTestRunning) return;
+
+    if (!hasCickaSharedToyCar(bridgeBeat)) {
+      this.toyCar.setVisible(true);
+      this.toyCar.setPosition(
+        BRIDGE_TRACER_WORLD.cickaPlaySpot.x + 66,
+        BRIDGE_TRACER_WORLD.cickaPlaySpot.y + 8
+      );
+      return;
+    }
+
+    if (bridgeBeat === 'toy_car_shared') {
+      this.toyCar.setVisible(true);
+      this.toyCar.setPosition(
+        BRIDGE_TRACER_WORLD.blueprint.x - 22,
+        BRIDGE_TRACER_WORLD.blueprint.y + 44
+      );
+      return;
+    }
+
+    this.toyCar.setVisible(true);
+    this.toyCar.setPosition(
+      BRIDGE_TRACER_WORLD.bridge.rightBankStartX + 120,
+      BRIDGE_TRACER_WORLD.floorY - 4
+    );
+  }
+
+  private showBridgePrompt(
+    target: BridgeTracerInteractionTarget,
+    x: number,
+    y: number
+  ): void {
+    const prompt = getBridgePromptText(target.promptLineId);
+    this.interactPrompt
+      ?.setText(`[E] ${prompt}`)
+      .setPosition(x, y)
+      .setVisible(true);
+  }
+
+  private showBridgeDialogue(
+    lineIds: readonly BridgeDialogueLineId[],
+    durationMs: number = BRIDGE_DIALOGUE_DURATION_MS
+  ): void {
+    if (!this.dialogueContainer || !this.dialogueText) return;
+    const text = lineIds.map((id) => {
+      const line = getBridgeDialogueLine(id);
+      return line.speaker === 'Prompt'
+        ? line.text
+        : `${line.speaker}: ${line.text}`;
+    }).join('\n');
+
+    this.dialogueText.setText(text);
+    this.dialogueContainer.setVisible(true);
+    this.dialogueHideEvent?.remove(false);
+    this.dialogueHideEvent = this.time.delayedCall(durationMs, () => {
+      this.dialogueContainer?.setVisible(false);
+    });
+  }
+
+  private createToyCar(x: number, y: number): Phaser.GameObjects.Container {
+    const container = this.add.container(x, y).setDepth(25);
+    const body = this.add.rectangle(0, -7, 48, 20, 0xf7f1df, 1)
+      .setStrokeStyle(3, 0x1f1f1d, 0.88);
+    const roof = this.add.rectangle(-4, -20, 24, 14, 0xf7f1df, 1)
+      .setStrokeStyle(2, 0x1f1f1d, 0.72);
+    const wheelLeft = this.add.circle(-15, 6, 6, 0x1f1f1d, 0.9);
+    const wheelRight = this.add.circle(16, 6, 6, 0x1f1f1d, 0.9);
+    container.add([body, roof, wheelLeft, wheelRight]);
+    return container;
+  }
+
+  private addHatching(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    spacing: number,
+    alpha: number
+  ): void {
+    const graphics = this.add.graphics().setDepth(4);
+    graphics.lineStyle(2, 0x1f1f1d, alpha);
+    for (let offset = 0; offset <= width + height; offset += spacing) {
+      graphics.strokeLineShape(new Phaser.Geom.Line(
+        x + offset,
+        y,
+        x + offset - height,
+        y + height
+      ));
+    }
+  }
+
+  private addStaticZone(
+    x: number,
+    y: number,
+    width: number,
+    height: number
+  ): Phaser.GameObjects.Zone {
+    const zone = this.add.zone(x, y, width, height);
+    this.physics.add.existing(zone, true);
+    return zone;
+  }
+
+  private asVisible<GameObject extends VisibleGameObject>(gameObject: GameObject): GameObject {
+    return gameObject;
+  }
+
+  private setVisible(objects: readonly VisibleGameObject[], visible: boolean): void {
+    objects.forEach((object) => object.setVisible(visible));
   }
 
   private resolveCameraZoom(): number {
@@ -364,19 +792,15 @@ export class RidgeScene extends Phaser.Scene {
     if (!this.player) return;
 
     const resetRequest = this.ridgeDevControls.consumeResetRequest?.();
-    if (resetRequest && this.ridgeSpawnPosition) {
-      this.movePlayerForDev({
-        x: this.ridgeSpawnPosition.x,
-        y: this.ridgeSpawnPosition.y
-      });
+    if (resetRequest) {
+      this.movePlayerForDev(this.ridgeSpawnPosition);
       return;
     }
 
     const request = this.ridgeDevControls.consumeTeleportRequest?.();
     if (!request) return;
 
-    const position = applyRidgeDevTeleportToPlayer(this.player, request);
-    this.refreshTraversalRuntimeSafePosition(position);
+    applyRidgeDevTeleportToPlayer(this.player, request);
     this.playerRuntime?.cameraRuntime?.refresh();
   }
 
@@ -386,41 +810,14 @@ export class RidgeScene extends Phaser.Scene {
     this.player.setVelocityX(0);
     this.player.setVelocityY(0);
     this.player.body.setAllowGravity(true);
-    this.refreshTraversalRuntimeSafePosition(position);
     this.playerRuntime?.cameraRuntime?.refresh();
   }
 
-  private refreshTraversalRuntimeSafePosition(position: { x: number; y: number }): void {
-    if (this.currentGeometry) {
-      this.traversalRuntime = createRidgeTraversalRuntime({
-        geometry: this.currentGeometry,
-        initialSafePosition: position
-      });
-    }
-  }
-
   private syncDevRuntimeState(): void {
-    if (!import.meta.env.DEV || !this.ridgeDevControls) return;
-    if (this.player) {
-      this.ridgeDevControls.publishPlayerSnapshot?.({
-        x: this.player.x,
-        y: this.player.y
-      });
-    }
-    this.renderDevDebugOverlay();
-  }
-
-  private renderDevDebugOverlay(): void {
-    if (!import.meta.env.DEV || !this.ridgeDevControls || !this.currentGeometry) return;
-    this.ridgeDebugOverlay ??= createRidgeDebugOverlay(this);
-    this.ridgeDebugOverlay.render({
-      geometry: this.currentGeometry,
-      interactionTargets: this.ridgeInteractionTargets,
-      player: this.player,
-      settings: resolveRidgeDevDebugSettings(
-        this.ridgeDevControls.resolveDebugSettings?.()
-      ),
-      traversalState: this.traversalRuntime?.getState()
+    if (!import.meta.env.DEV || !this.ridgeDevControls || !this.player) return;
+    this.ridgeDevControls.publishPlayerSnapshot?.({
+      x: this.player.x,
+      y: this.player.y
     });
   }
 }

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -259,10 +259,7 @@ export class RidgeScene extends Phaser.Scene {
   private runToyCarBridgeTest(
     effect: Extract<BridgeTracerEffect, { kind: 'runToyCarTest' }>
   ): void {
-    bridgeActions.setRidgeBridgeBeat('testing_bridge');
-    this.syncBridgeRouteState();
-    this.createBridgeInteractions();
-
+    this.bridgeStage?.hidePrompt();
     this.bridgeStage?.runToyCarTest(effect.lineIds, () => {
       bridgeActions.setRidgeBridgeBeat('bridge_complete');
       this.syncBridgeRouteState();

--- a/src/game/scenes/ridge/runtime/RidgeScene.ts
+++ b/src/game/scenes/ridge/runtime/RidgeScene.ts
@@ -4,7 +4,6 @@ import {
   bridgeStore,
   isItemEquipped,
   type OpenOverlayOptions,
-  type RidgeBridgeBeatState,
   type RidgeFirstPlayableRouteState
 } from '@/game/bridge/store';
 import { type OverlayId } from '@/game/overlays/overlayIds';
@@ -25,24 +24,10 @@ import {
   createSideViewPlayerRuntime,
   type SideViewPlayerRuntime
 } from '@/game/sharedSceneRuntime/player/SideViewPlayerRuntime';
-import { createUiText } from '@/game/sharedSceneRuntime/text/createUiText';
-import { TextureGenerator } from '@/game/sharedSceneRuntime/textures/TextureGenerator';
-import {
-  CICKA_ANIMATION_KEYS,
-  CICKA_FRAME_INDEX,
-  CICKA_ORIGIN,
-  CICKA_RUNTIME_SCALE,
-  CICKA_TEXTURE_KEY
-} from '../cicka/assets';
 import {
   createCickaAnimations,
   preloadCickaAssets
 } from '../cicka/assets';
-import {
-  getBridgeDialogueLine,
-  getBridgePromptText,
-  type BridgeDialogueLineId
-} from '../dialogue/bridgeDialogue';
 import {
   applyRidgeDevTeleportToPlayer,
   RIDGE_DEFAULT_CAMERA_ZOOM,
@@ -53,12 +38,15 @@ import {
   BRIDGE_TRACER_INTERACT_RADIUS,
   BRIDGE_TRACER_WORLD,
   createBridgeTracerInteractionTargets,
-  hasCickaSharedToyCar,
-  isBridgeCrossingOpen,
   type BridgeTracerEffect,
   type BridgeTracerInteractionTarget,
   type BridgeTracerTargetId
 } from './bridgeTracerSlice';
+import {
+  createBridgeTracerStageRuntime,
+  type BridgeTracerStageRuntime
+} from './BridgeTracerStageRuntime';
+import { TextureGenerator } from '@/game/sharedSceneRuntime/textures/TextureGenerator';
 
 interface RidgeSceneStartData {
   onClose?: () => void;
@@ -68,24 +56,15 @@ interface RidgeSceneStartData {
   ridgeDevControls?: RidgeDevControls;
 }
 
-type VisibleGameObject = Phaser.GameObjects.GameObject & {
-  setVisible(visible: boolean): VisibleGameObject;
-};
-
 const RIDGE_PLAYER_EDGE_PADDING = 48;
 const RIDGE_COYOTE_TIME_MS = 120;
 const RIDGE_JUMP_BUFFER_MS = 120;
-const BRIDGE_GROUND_COLLIDER_HEIGHT = 24;
-const BRIDGE_DIALOGUE_DURATION_MS = 5600;
-const BRIDGE_TEST_DURATION_MS = 1900;
-const BRIDGE_DIALOGUE_PANEL_WIDTH = 460;
-const BRIDGE_DIALOGUE_TEXT_WIDTH = 418;
 
 export class RidgeScene extends Phaser.Scene {
   player?: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
-  interactPrompt?: Phaser.GameObjects.Text;
 
   private playerRuntime?: SideViewPlayerRuntime;
+  private bridgeStage?: BridgeTracerStageRuntime;
   private interactionRuntime?: InteriorInteractionRuntime<BridgeTracerTargetId, BridgeTracerEffect>;
   private onClose: () => void = () => {};
   private isPaused = false;
@@ -97,21 +76,6 @@ export class RidgeScene extends Phaser.Scene {
     activeAreaId: 'bridge',
     bridgeBeat: 'intro'
   };
-
-  private groundPlatforms: Phaser.GameObjects.Zone[] = [];
-  private bridgeSpanCollider?: Phaser.GameObjects.Zone;
-  private bridgeBlockerCollider?: Phaser.GameObjects.Zone;
-  private blockedBridgeObjects: VisibleGameObject[] = [];
-  private completedBridgeObjects: VisibleGameObject[] = [];
-  private cickaSprite?: Phaser.GameObjects.Sprite;
-  private cickaShadow?: Phaser.GameObjects.Ellipse;
-  private toyCar?: Phaser.GameObjects.Container;
-  private handoffNote?: Phaser.GameObjects.Text;
-  private dialogueContainer?: Phaser.GameObjects.Container;
-  private dialogueText?: Phaser.GameObjects.Text;
-  private dialogueHideEvent?: Phaser.Time.TimerEvent;
-  private toyCarTween?: Phaser.Tweens.Tween;
-  private toyCarTestRunning = false;
 
   constructor() {
     super(PHASER_SCENE_KEYS.ridge);
@@ -146,8 +110,8 @@ export class RidgeScene extends Phaser.Scene {
       ? data.ridgeDevControls ?? this.ridgeDevControls
       : undefined;
     this.routeState = bridgeStore.getState().progress.ridge.firstPlayableRoute;
-    this.resetRuntimeObjects();
 
+    this.bridgeStage?.dispose();
     this.cameras.main.setBackgroundColor('#f7f1df');
     this.physics.world.setBounds(
       BRIDGE_TRACER_WORLD.bounds.x,
@@ -157,9 +121,8 @@ export class RidgeScene extends Phaser.Scene {
     );
     createCickaAnimations(this);
 
-    this.createBridgeBlockoutStage();
-    this.createPlayer(this.groundPlatforms);
-    this.createDialoguePanel();
+    this.bridgeStage = createBridgeTracerStageRuntime(this);
+    this.createPlayer(this.bridgeStage.platforms);
     this.syncBridgeRouteState();
     this.createBridgeInteractions();
     this.setPaused(this.isPaused);
@@ -190,7 +153,7 @@ export class RidgeScene extends Phaser.Scene {
     });
 
     if (!interaction?.prompt.visible || !interaction.activeTarget) {
-      this.interactPrompt?.setVisible(false);
+      this.bridgeStage?.hidePrompt();
       this.syncDevRuntimeState();
       return;
     }
@@ -199,294 +162,12 @@ export class RidgeScene extends Phaser.Scene {
       this.handleBridgeInteractionEffect(interaction.effect);
     }
 
-    this.showBridgePrompt(
+    this.bridgeStage?.showPrompt(
       interaction.activeTarget as BridgeTracerInteractionTarget,
       interaction.prompt.x,
       interaction.prompt.y
     );
     this.syncDevRuntimeState();
-  }
-
-  private resetRuntimeObjects(): void {
-    this.groundPlatforms = [];
-    this.bridgeSpanCollider = undefined;
-    this.bridgeBlockerCollider = undefined;
-    this.blockedBridgeObjects = [];
-    this.completedBridgeObjects = [];
-    this.cickaSprite = undefined;
-    this.cickaShadow = undefined;
-    this.toyCar = undefined;
-    this.handoffNote = undefined;
-    this.dialogueContainer = undefined;
-    this.dialogueText = undefined;
-    this.dialogueHideEvent?.remove(false);
-    this.dialogueHideEvent = undefined;
-    this.toyCarTween?.stop();
-    this.toyCarTween = undefined;
-    this.toyCarTestRunning = false;
-  }
-
-  private createBridgeBlockoutStage(): void {
-    this.add.rectangle(
-      BRIDGE_TRACER_WORLD.bounds.width / 2,
-      BRIDGE_TRACER_WORLD.bounds.height / 2,
-      BRIDGE_TRACER_WORLD.bounds.width,
-      BRIDGE_TRACER_WORLD.bounds.height,
-      0xf7f1df,
-      1
-    ).setDepth(-100);
-
-    this.addBackdropInk();
-    this.createBridgeGround();
-    this.createCickaPlaySpot();
-    this.createBridgeDraftsperson();
-    this.createBridgeCrossingVisuals();
-    this.createConcertHandoffNote();
-    this.createInteractionPrompt();
-  }
-
-  private addBackdropInk(): void {
-    const graphics = this.add.graphics().setDepth(-80);
-    graphics.lineStyle(2, 0x1f1f1d, 0.06);
-    for (let y = 116; y < BRIDGE_TRACER_WORLD.bounds.height; y += 96) {
-      graphics.strokeLineShape(new Phaser.Geom.Line(0, y, BRIDGE_TRACER_WORLD.bounds.width, y));
-    }
-
-    graphics.lineStyle(4, 0x1f1f1d, 0.12);
-    graphics.beginPath();
-    graphics.moveTo(0, BRIDGE_TRACER_WORLD.floorY - 34);
-    graphics.lineTo(220, BRIDGE_TRACER_WORLD.floorY - 58);
-    graphics.lineTo(460, BRIDGE_TRACER_WORLD.floorY - 34);
-    graphics.lineTo(760, BRIDGE_TRACER_WORLD.floorY - 46);
-    graphics.strokePath();
-
-    for (let x = 180; x < 1000; x += 190) {
-      graphics.lineStyle(3, 0x1f1f1d, 0.12);
-      graphics.strokeTriangle(
-        x,
-        BRIDGE_TRACER_WORLD.floorY - 72,
-        x - 34,
-        BRIDGE_TRACER_WORLD.floorY - 14,
-        x + 40,
-        BRIDGE_TRACER_WORLD.floorY - 14
-      );
-      graphics.lineStyle(2, 0x1f1f1d, 0.1);
-      graphics.strokeLineShape(new Phaser.Geom.Line(
-        x,
-        BRIDGE_TRACER_WORLD.floorY - 54,
-        x,
-        BRIDGE_TRACER_WORLD.floorY - 12
-      ));
-    }
-
-    graphics.lineStyle(5, 0x1f1f1d, 0.14);
-    graphics.strokeLineShape(new Phaser.Geom.Line(1980, 332, 2060, 250));
-    graphics.strokeLineShape(new Phaser.Geom.Line(2060, 250, 2140, 332));
-    graphics.lineStyle(3, 0x1f1f1d, 0.1);
-    graphics.strokeLineShape(new Phaser.Geom.Line(2024, 292, 2094, 292));
-  }
-
-  private createBridgeGround(): void {
-    const { floorY, bridge, bounds } = BRIDGE_TRACER_WORLD;
-    const groundY = floorY + BRIDGE_GROUND_COLLIDER_HEIGHT / 2;
-
-    this.add.rectangle(
-      bridge.leftBankEndX / 2,
-      floorY + 24,
-      bridge.leftBankEndX,
-      48,
-      0xf7f1df,
-      1
-    )
-      .setStrokeStyle(4, 0x1f1f1d, 0.8)
-      .setDepth(1);
-    this.add.rectangle(
-      bridge.rightBankStartX + (bounds.width - bridge.rightBankStartX) / 2,
-      floorY + 24,
-      bounds.width - bridge.rightBankStartX,
-      48,
-      0xf7f1df,
-      1
-    )
-      .setStrokeStyle(4, 0x1f1f1d, 0.8)
-      .setDepth(1);
-
-    this.addHatching(40, floorY + 8, bridge.leftBankEndX - 80, 34, 14, 0.12);
-    this.addHatching(bridge.rightBankStartX + 34, floorY + 8, bounds.width - bridge.rightBankStartX - 80, 34, 14, 0.12);
-
-    this.groundPlatforms.push(
-      this.addStaticZone(bridge.leftBankEndX / 2, groundY, bridge.leftBankEndX, BRIDGE_GROUND_COLLIDER_HEIGHT),
-      this.addStaticZone(
-        bridge.rightBankStartX + (bounds.width - bridge.rightBankStartX) / 2,
-        groundY,
-        bounds.width - bridge.rightBankStartX,
-        BRIDGE_GROUND_COLLIDER_HEIGHT
-      )
-    );
-  }
-
-  private createCickaPlaySpot(): void {
-    const { cickaPlaySpot } = BRIDGE_TRACER_WORLD;
-    this.cickaShadow = this.add.ellipse(
-      cickaPlaySpot.x,
-      cickaPlaySpot.y + 8,
-      92,
-      18,
-      0x1f1f1d,
-      0.12
-    ).setDepth(15);
-    this.cickaSprite = this.add.sprite(
-      cickaPlaySpot.x,
-      cickaPlaySpot.y,
-      CICKA_TEXTURE_KEY,
-      CICKA_FRAME_INDEX.perchSit
-    )
-      .setOrigin(CICKA_ORIGIN.x, CICKA_ORIGIN.y)
-      .setScale(CICKA_RUNTIME_SCALE)
-      .setDepth(26);
-    this.cickaSprite.play(CICKA_ANIMATION_KEYS.perchIdle);
-    this.toyCar = this.createToyCar(cickaPlaySpot.x + 66, cickaPlaySpot.y + 8);
-  }
-
-  private createBridgeDraftsperson(): void {
-    const { draftsperson, blueprint } = BRIDGE_TRACER_WORLD;
-    this.add.ellipse(draftsperson.x, draftsperson.y + 10, 80, 18, 0x1f1f1d, 0.1).setDepth(14);
-    this.add.rectangle(draftsperson.x, draftsperson.y - 40, 38, 62, 0xf7f1df, 1)
-      .setStrokeStyle(4, 0x1f1f1d, 0.86)
-      .setDepth(21);
-    this.add.circle(draftsperson.x, draftsperson.y - 82, 26, 0xf7f1df, 1)
-      .setStrokeStyle(4, 0x1f1f1d, 0.9)
-      .setDepth(22);
-    this.add.line(draftsperson.x + 6, draftsperson.y - 87, -6, 0, 6, 0, 0x1f1f1d, 0.8)
-      .setLineWidth(3)
-      .setDepth(23);
-    this.add.line(draftsperson.x - 16, draftsperson.y - 90, -5, -4, 5, 4, 0x1f1f1d, 0.65)
-      .setLineWidth(2)
-      .setDepth(23);
-    this.add.line(draftsperson.x + 16, draftsperson.y - 90, -5, 4, 5, -4, 0x1f1f1d, 0.65)
-      .setLineWidth(2)
-      .setDepth(23);
-
-    this.add.rectangle(blueprint.x, blueprint.y, 184, 116, 0xf7f1df, 1)
-      .setStrokeStyle(4, 0x1f1f1d, 0.82)
-      .setAngle(-2)
-      .setDepth(12);
-    this.add.line(blueprint.x - 48, blueprint.y - 6, -54, 0, -12, -18, 0x1f1f1d, 0.7)
-      .setLineWidth(4)
-      .setDepth(13);
-    this.add.line(blueprint.x + 42, blueprint.y - 2, 10, -18, 54, 2, 0x1f1f1d, 0.7)
-      .setLineWidth(4)
-      .setDepth(13);
-    this.completedBridgeObjects.push(this.asVisible(this.add.line(
-      blueprint.x,
-      blueprint.y - 13,
-      -26,
-      -6,
-      26,
-      6,
-      0x1f1f1d,
-      0.86
-    ).setLineWidth(4).setDepth(14)));
-    this.addHatching(blueprint.x - 74, blueprint.y + 28, 142, 24, 11, 0.1);
-  }
-
-  private createBridgeCrossingVisuals(): void {
-    const { bridge, floorY } = BRIDGE_TRACER_WORLD;
-    this.add.rectangle(bridge.leftBankEndX - 18, floorY - 22, 34, 88, 0xf7f1df, 1)
-      .setStrokeStyle(4, 0x1f1f1d, 0.84)
-      .setDepth(5);
-    this.add.rectangle(bridge.rightBankStartX + 18, floorY - 22, 34, 88, 0xf7f1df, 1)
-      .setStrokeStyle(4, 0x1f1f1d, 0.84)
-      .setDepth(5);
-
-    this.blockedBridgeObjects.push(
-      this.asVisible(this.add.rectangle(bridge.centerX, floorY - 40, 220, 44, 0xf7f1df, 0.7)
-        .setStrokeStyle(3, 0x1f1f1d, 0.45)
-        .setDepth(6)),
-      this.asVisible(this.add.line(bridge.centerX - 58, floorY - 42, -38, -22, 38, 22, 0x1f1f1d, 0.72)
-        .setLineWidth(5)
-        .setDepth(7)),
-      this.asVisible(this.add.line(bridge.centerX + 58, floorY - 42, -38, 22, 38, -22, 0x1f1f1d, 0.72)
-        .setLineWidth(5)
-        .setDepth(7))
-    );
-
-    const deck = this.add.rectangle(
-      bridge.centerX,
-      bridge.deckY - 12,
-      bridge.deckWidth,
-      24,
-      0xf7f1df,
-      1
-    )
-      .setStrokeStyle(5, 0x1f1f1d, 0.9)
-      .setDepth(8);
-    const topLine = this.add.line(bridge.centerX, bridge.deckY - 30, -130, 0, 130, 0, 0x1f1f1d, 0.62)
-      .setLineWidth(3)
-      .setDepth(9);
-    const bottomLine = this.add.line(bridge.centerX, bridge.deckY + 2, -128, 0, 128, 0, 0x1f1f1d, 0.36)
-      .setLineWidth(2)
-      .setDepth(9);
-    this.completedBridgeObjects.push(
-      this.asVisible(deck),
-      this.asVisible(topLine),
-      this.asVisible(bottomLine)
-    );
-  }
-
-  private createConcertHandoffNote(): void {
-    this.handoffNote = createUiText(
-      this,
-      BRIDGE_TRACER_WORLD.exit.x + 70,
-      BRIDGE_TRACER_WORLD.exit.y - 130,
-      'evening music ahead',
-      {
-        fontSize: '14px',
-        color: '#1a1a1a',
-        backgroundColor: '#f7f1df',
-        padding: { x: 6, y: 3 }
-      }
-    )
-      .setOrigin(0.5)
-      .setAngle(-2)
-      .setDepth(24)
-      .setVisible(false);
-  }
-
-  private createInteractionPrompt(): void {
-    this.interactPrompt?.destroy();
-    this.interactPrompt = createUiText(this, 0, 0, '', {
-      fontSize: '15px',
-      color: '#1a1a1a',
-      backgroundColor: '#f7f1df',
-      padding: { x: 6, y: 3 }
-    })
-      .setOrigin(0.5)
-      .setDepth(100)
-      .setVisible(false);
-  }
-
-  private createDialoguePanel(): void {
-    const container = this.add.container(GAME_DESIGN_WIDTH / 2, 78)
-      .setDepth(220)
-      .setScrollFactor(0)
-      .setVisible(false);
-    const panel = this.add.rectangle(0, 0, BRIDGE_DIALOGUE_PANEL_WIDTH, 150, 0xf7f1df, 0.96)
-      .setStrokeStyle(4, 0x1f1f1d, 0.9);
-    const label = createUiText(this, -210, -66, 'Bridge Tracer', {
-      fontSize: '12px',
-      color: '#4b4337'
-    }).setOrigin(0, 0.5);
-    const text = createUiText(this, -210, -46, '', {
-      fontSize: '12px',
-      color: '#1a1a1a',
-      lineSpacing: 5,
-      wordWrap: { width: BRIDGE_DIALOGUE_TEXT_WIDTH }
-    }).setOrigin(0, 0);
-
-    container.add([panel, label, text]);
-    this.dialogueContainer = container;
-    this.dialogueText = text;
   }
 
   private createPlayer(platforms: readonly Phaser.GameObjects.Zone[]): void {
@@ -542,238 +223,56 @@ export class RidgeScene extends Phaser.Scene {
   }
 
   private createBridgeInteractions(): void {
-    const targets = createBridgeTracerInteractionTargets(this.routeState);
     this.interactionRuntime = createInteriorInteractionRuntime<
       BridgeTracerTargetId,
       BridgeTracerEffect
     >({
       interactRadius: BRIDGE_TRACER_INTERACT_RADIUS,
-      targets
+      targets: createBridgeTracerInteractionTargets(this.routeState)
     });
   }
 
   private handleBridgeInteractionEffect(effect: BridgeTracerEffect): void {
-    if (effect.kind === 'showDialogue') {
-      this.showBridgeDialogue(effect.lineIds);
-      if (effect.nextBeat) {
-        bridgeActions.setRidgeBridgeBeat(effect.nextBeat);
+    switch (effect.kind) {
+      case 'showDialogue':
+        this.bridgeStage?.showDialogue(effect.lineIds);
+        if (effect.nextBeat) {
+          bridgeActions.setRidgeBridgeBeat(effect.nextBeat);
+          this.syncBridgeRouteState();
+          this.createBridgeInteractions();
+        }
+        return;
+      case 'runToyCarTest':
+        this.runToyCarBridgeTest(effect);
+        return;
+      case 'triggerConcertHandoff':
+        this.bridgeStage?.showDialogue(effect.lineIds, 7200);
+        bridgeActions.triggerRidgeConcertHandoff();
         this.syncBridgeRouteState();
         this.createBridgeInteractions();
-      }
-      return;
+        return;
+      default:
+        assertNever(effect);
     }
-
-    if (effect.kind === 'runToyCarTest') {
-      this.runToyCarBridgeTest(effect.lineIds);
-      return;
-    }
-
-    this.showBridgeDialogue(effect.lineIds, 7200);
-    bridgeActions.triggerRidgeConcertHandoff();
-    this.syncBridgeRouteState();
-    this.createBridgeInteractions();
   }
 
-  private runToyCarBridgeTest(lineIds: readonly BridgeDialogueLineId[]): void {
-    if (this.toyCarTestRunning) return;
-    this.toyCarTestRunning = true;
-    this.showBridgeDialogue(lineIds, BRIDGE_DIALOGUE_DURATION_MS + BRIDGE_TEST_DURATION_MS);
+  private runToyCarBridgeTest(
+    effect: Extract<BridgeTracerEffect, { kind: 'runToyCarTest' }>
+  ): void {
     bridgeActions.setRidgeBridgeBeat('testing_bridge');
     this.syncBridgeRouteState();
     this.createBridgeInteractions();
 
-    if (!this.toyCar) {
+    this.bridgeStage?.runToyCarTest(effect.lineIds, () => {
       bridgeActions.setRidgeBridgeBeat('bridge_complete');
       this.syncBridgeRouteState();
       this.createBridgeInteractions();
-      this.toyCarTestRunning = false;
-      return;
-    }
-
-    this.toyCar.setVisible(true);
-    this.toyCar.setPosition(
-      BRIDGE_TRACER_WORLD.blueprint.x - 22,
-      BRIDGE_TRACER_WORLD.blueprint.y + 44
-    );
-    this.toyCarTween?.stop();
-    this.toyCarTween = this.tweens.add({
-      targets: this.toyCar,
-      x: BRIDGE_TRACER_WORLD.bridge.rightBankStartX + 120,
-      y: BRIDGE_TRACER_WORLD.floorY - 4,
-      duration: BRIDGE_TEST_DURATION_MS,
-      ease: 'Sine.easeInOut',
-      onComplete: () => {
-        this.toyCarTestRunning = false;
-        bridgeActions.setRidgeBridgeBeat('bridge_complete');
-        this.syncBridgeRouteState();
-        this.createBridgeInteractions();
-        this.showBridgeDialogue(['bridge.draftsperson.toy_car_test.04'], 3600);
-      }
     });
   }
 
   private syncBridgeRouteState(): void {
     this.routeState = bridgeStore.getState().progress.ridge.firstPlayableRoute;
-    const beat = this.routeState.bridgeBeat;
-    const crossingOpen = isBridgeCrossingOpen(beat);
-    const drawingVisible = beat === 'testing_bridge' || crossingOpen;
-
-    this.setVisible(this.blockedBridgeObjects, !crossingOpen);
-    this.setVisible(this.completedBridgeObjects, drawingVisible);
-    this.syncBridgePhysics(crossingOpen);
-    this.syncCickaAndToyCar(beat);
-    this.handoffNote?.setVisible(beat === 'concert_handoff');
-  }
-
-  private syncBridgePhysics(crossingOpen: boolean): void {
-    if (crossingOpen) {
-      this.bridgeBlockerCollider?.destroy();
-      this.bridgeBlockerCollider = undefined;
-      if (!this.bridgeSpanCollider) {
-        this.bridgeSpanCollider = this.addStaticZone(
-          BRIDGE_TRACER_WORLD.bridge.centerX,
-          BRIDGE_TRACER_WORLD.floorY + BRIDGE_GROUND_COLLIDER_HEIGHT / 2,
-          BRIDGE_TRACER_WORLD.bridge.deckWidth,
-          BRIDGE_GROUND_COLLIDER_HEIGHT
-        );
-        if (this.player) {
-          this.physics.add.collider(this.player, this.bridgeSpanCollider);
-        }
-      }
-      return;
-    }
-
-    this.bridgeSpanCollider?.destroy();
-    this.bridgeSpanCollider = undefined;
-    if (!this.bridgeBlockerCollider) {
-      this.bridgeBlockerCollider = this.addStaticZone(
-        BRIDGE_TRACER_WORLD.bridge.leftBankEndX - 22,
-        BRIDGE_TRACER_WORLD.floorY - 58,
-        34,
-        126
-      );
-      if (this.player) {
-        this.physics.add.collider(this.player, this.bridgeBlockerCollider);
-      }
-    }
-  }
-
-  private syncCickaAndToyCar(bridgeBeat: RidgeBridgeBeatState): void {
-    const crossingOpen = isBridgeCrossingOpen(bridgeBeat);
-    const cickaSpot = crossingOpen
-      ? BRIDGE_TRACER_WORLD.cickaSettledSpot
-      : BRIDGE_TRACER_WORLD.cickaPlaySpot;
-    this.cickaSprite?.setPosition(cickaSpot.x, cickaSpot.y);
-    this.cickaShadow?.setPosition(cickaSpot.x, cickaSpot.y + 8);
-
-    if (!this.toyCar || this.toyCarTestRunning) return;
-
-    if (!hasCickaSharedToyCar(bridgeBeat)) {
-      this.toyCar.setVisible(true);
-      this.toyCar.setPosition(
-        BRIDGE_TRACER_WORLD.cickaPlaySpot.x + 66,
-        BRIDGE_TRACER_WORLD.cickaPlaySpot.y + 8
-      );
-      return;
-    }
-
-    if (bridgeBeat === 'toy_car_shared') {
-      this.toyCar.setVisible(true);
-      this.toyCar.setPosition(
-        BRIDGE_TRACER_WORLD.blueprint.x - 22,
-        BRIDGE_TRACER_WORLD.blueprint.y + 44
-      );
-      return;
-    }
-
-    this.toyCar.setVisible(true);
-    this.toyCar.setPosition(
-      BRIDGE_TRACER_WORLD.bridge.rightBankStartX + 120,
-      BRIDGE_TRACER_WORLD.floorY - 4
-    );
-  }
-
-  private showBridgePrompt(
-    target: BridgeTracerInteractionTarget,
-    x: number,
-    y: number
-  ): void {
-    const prompt = getBridgePromptText(target.promptLineId);
-    this.interactPrompt
-      ?.setText(`[E] ${prompt}`)
-      .setPosition(x, y)
-      .setVisible(true);
-  }
-
-  private showBridgeDialogue(
-    lineIds: readonly BridgeDialogueLineId[],
-    durationMs: number = BRIDGE_DIALOGUE_DURATION_MS
-  ): void {
-    if (!this.dialogueContainer || !this.dialogueText) return;
-    const text = lineIds.map((id) => {
-      const line = getBridgeDialogueLine(id);
-      return line.speaker === 'Prompt'
-        ? line.text
-        : `${line.speaker}: ${line.text}`;
-    }).join('\n');
-
-    this.dialogueText.setText(text);
-    this.dialogueContainer.setVisible(true);
-    this.dialogueHideEvent?.remove(false);
-    this.dialogueHideEvent = this.time.delayedCall(durationMs, () => {
-      this.dialogueContainer?.setVisible(false);
-    });
-  }
-
-  private createToyCar(x: number, y: number): Phaser.GameObjects.Container {
-    const container = this.add.container(x, y).setDepth(25);
-    const body = this.add.rectangle(0, -7, 48, 20, 0xf7f1df, 1)
-      .setStrokeStyle(3, 0x1f1f1d, 0.88);
-    const roof = this.add.rectangle(-4, -20, 24, 14, 0xf7f1df, 1)
-      .setStrokeStyle(2, 0x1f1f1d, 0.72);
-    const wheelLeft = this.add.circle(-15, 6, 6, 0x1f1f1d, 0.9);
-    const wheelRight = this.add.circle(16, 6, 6, 0x1f1f1d, 0.9);
-    container.add([body, roof, wheelLeft, wheelRight]);
-    return container;
-  }
-
-  private addHatching(
-    x: number,
-    y: number,
-    width: number,
-    height: number,
-    spacing: number,
-    alpha: number
-  ): void {
-    const graphics = this.add.graphics().setDepth(4);
-    graphics.lineStyle(2, 0x1f1f1d, alpha);
-    for (let offset = 0; offset <= width + height; offset += spacing) {
-      graphics.strokeLineShape(new Phaser.Geom.Line(
-        x + offset,
-        y,
-        x + offset - height,
-        y + height
-      ));
-    }
-  }
-
-  private addStaticZone(
-    x: number,
-    y: number,
-    width: number,
-    height: number
-  ): Phaser.GameObjects.Zone {
-    const zone = this.add.zone(x, y, width, height);
-    this.physics.add.existing(zone, true);
-    return zone;
-  }
-
-  private asVisible<GameObject extends VisibleGameObject>(gameObject: GameObject): GameObject {
-    return gameObject;
-  }
-
-  private setVisible(objects: readonly VisibleGameObject[], visible: boolean): void {
-    objects.forEach((object) => object.setVisible(visible));
+    this.bridgeStage?.syncBeat(this.routeState.bridgeBeat, this.player);
   }
 
   private resolveCameraZoom(): number {
@@ -820,4 +319,8 @@ export class RidgeScene extends Phaser.Scene {
       y: this.player.y
     });
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled Bridge tracer effect: ${JSON.stringify(value)}`);
 }

--- a/src/game/scenes/ridge/runtime/bridgeTracerSlice.test.ts
+++ b/src/game/scenes/ridge/runtime/bridgeTracerSlice.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { RidgeBridgeBeatState, RidgeFirstPlayableRouteState } from '@/game/bridge/store';
+import {
+  createBridgeTracerInteractionTargets,
+  hasCickaSharedToyCar,
+  isBridgeCrossingOpen
+} from './bridgeTracerSlice';
+
+function route(bridgeBeat: RidgeBridgeBeatState): RidgeFirstPlayableRouteState {
+  return {
+    activeAreaId: bridgeBeat === 'concert_handoff' ? 'concert' : 'bridge',
+    bridgeBeat
+  };
+}
+
+describe('Bridge Tracer Slice route targets', () => {
+  it('starts with Cicka first-meet and missing-span targets', () => {
+    const targets = createBridgeTracerInteractionTargets(route('intro'));
+
+    expect(targets.map((target) => target.id)).toEqual(['cicka', 'draftsperson']);
+    expect(targets[0]?.promptLineId).toBe('bridge.cicka.first_meet.01');
+    expect(targets[1]?.effect).toMatchObject({
+      kind: 'showDialogue',
+      nextBeat: 'needs_toy_car'
+    });
+  });
+
+  it('switches Cicka to parallel play after the draftsperson names the missing car', () => {
+    const targets = createBridgeTracerInteractionTargets(route('needs_toy_car'));
+    const cicka = targets.find((target) => target.id === 'cicka');
+
+    expect(cicka?.promptLineId).toBe('bridge.cicka.parallel_play.01');
+    expect(cicka?.effect).toMatchObject({
+      kind: 'showDialogue',
+      nextBeat: 'toy_car_shared',
+      lineIds: expect.arrayContaining(['bridge.cicka.parallel_play.04'])
+    });
+  });
+
+  it('enables the toy-car bridge test after Cicka shares the prop', () => {
+    const targets = createBridgeTracerInteractionTargets(route('toy_car_shared'));
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({
+      id: 'draftsperson',
+      promptLineId: 'bridge.draftsperson.toy_car_test.01',
+      effect: {
+        kind: 'runToyCarTest'
+      }
+    });
+  });
+
+  it('enables only the opened crossing exit after the bridge is complete', () => {
+    const targets = createBridgeTracerInteractionTargets(route('bridge_complete'));
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({
+      id: 'concert-exit',
+      promptLineId: 'bridge.exit.opened_crossing.01',
+      effect: {
+        kind: 'triggerConcertHandoff'
+      }
+    });
+  });
+
+  it('stops Bridge interactions once the Concert handoff is recorded', () => {
+    expect(createBridgeTracerInteractionTargets(route('concert_handoff'))).toEqual([]);
+  });
+
+  it('derives visible world-change helpers from the route state', () => {
+    expect(isBridgeCrossingOpen('intro')).toBe(false);
+    expect(isBridgeCrossingOpen('bridge_complete')).toBe(true);
+    expect(hasCickaSharedToyCar('needs_toy_car')).toBe(false);
+    expect(hasCickaSharedToyCar('toy_car_shared')).toBe(true);
+  });
+});

--- a/src/game/scenes/ridge/runtime/bridgeTracerSlice.test.ts
+++ b/src/game/scenes/ridge/runtime/bridgeTracerSlice.test.ts
@@ -7,8 +7,15 @@ import {
 } from './bridgeTracerSlice';
 
 function route(bridgeBeat: RidgeBridgeBeatState): RidgeFirstPlayableRouteState {
+  if (bridgeBeat === 'concert_handoff') {
+    return {
+      activeAreaId: 'concert',
+      bridgeBeat
+    };
+  }
+
   return {
-    activeAreaId: bridgeBeat === 'concert_handoff' ? 'concert' : 'bridge',
+    activeAreaId: 'bridge',
     bridgeBeat
   };
 }

--- a/src/game/scenes/ridge/runtime/bridgeTracerSlice.ts
+++ b/src/game/scenes/ridge/runtime/bridgeTracerSlice.ts
@@ -1,5 +1,6 @@
 import type { InteriorInteractionTarget } from '@/game/sharedSceneRuntime/interactions/InteriorInteractionRuntime';
 import type {
+  RidgeBridgeAreaBeatState,
   RidgeBridgeBeatState,
   RidgeFirstPlayableRouteState
 } from '@/game/bridge/store';
@@ -54,7 +55,7 @@ export type BridgeTracerEffect =
   | {
       kind: 'showDialogue';
       lineIds: BridgeDialogueLineId[];
-      nextBeat?: RidgeBridgeBeatState;
+      nextBeat?: RidgeBridgeAreaBeatState;
     }
   | {
       kind: 'runToyCarTest';
@@ -72,6 +73,8 @@ export type BridgeTracerInteractionTarget = InteriorInteractionTarget<
   promptLineId: BridgeDialogueLineId;
 };
 
+type BridgeTracerTargetFactory = () => BridgeTracerInteractionTarget;
+
 export function isBridgeCrossingOpen(bridgeBeat: RidgeBridgeBeatState): boolean {
   return bridgeBeat === 'bridge_complete' || bridgeBeat === 'concert_handoff';
 }
@@ -88,31 +91,22 @@ export function createBridgeTracerInteractionTargets(
   route: RidgeFirstPlayableRouteState
 ): BridgeTracerInteractionTarget[] {
   if (route.activeAreaId !== 'bridge') return [];
-
-  const targets: BridgeTracerInteractionTarget[] = [];
-
-  if (route.bridgeBeat === 'intro') {
-    targets.push(createCickaFirstMeetTarget());
-  }
-
-  if (route.bridgeBeat === 'needs_toy_car') {
-    targets.push(createCickaParallelPlayTarget());
-  }
-
-  if (route.bridgeBeat === 'intro' || route.bridgeBeat === 'needs_toy_car') {
-    targets.push(createMissingSpanTarget(route.bridgeBeat));
-  }
-
-  if (route.bridgeBeat === 'toy_car_shared') {
-    targets.push(createToyCarTestTarget());
-  }
-
-  if (route.bridgeBeat === 'bridge_complete') {
-    targets.push(createConcertExitTarget());
-  }
-
-  return targets;
+  return BRIDGE_TARGETS_BY_BEAT[route.bridgeBeat].map((createTarget) => createTarget());
 }
+
+const BRIDGE_TARGETS_BY_BEAT = {
+  intro: [
+    createCickaFirstMeetTarget,
+    createIntroMissingSpanTarget
+  ],
+  needs_toy_car: [
+    createCickaParallelPlayTarget,
+    createNeedsToyCarMissingSpanTarget
+  ],
+  toy_car_shared: [createToyCarTestTarget],
+  testing_bridge: [],
+  bridge_complete: [createConcertExitTarget]
+} satisfies Record<RidgeBridgeAreaBeatState, readonly BridgeTracerTargetFactory[]>;
 
 function createCickaFirstMeetTarget(): BridgeTracerInteractionTarget {
   return {
@@ -162,8 +156,16 @@ function createCickaParallelPlayTarget(): BridgeTracerInteractionTarget {
   };
 }
 
+function createIntroMissingSpanTarget(): BridgeTracerInteractionTarget {
+  return createMissingSpanTarget('intro');
+}
+
+function createNeedsToyCarMissingSpanTarget(): BridgeTracerInteractionTarget {
+  return createMissingSpanTarget('needs_toy_car');
+}
+
 function createMissingSpanTarget(
-  bridgeBeat: Extract<RidgeBridgeBeatState, 'intro' | 'needs_toy_car'>
+  bridgeBeat: Extract<RidgeBridgeAreaBeatState, 'intro' | 'needs_toy_car'>
 ): BridgeTracerInteractionTarget {
   return {
     id: 'draftsperson',

--- a/src/game/scenes/ridge/runtime/bridgeTracerSlice.ts
+++ b/src/game/scenes/ridge/runtime/bridgeTracerSlice.ts
@@ -82,7 +82,6 @@ export function isBridgeCrossingOpen(bridgeBeat: RidgeBridgeBeatState): boolean 
 export function hasCickaSharedToyCar(bridgeBeat: RidgeBridgeBeatState): boolean {
   return (
     bridgeBeat === 'toy_car_shared' ||
-    bridgeBeat === 'testing_bridge' ||
     isBridgeCrossingOpen(bridgeBeat)
   );
 }
@@ -104,7 +103,6 @@ const BRIDGE_TARGETS_BY_BEAT = {
     createNeedsToyCarMissingSpanTarget
   ],
   toy_car_shared: [createToyCarTestTarget],
-  testing_bridge: [],
   bridge_complete: [createConcertExitTarget]
 } satisfies Record<RidgeBridgeAreaBeatState, readonly BridgeTracerTargetFactory[]>;
 

--- a/src/game/scenes/ridge/runtime/bridgeTracerSlice.ts
+++ b/src/game/scenes/ridge/runtime/bridgeTracerSlice.ts
@@ -1,0 +1,236 @@
+import type { InteriorInteractionTarget } from '@/game/sharedSceneRuntime/interactions/InteriorInteractionRuntime';
+import type {
+  RidgeBridgeBeatState,
+  RidgeFirstPlayableRouteState
+} from '@/game/bridge/store';
+import type { BridgeDialogueLineId } from '../dialogue/bridgeDialogue';
+
+export const BRIDGE_TRACER_WORLD = {
+  bounds: {
+    x: 0,
+    y: 0,
+    width: 2600,
+    height: 600
+  },
+  floorY: 500,
+  spawn: {
+    x: 140,
+    y: 452
+  },
+  cickaPlaySpot: {
+    x: 650,
+    y: 458
+  },
+  cickaSettledSpot: {
+    x: 1850,
+    y: 458
+  },
+  draftsperson: {
+    x: 1295,
+    y: 456
+  },
+  blueprint: {
+    x: 1375,
+    y: 430
+  },
+  bridge: {
+    leftBankEndX: 1450,
+    rightBankStartX: 1730,
+    centerX: 1590,
+    deckY: 500,
+    deckWidth: 286
+  },
+  exit: {
+    x: 2315,
+    y: 456
+  }
+} as const;
+
+export const BRIDGE_TRACER_INTERACT_RADIUS = 86;
+
+export type BridgeTracerTargetId = 'cicka' | 'draftsperson' | 'concert-exit';
+
+export type BridgeTracerEffect =
+  | {
+      kind: 'showDialogue';
+      lineIds: BridgeDialogueLineId[];
+      nextBeat?: RidgeBridgeBeatState;
+    }
+  | {
+      kind: 'runToyCarTest';
+      lineIds: BridgeDialogueLineId[];
+    }
+  | {
+      kind: 'triggerConcertHandoff';
+      lineIds: BridgeDialogueLineId[];
+    };
+
+export type BridgeTracerInteractionTarget = InteriorInteractionTarget<
+  BridgeTracerTargetId,
+  BridgeTracerEffect
+> & {
+  promptLineId: BridgeDialogueLineId;
+};
+
+export function isBridgeCrossingOpen(bridgeBeat: RidgeBridgeBeatState): boolean {
+  return bridgeBeat === 'bridge_complete' || bridgeBeat === 'concert_handoff';
+}
+
+export function hasCickaSharedToyCar(bridgeBeat: RidgeBridgeBeatState): boolean {
+  return (
+    bridgeBeat === 'toy_car_shared' ||
+    bridgeBeat === 'testing_bridge' ||
+    isBridgeCrossingOpen(bridgeBeat)
+  );
+}
+
+export function createBridgeTracerInteractionTargets(
+  route: RidgeFirstPlayableRouteState
+): BridgeTracerInteractionTarget[] {
+  if (route.activeAreaId !== 'bridge') return [];
+
+  const targets: BridgeTracerInteractionTarget[] = [];
+
+  if (route.bridgeBeat === 'intro') {
+    targets.push(createCickaFirstMeetTarget());
+  }
+
+  if (route.bridgeBeat === 'needs_toy_car') {
+    targets.push(createCickaParallelPlayTarget());
+  }
+
+  if (route.bridgeBeat === 'intro' || route.bridgeBeat === 'needs_toy_car') {
+    targets.push(createMissingSpanTarget(route.bridgeBeat));
+  }
+
+  if (route.bridgeBeat === 'toy_car_shared') {
+    targets.push(createToyCarTestTarget());
+  }
+
+  if (route.bridgeBeat === 'bridge_complete') {
+    targets.push(createConcertExitTarget());
+  }
+
+  return targets;
+}
+
+function createCickaFirstMeetTarget(): BridgeTracerInteractionTarget {
+  return {
+    id: 'cicka',
+    kind: 'ridge-bridge-cicka',
+    x: BRIDGE_TRACER_WORLD.cickaPlaySpot.x,
+    distanceAnchorY: BRIDGE_TRACER_WORLD.cickaPlaySpot.y,
+    interactRadius: BRIDGE_TRACER_INTERACT_RADIUS,
+    prompt: {
+      x: BRIDGE_TRACER_WORLD.cickaPlaySpot.x,
+      y: BRIDGE_TRACER_WORLD.cickaPlaySpot.y - 116
+    },
+    promptLineId: 'bridge.cicka.first_meet.01',
+    effect: {
+      kind: 'showDialogue',
+      lineIds: [
+        'bridge.cicka.first_meet.01',
+        'bridge.cicka.first_meet.02',
+        'bridge.cicka.first_meet.03'
+      ]
+    }
+  };
+}
+
+function createCickaParallelPlayTarget(): BridgeTracerInteractionTarget {
+  return {
+    id: 'cicka',
+    kind: 'ridge-bridge-cicka',
+    x: BRIDGE_TRACER_WORLD.cickaPlaySpot.x,
+    distanceAnchorY: BRIDGE_TRACER_WORLD.cickaPlaySpot.y,
+    interactRadius: BRIDGE_TRACER_INTERACT_RADIUS,
+    prompt: {
+      x: BRIDGE_TRACER_WORLD.cickaPlaySpot.x,
+      y: BRIDGE_TRACER_WORLD.cickaPlaySpot.y - 116
+    },
+    promptLineId: 'bridge.cicka.parallel_play.01',
+    effect: {
+      kind: 'showDialogue',
+      lineIds: [
+        'bridge.cicka.parallel_play.01',
+        'bridge.cicka.parallel_play.02',
+        'bridge.cicka.parallel_play.03',
+        'bridge.cicka.parallel_play.04'
+      ],
+      nextBeat: 'toy_car_shared'
+    }
+  };
+}
+
+function createMissingSpanTarget(
+  bridgeBeat: Extract<RidgeBridgeBeatState, 'intro' | 'needs_toy_car'>
+): BridgeTracerInteractionTarget {
+  return {
+    id: 'draftsperson',
+    kind: 'ridge-bridge-draftsperson',
+    x: BRIDGE_TRACER_WORLD.draftsperson.x,
+    distanceAnchorY: BRIDGE_TRACER_WORLD.draftsperson.y,
+    interactRadius: BRIDGE_TRACER_INTERACT_RADIUS,
+    prompt: {
+      x: BRIDGE_TRACER_WORLD.draftsperson.x,
+      y: BRIDGE_TRACER_WORLD.draftsperson.y - 132
+    },
+    promptLineId: 'bridge.draftsperson.missing_span.03',
+    effect: {
+      kind: 'showDialogue',
+      lineIds: [
+        'bridge.draftsperson.missing_span.01',
+        'bridge.draftsperson.missing_span.02',
+        'bridge.draftsperson.missing_span.03'
+      ],
+      nextBeat: bridgeBeat === 'intro' ? 'needs_toy_car' : undefined
+    }
+  };
+}
+
+function createToyCarTestTarget(): BridgeTracerInteractionTarget {
+  return {
+    id: 'draftsperson',
+    kind: 'ridge-bridge-draftsperson',
+    x: BRIDGE_TRACER_WORLD.draftsperson.x,
+    distanceAnchorY: BRIDGE_TRACER_WORLD.draftsperson.y,
+    interactRadius: BRIDGE_TRACER_INTERACT_RADIUS,
+    prompt: {
+      x: BRIDGE_TRACER_WORLD.draftsperson.x,
+      y: BRIDGE_TRACER_WORLD.draftsperson.y - 132
+    },
+    promptLineId: 'bridge.draftsperson.toy_car_test.01',
+    effect: {
+      kind: 'runToyCarTest',
+      lineIds: [
+        'bridge.draftsperson.toy_car_test.01',
+        'bridge.draftsperson.toy_car_test.02',
+        'bridge.draftsperson.toy_car_test.03',
+        'bridge.draftsperson.toy_car_test.04'
+      ]
+    }
+  };
+}
+
+function createConcertExitTarget(): BridgeTracerInteractionTarget {
+  return {
+    id: 'concert-exit',
+    kind: 'ridge-bridge-exit',
+    x: BRIDGE_TRACER_WORLD.exit.x,
+    distanceAnchorY: BRIDGE_TRACER_WORLD.exit.y,
+    interactRadius: 104,
+    prompt: {
+      x: BRIDGE_TRACER_WORLD.exit.x,
+      y: BRIDGE_TRACER_WORLD.exit.y - 126
+    },
+    promptLineId: 'bridge.exit.opened_crossing.01',
+    effect: {
+      kind: 'triggerConcertHandoff',
+      lineIds: [
+        'bridge.exit.opened_crossing.01',
+        'bridge.exit.opened_crossing.02',
+        'bridge.exit.opened_crossing.03'
+      ]
+    }
+  };
+}

--- a/src/game/shell/InteractiveApp.test.tsx
+++ b/src/game/shell/InteractiveApp.test.tsx
@@ -100,7 +100,8 @@ describe('InteractiveApp', () => {
     expect(header.className).not.toContain('fixed');
     expect(toolbar).toBeDefined();
     expect(toolbar.className).not.toContain('fixed');
-    expect(screen.getByRole('button', { name: /open inventory/i }).className).not.toContain('fixed');
+    expect(screen.queryByRole('button', { name: /open inventory/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /open dev scene switcher/i }).className).not.toContain('fixed');
     expect(screen.getByRole('button', { name: /switch to static portfolio/i }).className).not.toContain('fixed');
   });
 
@@ -135,7 +136,7 @@ describe('InteractiveApp', () => {
   it('opens and closes inventory as a dialog that pauses UI state', async () => {
     render(<InteractiveApp onSwitchToStatic={vi.fn()} />);
 
-    await userEvent.click(screen.getByRole('button', { name: /open inventory/i }));
+    act(() => bridgeActions.openOverlay('inventory'));
 
     expect(await screen.findByRole('dialog', { name: /inventory/i })).toBeDefined();
     expect(bridgeStore.getState().activeOverlayId).toBe('inventory');

--- a/src/game/shell/InteractiveApp.tsx
+++ b/src/game/shell/InteractiveApp.tsx
@@ -1,11 +1,11 @@
-import { ArrowLeft, BookOpen, Backpack, Bug } from 'lucide-react';
+import { ArrowLeft, BookOpen, Bug } from 'lucide-react';
 import Game from './Game';
 import { bridgeActions, useBridgeState, type OpenOverlayOptions } from '@/game/bridge/store';
 import {
   getPhaserScenePresentationMode,
   type PhaserScenePresentationMode
 } from '@/game/sharedSceneRuntime/phaserScenePresentation';
-import { DEV_SWITCHER_OVERLAY_ID, INVENTORY_OVERLAY_ID, type OverlayId } from '@/game/overlays/overlayIds';
+import { DEV_SWITCHER_OVERLAY_ID, type OverlayId } from '@/game/overlays/overlayIds';
 import { OverlayHost } from '@/game/overlays/OverlayHost';
 import { SceneUiHost } from '@/game/sceneUi/SceneUiHost';
 import {
@@ -130,18 +130,6 @@ export default function InteractiveApp({ onSwitchToStatic }: InteractiveAppProps
               </Button>
             ) : (
               <>
-                <Button
-                  variant="floating"
-                  size="sm"
-                  onClick={() => bridgeActions.openOverlay(INVENTORY_OVERLAY_ID)}
-                  className="sm:px-3 sm:py-1.5 sm:text-xs"
-                  aria-haspopup="dialog"
-                  aria-expanded={bridge.activeOverlayId === INVENTORY_OVERLAY_ID}
-                  aria-label={messages.gameShell.openInventory}
-                >
-                  <Backpack className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
-                  <span>{messages.gameShell.inventory}</span>
-                </Button>
                 {import.meta.env.DEV && (
                   <Button
                     variant="floating"

--- a/src/shared/i18n/messages/en/scenes.ts
+++ b/src/shared/i18n/messages/en/scenes.ts
@@ -35,6 +35,41 @@ export const sceneMessages = {
         stampedeMemory: "mrrp!",
       },
     },
+    bridge: {
+      speakers: {
+        prompt: "Prompt",
+        cicka: "Cicka",
+        bridgeDraftsperson: "Bridge Draftsperson",
+      },
+      dialogue: {
+        "bridge.cicka.first_meet.01": "Sit near Cicka",
+        "bridge.cicka.first_meet.02": "Small chirp.",
+        "bridge.cicka.first_meet.03": "Cicka bats the tiny car back into place.",
+        "bridge.draftsperson.missing_span.01":
+          "The middle span keeps looking brave until I imagine someone crossing it.",
+        "bridge.draftsperson.missing_span.02":
+          "I had a tiny test car for this. It was here a minute ago.",
+        "bridge.draftsperson.missing_span.03": "Look for the tiny test car",
+        "bridge.cicka.parallel_play.01": "Sit with Cicka",
+        "bridge.cicka.parallel_play.02": "Roll the car back gently",
+        "bridge.cicka.parallel_play.03": "Quiet purr.",
+        "bridge.cicka.parallel_play.04": "Cicka leaves the tiny car beside you.",
+        "bridge.draftsperson.toy_car_test.01":
+          "Set the tiny car on the drawing",
+        "bridge.draftsperson.toy_car_test.02":
+          "If it can carry this much courage, maybe it can carry us.",
+        "bridge.draftsperson.toy_car_test.03":
+          "The toy car rolls across the new span.",
+        "bridge.draftsperson.toy_car_test.04":
+          "That line holds. The bridge knows it now.",
+        "bridge.exit.opened_crossing.01": "Cross the finished bridge",
+        "bridge.exit.opened_crossing.02":
+          "Thank you. I think I can leave this line alone now.",
+        "bridge.exit.opened_crossing.03":
+          "The page turns toward evening music.",
+      },
+      handoffNote: "evening music ahead",
+    },
   },
   stampedeSketch: {
     result: {


### PR DESCRIPTION
## Summary

- Implements the issue #88 Bridge Tracer Slice for Ridge as the first playable Bridge route.
- Adds typed `firstPlayableRoute` progression, Bridge dialogue, Bridge tracer interaction targets, and a focused Bridge stage runtime.
- Keeps RidgeScene as the scene adapter while Bridge presentation, physics, prompts, dialogue, and toy-car animation live in `BridgeTracerStageRuntime`.
- Addresses the thermo-nuclear review findings: discriminated route state, exhaustive effect handling, beat-to-target table, RidgeScene decomposition, and removal of transient `testing_bridge` from durable route state.
- Removes the default Inventory button from the interactive top chrome while keeping the inventory overlay/runtime path intact.
- Documents accepted post-tracer sequencing for Bridge visual coherence, conversation UI, and screen-usage investigation.

## Notes

- Bridge visuals use the smallest drawn Phaser placeholders for the draftsperson, missing span, completed span, toy car, and handoff note so runtime acceptance criteria stay testable without blocking on final art.
- The toy-car bridge test is scene-local animation state. Durable route state remains `toy_car_shared` while the animation runs, then commits `bridge_complete` atomically when the test finishes.
- Deferred follow-up: #90 Bridge Visual Coherence Pass before Concert.
- Deferred follow-up: #91 Ridge Character Conversation Overlay.
- Deferred follow-up: #92 Investigate interactive shell screen usage and fullscreen direction.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm docs:check`
- `pnpm test -- src/game/bridge/store.test.ts src/game/scenes/ridge/runtime/bridgeTracerSlice.test.ts src/game/scenes/ridge/dialogue/bridgeDialogue.test.ts`
- `pnpm test -- src/game/shell/InteractiveApp.test.tsx`
- `pnpm check`
- `git diff --check`
- Browser smoke on `http://127.0.0.1:5173/?mode=interactive&startScene=ridge`: Cicka first meet, draftsperson missing span, Cicka toy-car share, toy-car bridge test, completed bridge crossing, no page console errors.
- Browser smoke after chrome polish on `http://127.0.0.1:5173/?mode=interactive&startScene=ridge`: top chrome shows Dev + Static only, no Inventory button, no page console errors.
