### PR TITLE
[codex] Fix Ridge PR #94 review comments

### DIFF
--- a/src/game/scenes/ridge/runtime/BridgeTracerStageRuntime.ts
+++ b/src/game/scenes/ridge/runtime/BridgeTracerStageRuntime.ts
@@ -327,19 +327,6 @@ class BridgeTracerStageRuntimeImpl implements BridgeTracerStageRuntime {
       .setDepth(26);
     this.cickaSprite.play(CICKA_ANIMATION_KEYS.perchIdle);
     this.toyCar = this.createToyCar(cickaPlaySpot.x + 72, groundY - 2);
-    this.toyCarTween = this.scene.tweens.add({
-      targets: this.toyCar,
-      x: cickaPlaySpot.x + 98,
-      angle: 5,
-      duration: 1180,
-      ease: 'Sine.easeInOut',
-      repeat: -1,
-      onUpdate: () => {
-        if (!this.toyCar) return;
-        this.syncToyCarSupport(this.toyCar.x, this.toyCar.y, true);
-      },
-      yoyo: true
-    });
   }
 
   private createBridgeDraftsperson(): void {
@@ -483,8 +470,29 @@ class BridgeTracerStageRuntimeImpl implements BridgeTracerStageRuntime {
         cickaGroundY - 2
       );
       this.syncToyCarSupport(this.toyCar.x, this.toyCar.y, true);
+
+      if (!this.toyCarTween || !this.toyCarTween.isPlaying()) {
+        this.toyCarTween?.stop();
+        this.toyCarTween = this.scene.tweens.add({
+          targets: this.toyCar,
+          x: cickaSpot.x + 98,
+          angle: 5,
+          duration: 1180,
+          ease: 'Sine.easeInOut',
+          repeat: -1,
+          onUpdate: () => {
+            if (!this.toyCar) return;
+            this.syncToyCarSupport(this.toyCar.x, this.toyCar.y, true);
+          },
+          yoyo: true
+        });
+      }
       return;
     }
+
+    this.toyCarTween?.stop();
+    this.toyCarTween = undefined;
+    this.toyCar.setAngle(0);
 
     if (bridgeBeat === 'toy_car_shared') {
       this.toyCar.setVisible(false);
@@ -522,7 +530,8 @@ class BridgeTracerStageRuntimeImpl implements BridgeTracerStageRuntime {
 
     if (!isTalking) {
       this.builderIdleTween?.resume();
-      this.bridgeBuilder.setScale(0.76).setAngle(0);
+      const groundY = this.getGroundedY(BRIDGE_TRACER_WORLD.draftsperson.y);
+      this.bridgeBuilder.setY(groundY - 2).setScale(0.76).setAngle(0);
       return;
     }
 

--- a/src/game/shell/Game.tsx
+++ b/src/game/shell/Game.tsx
@@ -7,7 +7,7 @@ import { usePhaserGameBoot } from './usePhaserGameBoot';
 import { usePhaserGamePauseSync } from './usePhaserGamePauseSync';
 import { usePhaserScaleRefresh } from './usePhaserScaleRefresh';
 import type { PhaserScenePresentationMode } from '@/game/sharedSceneRuntime/phaserScenePresentation';
-import { RIDGE_SCENE_ID, type SceneId } from '@/game/scenes/sceneIds';
+import type { SceneId } from '@/game/scenes/sceneIds';
 import type { OverlayId } from '@/game/overlays/overlayIds';
 import type { OpenOverlayOptions } from '@/game/bridge/store';
 import type { RidgeDevControls } from '@/game/scenes/ridge/runtime/ridgeDevControls';
@@ -64,13 +64,10 @@ export default function Game({
   const frameClassName = chrome === 'framed'
     ? 'relative h-full w-full min-h-0 overflow-hidden rounded-lg border-4 border-neutral-800 bg-[#fbfbf9] shadow-[8px_8px_0px_0px_rgba(26,26,26,1)]'
     : 'relative h-full w-full min-h-0 overflow-hidden bg-[#fbfbf9]';
-  const gameCanvasStyle = activeSceneId === RIDGE_SCENE_ID
-    ? { filter: 'grayscale(1) contrast(1.08)' }
-    : undefined;
 
   return (
     <div className={frameClassName}>
-      <div ref={containerRef} className="absolute inset-0 outline-none" style={gameCanvasStyle} />
+      <div ref={containerRef} className="absolute inset-0 outline-none" />
       {shouldUseGestureOverlay && (
         <>
           <div


### PR DESCRIPTION
## Summary

- Move the Bridge toy-car idle tween lifecycle into `syncCickaAndToyCar`, stopping it once the toy car is shared or the bridge is complete.
- Reset the bridge builder baseline when dialogue stops so the talking tween cannot leave the sprite vertically offset.
- Remove the full-canvas Ridge CSS grayscale/contrast filter from the Phaser container.

## Why

PR #94 was merged before the review comments were addressed. This follow-up keeps the fix scoped to those comments without reopening the merged PR history.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test src/game/scenes/ridge/runtime/bridgeTracerSlice.test.ts src/game/shell/InteractiveApp.test.tsx`